### PR TITLE
chore: add eslint-plugin-unused-imports to auto-remove unused imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,7 +9,7 @@ module.exports = {
     "prettier",
     "eslint-config-prettier",
   ],
-  plugins: ["react-refresh"],
+  plugins: ["react-refresh", "unused-imports"],
   settings: {
     react: {
       version: "detect",
@@ -25,6 +25,12 @@ module.exports = {
     }
   },
   rules: {
+    "@typescript-eslint/no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" }
+    ],
     "react-refresh/only-export-components": [
       "warn",
       { "allowConstantExport": true }

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.1",
+        "eslint-plugin-unused-imports": "^4.4.1",
         "postcss": "^8.4.21",
         "postcss-cli": "^10.1.0",
         "postcss-nesting": "^11.2.1",
@@ -3953,6 +3954,22 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.4.1.tgz",
+      "integrity": "sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^10.0.0 || ^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {
@@ -13263,6 +13280,13 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.1.tgz",
       "integrity": "sha512-QgrvtRJkmV+m4w953LS146+6RwEe5waouubFVNLBfOjXJf6MLczjymO8fOcKj9jMS8aKkTCMJqiPu2WEeFI99A==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-unused-imports": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.4.1.tgz",
+      "integrity": "sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.1",
+    "eslint-plugin-unused-imports": "^4.4.1",
     "postcss": "^8.4.21",
     "postcss-cli": "^10.1.0",
     "postcss-nesting": "^11.2.1",

--- a/src/hooks/useStock.ts
+++ b/src/hooks/useStock.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import StockService, { Stock, StockQueryParams } from '@/services/StockService'
+import StockService, { StockQueryParams } from '@/services/StockService'
 
 export function useStock(params?: StockQueryParams) {
     return useQuery({


### PR DESCRIPTION
  ## Descripción

  Replace @typescript-eslint/no-unused-vars with unused-imports plugin                                                                                                            
  so that `npm run lint:fix` automatically removes unused imports.
  Variables starting with _ are ignored.

## Tipo de cambio

- [ ] 🐛 Bug fix
- [ ] ✨ Nueva funcionalidad
- [x] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
