### PR TITLE
feat: adapt frontend to new API envelope format and add server-side pagination

### DIFF
--- a/api_response_format.md
+++ b/api_response_format.md
@@ -1,0 +1,325 @@
+# Faclab Core — Formato de Respuestas API y Paginación
+
+Guía para consumir la API desde un cliente frontend. Todos los campos JSON usan **camelCase**.
+
+---
+
+## 1. Envelope de Respuesta
+
+Toda respuesta exitosa sigue un patrón envelope con dos campos raíz: `data` y `meta`.
+
+### Respuesta de un solo recurso
+
+```
+GET /api/admin/products/1
+```
+
+```json
+{
+  "data": {
+    "id": 1,
+    "name": "Tornillo M6",
+    "sku": "SKU-001",
+    "categoryId": 5,
+    "salePrice": 0.25,
+    "isActive": true
+  },
+  "meta": {
+    "requestId": "550e8400-e29b-41d4-a716-446655440000",
+    "timestamp": "2026-03-05T14:23:45.123456+00:00"
+  }
+}
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `data` | `object` | El recurso solicitado |
+| `meta.requestId` | `string (UUID)` | Identificador único de la petición. Se puede enviar desde el cliente con el header `X-Request-ID`; si no se envía, el servidor genera uno |
+| `meta.timestamp` | `string (ISO 8601)` | Fecha/hora UTC en que se generó la respuesta |
+
+### Respuesta de lista simple (sin paginación)
+
+Se usa para sub-recursos o colecciones pequeñas que no requieren paginación.
+
+```
+GET /api/admin/sales/10/items
+```
+
+```json
+{
+  "data": [
+    { "id": 1, "productId": 5, "quantity": 2, "unitPrice": 49.99, "subtotal": 99.98 },
+    { "id": 2, "productId": 8, "quantity": 1, "unitPrice": 29.99, "subtotal": 29.99 }
+  ],
+  "meta": {
+    "requestId": "...",
+    "timestamp": "..."
+  }
+}
+```
+
+`data` es un **array** de objetos. `meta` no incluye información de paginación.
+
+### Respuesta paginada
+
+Se usa para listados principales (productos, categorías, stock, movimientos, etc.).
+
+```
+GET /api/admin/products?limit=10&offset=20
+```
+
+```json
+{
+  "data": [
+    { "id": 21, "name": "Producto 21", "sku": "SKU-021", "salePrice": 49.99 },
+    { "id": 22, "name": "Producto 22", "sku": "SKU-022", "salePrice": 79.99 }
+  ],
+  "meta": {
+    "requestId": "550e8400-e29b-41d4-a716-446655440000",
+    "timestamp": "2026-03-05T14:23:45.123456+00:00",
+    "pagination": {
+      "total": 250,
+      "limit": 10,
+      "offset": 20
+    }
+  }
+}
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `data` | `array` | Lista de recursos de la página actual |
+| `meta.pagination.total` | `int` | Cantidad total de registros que coinciden con los filtros |
+| `meta.pagination.limit` | `int` | Tamaño de página solicitado |
+| `meta.pagination.offset` | `int` | Cantidad de registros omitidos (inicio de la página) |
+
+---
+
+## 2. Paginación
+
+### Query parameters
+
+| Parámetro | Tipo | Default | Rango | Descripción |
+|-----------|------|---------|-------|-------------|
+| `limit` | `int` | `100` | `1 – 1000` | Cantidad máxima de elementos por página |
+| `offset` | `int` | `0` | `≥ 0` | Cantidad de elementos a saltar desde el inicio |
+
+### Cálculos útiles para el frontend
+
+```ts
+const currentPage = Math.floor(offset / limit) + 1;
+const totalPages  = Math.ceil(total / limit);
+const hasNext     = offset + limit < total;
+const hasPrev     = offset > 0;
+
+// Para ir a una página específica:
+const goToPage = (page: number) => {
+  const newOffset = (page - 1) * limit;
+  // fetch con ?limit=${limit}&offset=${newOffset}
+};
+```
+
+### Ejemplo de implementación con fetch
+
+```ts
+interface PaginationMeta {
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+interface Meta {
+  requestId: string;
+  timestamp: string;
+  pagination?: PaginationMeta;
+}
+
+interface ApiResponse<T> {
+  data: T;
+  meta: Meta;
+}
+
+// Obtener lista paginada
+async function fetchProducts(limit = 10, offset = 0) {
+  const res = await fetch(`/api/admin/products?limit=${limit}&offset=${offset}`);
+  const json: ApiResponse<Product[]> = await res.json();
+
+  return {
+    items: json.data,
+    total: json.meta.pagination!.total,
+    limit: json.meta.pagination!.limit,
+    offset: json.meta.pagination!.offset,
+  };
+}
+```
+
+---
+
+## 3. Filtros adicionales
+
+Algunos endpoints aceptan query params extra para filtrar. Se combinan con `limit` y `offset`.
+
+```
+GET /api/admin/products?categoryId=3&limit=25&offset=0
+GET /api/admin/stock?warehouseId=1&limit=50&offset=0
+```
+
+Los filtros disponibles dependen de cada endpoint. Consultar la documentación interactiva en `/docs/admin`.
+
+---
+
+## 4. Respuestas de Error
+
+Todas las respuestas de error usan el mismo envelope con `errors` (array) y `meta`.
+
+### Estructura
+
+```json
+{
+  "errors": [
+    {
+      "code": "ERROR_CODE",
+      "message": "Descripción legible del error",
+      "field": "body.fieldName"
+    }
+  ],
+  "meta": {
+    "requestId": "...",
+    "timestamp": "..."
+  }
+}
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `errors` | `array` | Lista de errores (puede haber varios en validación) |
+| `errors[].code` | `string` | Código máquina del error |
+| `errors[].message` | `string` | Mensaje legible para humanos |
+| `errors[].field` | `string \| null` | Ruta del campo que causó el error (solo en errores de validación) |
+
+### Códigos HTTP y tipos de error
+
+| HTTP Status | Código | Cuándo ocurre |
+|-------------|--------|---------------|
+| `400` | Varía por dominio | Violación de regla de negocio (ej: stock insuficiente, estado inválido) |
+| `404` | `NOT_FOUND` | Recurso no encontrado |
+| `409` | `INTEGRITY_ERROR` | Conflicto de integridad (ej: eliminar un registro referenciado por otros) |
+| `422` | `VALIDATION_ERROR` | Error de validación de campos en el body |
+| `422` | `REQUEST_VALIDATION_ERROR` | Error de validación en query params o path params |
+| `500` | `INTERNAL_ERROR` | Error interno no controlado |
+
+### Ejemplos
+
+**404 — Recurso no encontrado:**
+
+```json
+{
+  "errors": [
+    { "code": "NOT_FOUND", "message": "Product with id 999 not found" }
+  ],
+  "meta": { "requestId": "...", "timestamp": "..." }
+}
+```
+
+**422 — Errores de validación (múltiples campos):**
+
+```json
+{
+  "errors": [
+    { "code": "VALIDATION_ERROR", "message": "Field required", "field": "body.name" },
+    { "code": "VALIDATION_ERROR", "message": "ensure this value is greater than 0", "field": "body.salePrice" }
+  ],
+  "meta": { "requestId": "...", "timestamp": "..." }
+}
+```
+
+**400 — Error de dominio:**
+
+```json
+{
+  "errors": [
+    { "code": "INSUFFICIENT_STOCK", "message": "Insufficient stock for product 5. Requested: 100, Available: 50" }
+  ],
+  "meta": { "requestId": "...", "timestamp": "..." }
+}
+```
+
+**409 — Error de integridad:**
+
+```json
+{
+  "errors": [
+    { "code": "INTEGRITY_ERROR", "message": "Cannot complete operation because this record is referenced by other records" }
+  ],
+  "meta": { "requestId": "...", "timestamp": "..." }
+}
+```
+
+---
+
+## 5. Headers relevantes
+
+| Header | Dirección | Descripción |
+|--------|-----------|-------------|
+| `X-Request-ID` | Request → Response | UUID para rastrear la petición. Si el cliente lo envía, el servidor lo respeta; si no, genera uno nuevo. Se incluye en `meta.requestId` |
+| `Content-Type` | Response | Siempre `application/json` |
+
+---
+
+## 6. Resumen de tipos TypeScript
+
+```ts
+// === Meta ===
+interface Meta {
+  requestId: string;
+  timestamp: string;
+}
+
+interface PaginationMeta {
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+interface PaginatedMeta extends Meta {
+  pagination: PaginationMeta;
+}
+
+// === Respuestas exitosas ===
+interface DataResponse<T> {
+  data: T;
+  meta: Meta;
+}
+
+interface ListResponse<T> {
+  data: T[];
+  meta: Meta;
+}
+
+interface PaginatedResponse<T> {
+  data: T[];
+  meta: PaginatedMeta;
+}
+
+// === Respuestas de error ===
+interface ErrorDetail {
+  code: string;
+  message: string;
+  field?: string;
+}
+
+interface ErrorResponse {
+  errors: ErrorDetail[];
+  meta: Meta;
+}
+```
+
+---
+
+## 7. Convenciones de naming
+
+- **JSON**: todos los campos usan `camelCase` (`categoryId`, `salePrice`, `isActive`)
+- **Query params**: `camelCase` (`categoryId`, `warehouseId`, `limit`, `offset`)
+- **Endpoints Admin**: `/api/admin/{resource}`
+- **Endpoints POS**: `/api/pos/{resource}`
+- **Documentación interactiva**: `/docs` (general), `/docs/admin`, `/docs/pos`

--- a/src/@types/api.ts
+++ b/src/@types/api.ts
@@ -1,0 +1,40 @@
+export interface PaginationMeta {
+    total: number
+    limit: number
+    offset: number
+}
+
+export interface Meta {
+    requestId: string
+    timestamp: string
+}
+
+export interface PaginatedMeta extends Meta {
+    pagination: PaginationMeta
+}
+
+export interface DataResponse<T> {
+    data: T
+    meta: Meta
+}
+
+export interface PaginatedResponse<T> {
+    data: T[]
+    meta: PaginatedMeta
+}
+
+export interface ErrorDetail {
+    code: string
+    message: string
+    field?: string
+}
+
+export interface ErrorResponse {
+    errors: ErrorDetail[]
+    meta: Meta
+}
+
+export interface PaginationParams {
+    limit?: number
+    offset?: number
+}

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,56 +1,63 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+    useQuery,
+    useMutation,
+    useQueryClient,
+    keepPreviousData,
+} from '@tanstack/react-query'
 import CategoryService, { CategoryInput } from '@/services/CategoryService'
+import type { PaginationParams } from '@/@types/api'
 
-// GET /categories - Obtener todas las categorías
-export function useCategories() {
+export function useCategories(params?: PaginationParams) {
     return useQuery({
-        queryKey: ['categories'],
+        queryKey: ['categories', params],
         queryFn: async () => {
-            const response = await CategoryService.getCategories()
-            return response.data
+            const response = await CategoryService.getCategories(params)
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
         },
+        placeholderData: keepPreviousData,
     })
 }
 
-// GET /categories/:id - Obtener una categoría por ID
 export function useCategory(id: number) {
     return useQuery({
         queryKey: ['categories', id],
         queryFn: async () => {
             const response = await CategoryService.getCategoryById(id)
-            return response.data
+            return response.data.data
         },
         enabled: !!id,
     })
 }
 
-// POST /categories - Crear una nueva categoría
 export function useCreateCategory() {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: (category: CategoryInput) =>
-            CategoryService.createCategory(category),
-
+        mutationFn: async (category: CategoryInput) => {
+            const response = await CategoryService.createCategory(category)
+            return response.data.data
+        },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['categories'] })
         },
     })
 }
 
-// PUT /categories/:id - Actualizar una categoría
 export function useUpdateCategory() {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: ({
+        mutationFn: async ({
             id,
             data,
         }: {
             id: number
             data: Partial<CategoryInput>
-        }) => CategoryService.updateCategory(id, data),
-
+        }) => {
+            const response = await CategoryService.updateCategory(id, data)
+            return response.data.data
+        },
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({
                 queryKey: ['categories', variables.id],
@@ -60,13 +67,11 @@ export function useUpdateCategory() {
     })
 }
 
-// DELETE /categories/:id - Eliminar una categoría
 export function useDeleteCategory() {
     const queryClient = useQueryClient()
 
     return useMutation({
         mutationFn: (id: number) => CategoryService.deleteCategory(id),
-
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['categories'] })
         },

--- a/src/hooks/useCustomerContacts.ts
+++ b/src/hooks/useCustomerContacts.ts
@@ -10,7 +10,7 @@ export function useCustomerContacts(customerId: number) {
             const response = await CustomerContactService.getCustomerContacts(
                 customerId
             )
-            return response.data
+            return response.data.data
         },
         enabled: customerId > 0,
     })
@@ -21,7 +21,7 @@ export function useCustomerContact(id: number) {
         queryKey: ['customerContacts', 'detail', id],
         queryFn: async () => {
             const response = await CustomerContactService.getCustomerContact(id)
-            return response.data
+            return response.data.data
         },
         enabled: id > 0,
     })
@@ -42,10 +42,9 @@ export function useCreateCustomerContact() {
                 customerId,
                 contact
             )
-            return response.data
+            return response.data.data
         },
         onSuccess: (_, variables) => {
-            // Invalidate the contacts list for this customer
             queryClient.invalidateQueries({
                 queryKey: ['customerContacts', variables.customerId],
             })
@@ -68,14 +67,12 @@ export function useUpdateCustomerContact() {
                 id,
                 contact
             )
-            return response.data
+            return response.data.data
         },
         onSuccess: (data) => {
-            // Invalidate the contacts list for this customer
             queryClient.invalidateQueries({
                 queryKey: ['customerContacts', data.customerId],
             })
-            // Invalidate the specific contact
             queryClient.invalidateQueries({
                 queryKey: ['customerContacts', 'detail', data.id],
             })
@@ -87,17 +84,10 @@ export function useDeleteCustomerContact() {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: async ({
-            id,
-            customerId: _customerId,
-        }: {
-            id: number
-            customerId: number
-        }) => {
+        mutationFn: async ({ id }: { id: number; customerId: number }) => {
             await CustomerContactService.deleteCustomerContact(id)
         },
         onSuccess: (_, variables) => {
-            // Invalidate the contacts list for this customer
             queryClient.invalidateQueries({
                 queryKey: ['customerContacts', variables.customerId],
             })

--- a/src/hooks/useCustomers.ts
+++ b/src/hooks/useCustomers.ts
@@ -1,13 +1,21 @@
 import CustomerService, { CustomerInput } from '@/services/CustomerService'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+    keepPreviousData,
+} from '@tanstack/react-query'
+import type { PaginationParams } from '@/@types/api'
 
-export function useCustomers() {
+export function useCustomers(params?: PaginationParams) {
     return useQuery({
-        queryKey: ['customers'],
+        queryKey: ['customers', params],
         queryFn: async () => {
-            const response = await CustomerService.getCustomers()
-            return response.data
+            const response = await CustomerService.getCustomers(params)
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
         },
+        placeholderData: keepPreviousData,
     })
 }
 
@@ -16,7 +24,7 @@ export function useCustomer(id: number) {
         queryKey: ['customers', id],
         queryFn: async () => {
             const response = await CustomerService.getCustomer(id)
-            return response.data
+            return response.data.data
         },
         enabled: id > 0,
     })
@@ -27,7 +35,7 @@ export function useSearchCustomerByTaxId(taxId: string) {
         queryKey: ['customers', 'search', taxId],
         queryFn: async () => {
             const response = await CustomerService.searchCustomerByTaxId(taxId)
-            return response.data
+            return response.data.data
         },
         enabled: !!taxId,
     })
@@ -39,7 +47,7 @@ export function useCreateCustomer() {
     return useMutation({
         mutationFn: async (customer: CustomerInput) => {
             const response = await CustomerService.createCustomer(customer)
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['customers'] })
@@ -59,7 +67,7 @@ export function useUpdateCustomer() {
             data: CustomerInput
         }) => {
             const response = await CustomerService.updateCustomer(id, data)
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['customers'] })
@@ -86,7 +94,7 @@ export function useActivateCustomer() {
     return useMutation({
         mutationFn: async (id: number) => {
             const response = await CustomerService.activateCustomer(id)
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['customers'] })
@@ -100,7 +108,7 @@ export function useDeactivateCustomer() {
     return useMutation({
         mutationFn: async (id: number) => {
             const response = await CustomerService.deactivateCustomer(id)
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['customers'] })

--- a/src/hooks/useLocations.ts
+++ b/src/hooks/useLocations.ts
@@ -1,16 +1,23 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import LocationService, { LocationInput } from '@/services/LocationService'
+import {
+    useQuery,
+    useMutation,
+    useQueryClient,
+    keepPreviousData,
+} from '@tanstack/react-query'
+import LocationService, {
+    LocationInput,
+    type LocationQueryParams,
+} from '@/services/LocationService'
 
-export function useLocations(params?: {
-    warehouseId?: number
-    isActive?: boolean
-}) {
+export function useLocations(params?: LocationQueryParams) {
     return useQuery({
         queryKey: ['locations', params],
         queryFn: async () => {
             const response = await LocationService.getLocations(params)
-            return response.data
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
         },
+        placeholderData: keepPreviousData,
     })
 }
 
@@ -19,7 +26,7 @@ export function useLocation(id: number) {
         queryKey: ['locations', id],
         queryFn: async () => {
             const response = await LocationService.getLocationById(id)
-            return response.data
+            return response.data.data
         },
         enabled: !!id,
     })
@@ -29,8 +36,10 @@ export function useCreateLocation() {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: (data: LocationInput) =>
-            LocationService.createLocation(data),
+        mutationFn: async (data: LocationInput) => {
+            const response = await LocationService.createLocation(data)
+            return response.data.data
+        },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['locations'] })
         },
@@ -41,13 +50,16 @@ export function useUpdateLocation() {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: ({
+        mutationFn: async ({
             id,
             data,
         }: {
             id: number
             data: Partial<LocationInput>
-        }) => LocationService.updateLocation(id, data),
+        }) => {
+            const response = await LocationService.updateLocation(id, data)
+            return response.data.data
+        },
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({
                 queryKey: ['locations', variables.id],

--- a/src/hooks/useLots.ts
+++ b/src/hooks/useLots.ts
@@ -1,4 +1,9 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+    useQuery,
+    useMutation,
+    useQueryClient,
+    keepPreviousData,
+} from '@tanstack/react-query'
 import LotService, {
     type LotInput,
     type LotQueryParams,
@@ -9,8 +14,10 @@ export function useLots(params?: LotQueryParams) {
         queryKey: ['lots', params],
         queryFn: async () => {
             const response = await LotService.getLots(params)
-            return response.data
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
         },
+        placeholderData: keepPreviousData,
     })
 }
 
@@ -19,7 +26,7 @@ export function useLot(id: number) {
         queryKey: ['lots', id],
         queryFn: async () => {
             const response = await LotService.getLot(id)
-            return response.data
+            return response.data.data
         },
         enabled: id > 0,
     })
@@ -31,7 +38,7 @@ export function useCreateLot() {
     return useMutation({
         mutationFn: async (lot: LotInput) => {
             const response = await LotService.createLot(lot)
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['lots'] })
@@ -45,7 +52,7 @@ export function useUpdateLot() {
     return useMutation({
         mutationFn: async ({ id, data }: { id: number; data: LotInput }) => {
             const response = await LotService.updateLot(id, data)
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['lots'] })

--- a/src/hooks/useMovements.ts
+++ b/src/hooks/useMovements.ts
@@ -1,4 +1,9 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+    useQuery,
+    useMutation,
+    useQueryClient,
+    keepPreviousData,
+} from '@tanstack/react-query'
 import MovementService, {
     MovementInput,
     MovementQueryParams,
@@ -9,8 +14,10 @@ export function useMovements(params?: MovementQueryParams) {
         queryKey: ['movements', params],
         queryFn: async () => {
             const response = await MovementService.getMovements(params)
-            return response.data
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
         },
+        placeholderData: keepPreviousData,
     })
 }
 
@@ -20,12 +27,10 @@ export function useCreateMovement() {
     return useMutation({
         mutationFn: async (movement: MovementInput) => {
             const response = await MovementService.createMovement(movement)
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
-            // Invalidate all movement queries to refetch
             queryClient.invalidateQueries({ queryKey: ['movements'] })
-            // Also invalidate stock queries since movements affect stock
             queryClient.invalidateQueries({ queryKey: ['stock'] })
         },
     })

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,59 +1,64 @@
 import InventoryService, { ProductInput } from '@/services/InventoryService'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+    keepPreviousData,
+} from '@tanstack/react-query'
+import type { PaginationParams } from '@/@types/api'
 
-// GET /products - Obtener todos los productos
-export function useProducts() {
+export function useProducts(params?: PaginationParams) {
     return useQuery({
-        queryKey: ['products'],
+        queryKey: ['products', params],
         queryFn: async () => {
-            const response = await InventoryService.getProducts()
-            return response.data
+            const response = await InventoryService.getProducts(params)
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
         },
+        placeholderData: keepPreviousData,
     })
 }
 
-// GET /products/:id - Obtener un producto por ID
 export function useProduct(id: number) {
     return useQuery({
         queryKey: ['products', id],
         queryFn: async () => {
             const response = await InventoryService.getProductById(id)
-            return response.data
+            return response.data.data
         },
         enabled: !!id,
     })
 }
 
-// POST /products - Crear un nuevo producto
 export function useCreateProduct() {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: (product: ProductInput) =>
-            InventoryService.createProduct(product),
-
+        mutationFn: async (product: ProductInput) => {
+            const response = await InventoryService.createProduct(product)
+            return response.data.data
+        },
         onSuccess: () => {
-            // Invalida el cache para refrescar la lista
             queryClient.invalidateQueries({ queryKey: ['products'] })
         },
     })
 }
 
-// PUT /products/:id - Actualizar un producto
 export function useUpdateProduct() {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: ({
+        mutationFn: async ({
             id,
             data,
         }: {
             id: number
             data: Partial<ProductInput>
-        }) => InventoryService.updateProduct(id, data),
-
+        }) => {
+            const response = await InventoryService.updateProduct(id, data)
+            return response.data.data
+        },
         onSuccess: (_, variables) => {
-            // Invalida el producto específico y la lista
             queryClient.invalidateQueries({
                 queryKey: ['products', variables.id],
             })
@@ -62,13 +67,11 @@ export function useUpdateProduct() {
     })
 }
 
-// DELETE /products/:id - Eliminar un producto
 export function useDeleteProduct() {
     const queryClient = useQueryClient()
 
     return useMutation({
         mutationFn: (id: number) => InventoryService.deleteProduct(id),
-
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['products'] })
         },

--- a/src/hooks/useSerialNumbers.ts
+++ b/src/hooks/useSerialNumbers.ts
@@ -1,4 +1,9 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+    useQuery,
+    useMutation,
+    useQueryClient,
+    keepPreviousData,
+} from '@tanstack/react-query'
 import SerialNumberService, {
     type SerialNumberInput,
     type SerialNumberQueryParams,
@@ -10,8 +15,10 @@ export function useSerialNumbers(params?: SerialNumberQueryParams) {
         queryKey: ['serialNumbers', params],
         queryFn: async () => {
             const response = await SerialNumberService.getSerialNumbers(params)
-            return response.data
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
         },
+        placeholderData: keepPreviousData,
     })
 }
 
@@ -20,7 +27,7 @@ export function useSerialNumber(id: number) {
         queryKey: ['serialNumbers', id],
         queryFn: async () => {
             const response = await SerialNumberService.getSerialNumber(id)
-            return response.data
+            return response.data.data
         },
         enabled: id > 0,
     })
@@ -34,7 +41,7 @@ export function useCreateSerialNumber() {
             const response = await SerialNumberService.createSerialNumber(
                 serialNumber
             )
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['serialNumbers'] })
@@ -57,7 +64,7 @@ export function useUpdateSerialNumber() {
                 id,
                 data
             )
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['serialNumbers'] })
@@ -90,7 +97,7 @@ export function useChangeSerialNumberStatus() {
             status: SerialStatus
         }) => {
             const response = await SerialNumberService.changeStatus(id, status)
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['serialNumbers'] })

--- a/src/hooks/useStock.ts
+++ b/src/hooks/useStock.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import StockService, { StockQueryParams } from '@/services/StockService'
 
 export function useStock(params?: StockQueryParams) {
@@ -6,7 +6,9 @@ export function useStock(params?: StockQueryParams) {
         queryKey: ['stock', params],
         queryFn: async () => {
             const response = await StockService.getStock(params)
-            return response.data
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
         },
+        placeholderData: keepPreviousData,
     })
 }

--- a/src/hooks/useSupplierContacts.ts
+++ b/src/hooks/useSupplierContacts.ts
@@ -10,7 +10,7 @@ export function useSupplierContacts(supplierId: number) {
             const response = await SupplierContactService.getSupplierContacts(
                 supplierId
             )
-            return response.data
+            return response.data.data
         },
         enabled: supplierId > 0,
     })
@@ -21,7 +21,7 @@ export function useSupplierContact(id: number) {
         queryKey: ['supplierContacts', 'detail', id],
         queryFn: async () => {
             const response = await SupplierContactService.getSupplierContact(id)
-            return response.data
+            return response.data.data
         },
         enabled: id > 0,
     })
@@ -42,7 +42,7 @@ export function useCreateSupplierContact() {
                 supplierId,
                 contact
             )
-            return response.data
+            return response.data.data
         },
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({
@@ -67,7 +67,7 @@ export function useUpdateSupplierContact() {
                 id,
                 contact
             )
-            return response.data
+            return response.data.data
         },
         onSuccess: (data) => {
             queryClient.invalidateQueries({

--- a/src/hooks/useSupplierProducts.ts
+++ b/src/hooks/useSupplierProducts.ts
@@ -10,7 +10,7 @@ export function useSupplierProducts(supplierId: number) {
             const response = await SupplierProductService.getSupplierProducts(
                 supplierId
             )
-            return response.data
+            return response.data.data
         },
         enabled: supplierId > 0,
     })
@@ -24,7 +24,7 @@ export function useSupplierProductsByProduct(productId: number) {
                 await SupplierProductService.getSupplierProductsByProduct(
                     productId
                 )
-            return response.data
+            return response.data.data
         },
         enabled: productId > 0,
     })
@@ -45,7 +45,7 @@ export function useCreateSupplierProduct() {
                 supplierId,
                 product
             )
-            return response.data
+            return response.data.data
         },
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({
@@ -70,7 +70,7 @@ export function useUpdateSupplierProduct() {
                 id,
                 product
             )
-            return response.data
+            return response.data.data
         },
         onSuccess: (data) => {
             queryClient.invalidateQueries({

--- a/src/hooks/useSuppliers.ts
+++ b/src/hooks/useSuppliers.ts
@@ -1,13 +1,21 @@
 import SupplierService, { SupplierInput } from '@/services/SupplierService'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+    keepPreviousData,
+} from '@tanstack/react-query'
+import type { PaginationParams } from '@/@types/api'
 
-export function useSuppliers() {
+export function useSuppliers(params?: PaginationParams) {
     return useQuery({
-        queryKey: ['suppliers'],
+        queryKey: ['suppliers', params],
         queryFn: async () => {
-            const response = await SupplierService.getSuppliers()
-            return response.data
+            const response = await SupplierService.getSuppliers(params)
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
         },
+        placeholderData: keepPreviousData,
     })
 }
 
@@ -16,7 +24,7 @@ export function useSupplier(id: number) {
         queryKey: ['suppliers', id],
         queryFn: async () => {
             const response = await SupplierService.getSupplier(id)
-            return response.data
+            return response.data.data
         },
         enabled: id > 0,
     })
@@ -28,7 +36,7 @@ export function useCreateSupplier() {
     return useMutation({
         mutationFn: async (supplier: SupplierInput) => {
             const response = await SupplierService.createSupplier(supplier)
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['suppliers'] })
@@ -48,7 +56,7 @@ export function useUpdateSupplier() {
             data: SupplierInput
         }) => {
             const response = await SupplierService.updateSupplier(id, data)
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['suppliers'] })
@@ -75,7 +83,7 @@ export function useActivateSupplier() {
     return useMutation({
         mutationFn: async (id: number) => {
             const response = await SupplierService.activateSupplier(id)
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['suppliers'] })
@@ -89,7 +97,7 @@ export function useDeactivateSupplier() {
     return useMutation({
         mutationFn: async (id: number) => {
             const response = await SupplierService.deactivateSupplier(id)
-            return response.data
+            return response.data.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['suppliers'] })

--- a/src/hooks/useUnitsOfMeasure.ts
+++ b/src/hooks/useUnitsOfMeasure.ts
@@ -1,17 +1,25 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+    useQuery,
+    useMutation,
+    useQueryClient,
+    keepPreviousData,
+} from '@tanstack/react-query'
 import UnitOfMeasureService, {
     UnitOfMeasureInput,
+    type UnitOfMeasureQueryParams,
 } from '@/services/UnitOfMeasureService'
 
-export function useUnitsOfMeasure(params?: { isActive?: boolean }) {
+export function useUnitsOfMeasure(params?: UnitOfMeasureQueryParams) {
     return useQuery({
         queryKey: ['units-of-measure', params],
         queryFn: async () => {
             const response = await UnitOfMeasureService.getUnitsOfMeasure(
                 params
             )
-            return response.data
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
         },
+        placeholderData: keepPreviousData,
     })
 }
 
@@ -20,7 +28,7 @@ export function useUnitOfMeasure(id: number) {
         queryKey: ['units-of-measure', id],
         queryFn: async () => {
             const response = await UnitOfMeasureService.getUnitOfMeasureById(id)
-            return response.data
+            return response.data.data
         },
         enabled: !!id,
     })
@@ -30,8 +38,12 @@ export function useCreateUnitOfMeasure() {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: (data: UnitOfMeasureInput) =>
-            UnitOfMeasureService.createUnitOfMeasure(data),
+        mutationFn: async (data: UnitOfMeasureInput) => {
+            const response = await UnitOfMeasureService.createUnitOfMeasure(
+                data
+            )
+            return response.data.data
+        },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['units-of-measure'] })
         },
@@ -42,13 +54,19 @@ export function useUpdateUnitOfMeasure() {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: ({
+        mutationFn: async ({
             id,
             data,
         }: {
             id: number
             data: Partial<UnitOfMeasureInput>
-        }) => UnitOfMeasureService.updateUnitOfMeasure(id, data),
+        }) => {
+            const response = await UnitOfMeasureService.updateUnitOfMeasure(
+                id,
+                data
+            )
+            return response.data.data
+        },
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({
                 queryKey: ['units-of-measure', variables.id],

--- a/src/hooks/useWarehouses.ts
+++ b/src/hooks/useWarehouses.ts
@@ -1,13 +1,23 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import WarehouseService, { WarehouseInput } from '@/services/WarehouseService'
+import {
+    useQuery,
+    useMutation,
+    useQueryClient,
+    keepPreviousData,
+} from '@tanstack/react-query'
+import WarehouseService, {
+    WarehouseInput,
+    type WarehouseQueryParams,
+} from '@/services/WarehouseService'
 
-export function useWarehouses(params?: { isActive?: boolean }) {
+export function useWarehouses(params?: WarehouseQueryParams) {
     return useQuery({
         queryKey: ['warehouses', params],
         queryFn: async () => {
             const response = await WarehouseService.getWarehouses(params)
-            return response.data
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
         },
+        placeholderData: keepPreviousData,
     })
 }
 
@@ -16,7 +26,7 @@ export function useWarehouse(id: number) {
         queryKey: ['warehouses', id],
         queryFn: async () => {
             const response = await WarehouseService.getWarehouseById(id)
-            return response.data
+            return response.data.data
         },
         enabled: !!id,
     })
@@ -26,8 +36,10 @@ export function useCreateWarehouse() {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: (data: WarehouseInput) =>
-            WarehouseService.createWarehouse(data),
+        mutationFn: async (data: WarehouseInput) => {
+            const response = await WarehouseService.createWarehouse(data)
+            return response.data.data
+        },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['warehouses'] })
         },
@@ -38,13 +50,16 @@ export function useUpdateWarehouse() {
     const queryClient = useQueryClient()
 
     return useMutation({
-        mutationFn: ({
+        mutationFn: async ({
             id,
             data,
         }: {
             id: number
             data: Partial<WarehouseInput>
-        }) => WarehouseService.updateWarehouse(id, data),
+        }) => {
+            const response = await WarehouseService.updateWarehouse(id, data)
+            return response.data.data
+        },
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({
                 queryKey: ['warehouses', variables.id],

--- a/src/services/CategoryService.ts
+++ b/src/services/CategoryService.ts
@@ -1,7 +1,11 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type {
+    PaginatedResponse,
+    DataResponse,
+    PaginationParams,
+} from '@/@types/api'
 
-// Interfaces para el servicio de categorías
 export interface Category {
     id: number
     name: string
@@ -12,10 +16,6 @@ export interface CategoryInput {
     name: string
     description?: string
     [key: string]: unknown
-}
-
-export interface CategoryResponse {
-    data: Category[]
 }
 
 export interface CategoryConfig {
@@ -33,65 +33,50 @@ class CategoryService {
             : appConfig.inventoryApiHost || ''
     }
 
-    /**
-     * Configura el host para el servicio de categorías
-     * @param config Configuración del servicio
-     */
     setConfig(config: Partial<CategoryConfig>) {
         this.config = { ...this.config, ...config }
         return this
     }
 
-    /**
-     * Obtiene la lista completa de categorías
-     */
-    async getCategories() {
-        return ApiService.fetchData<Category[]>({
-            url: `${this.config.host}/categories`,
+    async getCategories(params?: PaginationParams) {
+        const queryParams = new URLSearchParams()
+        if (params?.limit !== undefined)
+            queryParams.append('limit', params.limit.toString())
+        if (params?.offset !== undefined)
+            queryParams.append('offset', params.offset.toString())
+        const queryString = queryParams.toString()
+        const url = queryString
+            ? `${this.config.host}/categories?${queryString}`
+            : `${this.config.host}/categories`
+        return ApiService.fetchData<PaginatedResponse<Category>>({
+            url,
             method: 'get',
         })
     }
 
-    /**
-     * Obtiene una categoría por su ID
-     * @param id ID de la categoría
-     */
     async getCategoryById(id: number) {
-        return ApiService.fetchData<Category>({
+        return ApiService.fetchData<DataResponse<Category>>({
             url: `${this.config.host}/categories/${id}`,
             method: 'get',
         })
     }
 
-    /**
-     * Crea una nueva categoría
-     * @param category Datos de la categoría
-     */
     async createCategory(category: CategoryInput) {
-        return ApiService.fetchData<Category>({
+        return ApiService.fetchData<DataResponse<Category>>({
             url: `${this.config.host}/categories`,
             method: 'post',
             data: category,
         })
     }
 
-    /**
-     * Actualiza una categoría existente
-     * @param id ID de la categoría
-     * @param category Datos de la categoría
-     */
     async updateCategory(id: number, category: Partial<CategoryInput>) {
-        return ApiService.fetchData<Category>({
+        return ApiService.fetchData<DataResponse<Category>>({
             url: `${this.config.host}/categories/${id}`,
             method: 'put',
             data: category,
         })
     }
 
-    /**
-     * Elimina una categoría
-     * @param id ID de la categoría
-     */
     async deleteCategory(id: number) {
         return ApiService.fetchData({
             url: `${this.config.host}/categories/${id}`,

--- a/src/services/CustomerContactService.ts
+++ b/src/services/CustomerContactService.ts
@@ -1,5 +1,6 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type { DataResponse } from '@/@types/api'
 
 export interface CustomerContact {
     id: number
@@ -17,53 +18,44 @@ export interface CustomerContactInput {
     phone?: string
 }
 
-export interface CustomerContactsResponse {
-    data: CustomerContact[]
-}
-
 class CustomerContactService {
     private config = {
         host: appConfig.inventoryApiHost || 'http://localhost:3000',
     }
 
-    // Get contacts for a specific customer
     async getCustomerContacts(customerId: number) {
-        return ApiService.fetchData<CustomerContactsResponse>({
+        return ApiService.fetchData<DataResponse<CustomerContact[]>>({
             url: `${this.config.host}/customers/${customerId}/contacts`,
             method: 'get',
         })
     }
 
-    // Get a specific contact by ID
     async getCustomerContact(id: number) {
-        return ApiService.fetchData<CustomerContact>({
+        return ApiService.fetchData<DataResponse<CustomerContact>>({
             url: `${this.config.host}/customer-contacts/${id}`,
             method: 'get',
         })
     }
 
-    // Create a contact for a customer
     async createCustomerContact(
         customerId: number,
         contact: CustomerContactInput
     ) {
-        return ApiService.fetchData<CustomerContact>({
+        return ApiService.fetchData<DataResponse<CustomerContact>>({
             url: `${this.config.host}/customers/${customerId}/contacts`,
             method: 'post',
             data: contact,
         })
     }
 
-    // Update a contact
     async updateCustomerContact(id: number, contact: CustomerContactInput) {
-        return ApiService.fetchData<CustomerContact>({
+        return ApiService.fetchData<DataResponse<CustomerContact>>({
             url: `${this.config.host}/customer-contacts/${id}`,
             method: 'put',
             data: contact,
         })
     }
 
-    // Delete a contact
     async deleteCustomerContact(id: number) {
         return ApiService.fetchData<void>({
             url: `${this.config.host}/customer-contacts/${id}`,

--- a/src/services/CustomerService.ts
+++ b/src/services/CustomerService.ts
@@ -1,7 +1,11 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type {
+    PaginatedResponse,
+    DataResponse,
+    PaginationParams,
+} from '@/@types/api'
 
-// TaxType enum: 1=RUC, 2=NATIONAL_ID, 3=PASSPORT, 4=FOREIGN_ID
 export type TaxType = 1 | 2 | 3 | 4
 
 export const TAX_TYPE_LABELS: Record<TaxType, string> = {
@@ -42,38 +46,43 @@ export interface CustomerInput {
     isActive?: boolean
 }
 
-export interface CustomersResponse {
-    data: Customer[]
-}
-
 class CustomerService {
     private config = {
         host: appConfig.inventoryApiHost || 'http://localhost:3000',
     }
 
-    async getCustomers() {
-        return ApiService.fetchData<CustomersResponse>({
-            url: `${this.config.host}/customers`,
+    async getCustomers(params?: PaginationParams) {
+        const queryParams = new URLSearchParams()
+        if (params?.limit !== undefined)
+            queryParams.append('limit', params.limit.toString())
+        if (params?.offset !== undefined)
+            queryParams.append('offset', params.offset.toString())
+        const queryString = queryParams.toString()
+        const url = queryString
+            ? `${this.config.host}/customers?${queryString}`
+            : `${this.config.host}/customers`
+        return ApiService.fetchData<PaginatedResponse<Customer>>({
+            url,
             method: 'get',
         })
     }
 
     async getCustomer(id: number) {
-        return ApiService.fetchData<Customer>({
+        return ApiService.fetchData<DataResponse<Customer>>({
             url: `${this.config.host}/customers/${id}`,
             method: 'get',
         })
     }
 
     async searchCustomerByTaxId(taxId: string) {
-        return ApiService.fetchData<Customer>({
+        return ApiService.fetchData<DataResponse<Customer>>({
             url: `${this.config.host}/customers/search/by-tax-id?tax_id=${taxId}`,
             method: 'get',
         })
     }
 
     async createCustomer(customer: CustomerInput) {
-        return ApiService.fetchData<Customer>({
+        return ApiService.fetchData<DataResponse<Customer>>({
             url: `${this.config.host}/customers`,
             method: 'post',
             data: customer,
@@ -81,7 +90,7 @@ class CustomerService {
     }
 
     async updateCustomer(id: number, customer: CustomerInput) {
-        return ApiService.fetchData<Customer>({
+        return ApiService.fetchData<DataResponse<Customer>>({
             url: `${this.config.host}/customers/${id}`,
             method: 'put',
             data: customer,
@@ -96,14 +105,14 @@ class CustomerService {
     }
 
     async activateCustomer(id: number) {
-        return ApiService.fetchData<Customer>({
+        return ApiService.fetchData<DataResponse<Customer>>({
             url: `${this.config.host}/customers/${id}/activate`,
             method: 'post',
         })
     }
 
     async deactivateCustomer(id: number) {
-        return ApiService.fetchData<Customer>({
+        return ApiService.fetchData<DataResponse<Customer>>({
             url: `${this.config.host}/customers/${id}/deactivate`,
             method: 'post',
         })

--- a/src/services/InventoryService.ts
+++ b/src/services/InventoryService.ts
@@ -1,7 +1,11 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type {
+    PaginatedResponse,
+    DataResponse,
+    PaginationParams,
+} from '@/@types/api'
 
-// Interfaces para el servicio de inventario
 export interface Product {
     id: number
     name: string
@@ -20,10 +24,6 @@ export interface ProductInput {
     [key: string]: unknown
 }
 
-export interface ProductResponse {
-    data: Product[]
-}
-
 export interface InventoryConfig {
     host: string
 }
@@ -34,71 +34,55 @@ class InventoryService {
     }
 
     constructor() {
-        // Usa el host específico para inventario si está definido, o el apiPrefix general
         this.config.host = appConfig.enableMock
             ? appConfig.apiPrefix
             : appConfig.inventoryApiHost || ''
     }
 
-    /**
-     * Configura el host para el servicio de inventario
-     * @param config Configuración del servicio
-     */
     setConfig(config: Partial<InventoryConfig>) {
         this.config = { ...this.config, ...config }
         return this
     }
 
-    /**
-     * Obtiene la lista completa de productos
-     */
-    async getProducts() {
-        return ApiService.fetchData<ProductResponse>({
-            url: `${this.config.host}/products`,
+    async getProducts(params?: PaginationParams) {
+        const queryParams = new URLSearchParams()
+        if (params?.limit !== undefined)
+            queryParams.append('limit', params.limit.toString())
+        if (params?.offset !== undefined)
+            queryParams.append('offset', params.offset.toString())
+        const queryString = queryParams.toString()
+        const url = queryString
+            ? `${this.config.host}/products?${queryString}`
+            : `${this.config.host}/products`
+        return ApiService.fetchData<PaginatedResponse<Product>>({
+            url,
             method: 'get',
         })
     }
 
-    /**
-     * Obtiene un producto por su ID
-     * @param id ID del producto
-     */
     async getProductById(id: number) {
-        return ApiService.fetchData<Product>({
+        return ApiService.fetchData<DataResponse<Product>>({
             url: `${this.config.host}/products/${id}`,
             method: 'get',
         })
     }
 
-    /**
-     * Crea un nuevo producto
-     * @param product Datos del producto
-     */
     async createProduct(product: ProductInput) {
-        return ApiService.fetchData<Product>({
+        return ApiService.fetchData<DataResponse<Product>>({
             url: `${this.config.host}/products`,
             method: 'post',
             data: product,
         })
     }
 
-    /**
-     * Actualiza un producto existente
-     * @param id ID del producto
-     * @param product Datos del producto
-     */
     async updateProduct(id: number, product: Partial<ProductInput>) {
-        return ApiService.fetchData<Product>({
+        return ApiService.fetchData<DataResponse<Product>>({
             url: `${this.config.host}/products/${id}`,
             method: 'put',
             data: product,
         })
     }
 
-    /**
-     * Elimina un producto
-     * @param id ID del producto
-     */
     async deleteProduct(id: number) {
         return ApiService.fetchData({
             url: `${this.config.host}/products/${id}`,

--- a/src/services/LocationService.ts
+++ b/src/services/LocationService.ts
@@ -1,5 +1,10 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type {
+    PaginatedResponse,
+    DataResponse,
+    PaginationParams,
+} from '@/@types/api'
 
 export type LocationType = 'STORAGE' | 'RECEIVING' | 'SHIPPING' | 'RETURN'
 
@@ -23,6 +28,11 @@ export interface LocationInput {
     [key: string]: unknown
 }
 
+export interface LocationQueryParams extends PaginationParams {
+    warehouseId?: number
+    isActive?: boolean
+}
+
 class LocationService {
     private host: string
 
@@ -32,23 +42,35 @@ class LocationService {
             : appConfig.inventoryApiHost || ''
     }
 
-    async getLocations(params?: { warehouseId?: number; isActive?: boolean }) {
-        return ApiService.fetchData<Location[]>({
-            url: `${this.host}/locations`,
+    async getLocations(params?: LocationQueryParams) {
+        const queryParams = new URLSearchParams()
+        if (params?.warehouseId !== undefined)
+            queryParams.append('warehouseId', params.warehouseId.toString())
+        if (params?.isActive !== undefined)
+            queryParams.append('isActive', params.isActive.toString())
+        if (params?.limit !== undefined)
+            queryParams.append('limit', params.limit.toString())
+        if (params?.offset !== undefined)
+            queryParams.append('offset', params.offset.toString())
+        const queryString = queryParams.toString()
+        const url = queryString
+            ? `${this.host}/locations?${queryString}`
+            : `${this.host}/locations`
+        return ApiService.fetchData<PaginatedResponse<Location>>({
+            url,
             method: 'get',
-            params,
         })
     }
 
     async getLocationById(id: number) {
-        return ApiService.fetchData<Location>({
+        return ApiService.fetchData<DataResponse<Location>>({
             url: `${this.host}/locations/${id}`,
             method: 'get',
         })
     }
 
     async createLocation(data: LocationInput) {
-        return ApiService.fetchData<Location>({
+        return ApiService.fetchData<DataResponse<Location>>({
             url: `${this.host}/locations`,
             method: 'post',
             data,
@@ -56,7 +78,7 @@ class LocationService {
     }
 
     async updateLocation(id: number, data: Partial<LocationInput>) {
-        return ApiService.fetchData<Location>({
+        return ApiService.fetchData<DataResponse<Location>>({
             url: `${this.host}/locations/${id}`,
             method: 'put',
             data,

--- a/src/services/LotService.ts
+++ b/src/services/LotService.ts
@@ -1,5 +1,10 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type {
+    PaginatedResponse,
+    DataResponse,
+    PaginationParams,
+} from '@/@types/api'
 
 export interface Lot {
     id: number
@@ -25,7 +30,7 @@ export interface LotInput {
     notes?: string
 }
 
-export interface LotQueryParams {
+export interface LotQueryParams extends PaginationParams {
     productId?: number
     expiringInDays?: number
 }
@@ -47,27 +52,33 @@ class LotService {
                 params.expiringInDays.toString()
             )
         }
+        if (params?.limit !== undefined) {
+            queryParams.append('limit', params.limit.toString())
+        }
+        if (params?.offset !== undefined) {
+            queryParams.append('offset', params.offset.toString())
+        }
 
         const queryString = queryParams.toString()
         const url = queryString
             ? `${this.config.host}/lots?${queryString}`
             : `${this.config.host}/lots`
 
-        return ApiService.fetchData<Lot[]>({
+        return ApiService.fetchData<PaginatedResponse<Lot>>({
             url,
             method: 'get',
         })
     }
 
     async getLot(id: number) {
-        return ApiService.fetchData<Lot>({
+        return ApiService.fetchData<DataResponse<Lot>>({
             url: `${this.config.host}/lots/${id}`,
             method: 'get',
         })
     }
 
     async createLot(lot: LotInput) {
-        return ApiService.fetchData<Lot>({
+        return ApiService.fetchData<DataResponse<Lot>>({
             url: `${this.config.host}/lots`,
             method: 'post',
             data: lot,
@@ -75,7 +86,7 @@ class LotService {
     }
 
     async updateLot(id: number, lot: LotInput) {
-        return ApiService.fetchData<Lot>({
+        return ApiService.fetchData<DataResponse<Lot>>({
             url: `${this.config.host}/lots/${id}`,
             method: 'put',
             data: lot,

--- a/src/services/MovementService.ts
+++ b/src/services/MovementService.ts
@@ -1,5 +1,6 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type { PaginatedResponse, DataResponse } from '@/@types/api'
 
 export type MovementType = 'in' | 'out'
 
@@ -9,7 +10,7 @@ export interface Movement {
     quantity: number
     type: MovementType
     reason?: string | null
-    date?: string | null // ISO 8601 datetime
+    date?: string | null
 }
 
 export interface MovementInput {
@@ -17,16 +18,16 @@ export interface MovementInput {
     quantity: number
     type: MovementType
     reason?: string
-    date?: string // ISO 8601 datetime
+    date?: string
 }
 
 export interface MovementQueryParams {
     productId?: number
     type?: MovementType
-    fromDate?: string // ISO 8601 datetime
-    toDate?: string // ISO 8601 datetime
-    limit?: number // default: 100, range: 1-1000
-    offset?: number // default: 0
+    fromDate?: string
+    toDate?: string
+    limit?: number
+    offset?: number
 }
 
 class MovementService {
@@ -34,12 +35,6 @@ class MovementService {
         host: appConfig.inventoryApiHost || 'http://localhost:3000',
     }
 
-    /**
-     * Validates a movement before sending to API
-     * - If type is "in", quantity must be positive
-     * - If type is "out", quantity must be negative
-     * - Quantity cannot be zero
-     */
     validateMovement(movement: MovementInput): {
         valid: boolean
         error?: string
@@ -92,20 +87,19 @@ class MovementService {
             ? `${this.config.host}/movements?${queryString}`
             : `${this.config.host}/movements`
 
-        return ApiService.fetchData<Movement[]>({
+        return ApiService.fetchData<PaginatedResponse<Movement>>({
             url,
             method: 'get',
         })
     }
 
     async createMovement(movement: MovementInput) {
-        // Validate before sending
         const validation = this.validateMovement(movement)
         if (!validation.valid) {
             throw new Error(validation.error)
         }
 
-        return ApiService.fetchData<Movement>({
+        return ApiService.fetchData<DataResponse<Movement>>({
             url: `${this.config.host}/movements`,
             method: 'post',
             data: movement,

--- a/src/services/SerialNumberService.ts
+++ b/src/services/SerialNumberService.ts
@@ -1,5 +1,10 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type {
+    PaginatedResponse,
+    DataResponse,
+    PaginationParams,
+} from '@/@types/api'
 
 export type SerialStatus =
     | 'AVAILABLE'
@@ -39,7 +44,7 @@ export interface SerialNumberInput {
     notes?: string
 }
 
-export interface SerialNumberQueryParams {
+export interface SerialNumberQueryParams extends PaginationParams {
     productId?: number
     status?: SerialStatus
     lotId?: number
@@ -66,27 +71,33 @@ class SerialNumberService {
         if (params?.locationId) {
             queryParams.append('locationId', params.locationId.toString())
         }
+        if (params?.limit !== undefined) {
+            queryParams.append('limit', params.limit.toString())
+        }
+        if (params?.offset !== undefined) {
+            queryParams.append('offset', params.offset.toString())
+        }
 
         const queryString = queryParams.toString()
         const url = queryString
             ? `${this.config.host}/serials?${queryString}`
             : `${this.config.host}/serials`
 
-        return ApiService.fetchData<SerialNumber[]>({
+        return ApiService.fetchData<PaginatedResponse<SerialNumber>>({
             url,
             method: 'get',
         })
     }
 
     async getSerialNumber(id: number) {
-        return ApiService.fetchData<SerialNumber>({
+        return ApiService.fetchData<DataResponse<SerialNumber>>({
             url: `${this.config.host}/serials/${id}`,
             method: 'get',
         })
     }
 
     async createSerialNumber(serialNumber: SerialNumberInput) {
-        return ApiService.fetchData<SerialNumber>({
+        return ApiService.fetchData<DataResponse<SerialNumber>>({
             url: `${this.config.host}/serials`,
             method: 'post',
             data: serialNumber,
@@ -94,7 +105,7 @@ class SerialNumberService {
     }
 
     async updateSerialNumber(id: number, serialNumber: SerialNumberInput) {
-        return ApiService.fetchData<SerialNumber>({
+        return ApiService.fetchData<DataResponse<SerialNumber>>({
             url: `${this.config.host}/serials/${id}`,
             method: 'put',
             data: serialNumber,
@@ -109,7 +120,7 @@ class SerialNumberService {
     }
 
     async changeStatus(id: number, status: SerialStatus) {
-        return ApiService.fetchData<SerialNumber>({
+        return ApiService.fetchData<DataResponse<SerialNumber>>({
             url: `${this.config.host}/serials/${id}/status`,
             method: 'put',
             data: { status },

--- a/src/services/StockService.ts
+++ b/src/services/StockService.ts
@@ -1,5 +1,6 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type { PaginatedResponse } from '@/@types/api'
 
 export interface Stock {
     id: number
@@ -10,8 +11,8 @@ export interface Stock {
 
 export interface StockQueryParams {
     productId?: number
-    limit?: number // default: 100, range: 1-1000
-    offset?: number // default: 0
+    limit?: number
+    offset?: number
 }
 
 class StockService {
@@ -37,7 +38,7 @@ class StockService {
             ? `${this.config.host}/stock?${queryString}`
             : `${this.config.host}/stock`
 
-        return ApiService.fetchData<Stock[]>({
+        return ApiService.fetchData<PaginatedResponse<Stock>>({
             url,
             method: 'get',
         })

--- a/src/services/SupplierContactService.ts
+++ b/src/services/SupplierContactService.ts
@@ -1,5 +1,6 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type { DataResponse } from '@/@types/api'
 
 export interface SupplierContact {
     id: number
@@ -17,24 +18,20 @@ export interface SupplierContactInput {
     phone?: string
 }
 
-export interface SupplierContactsResponse {
-    data: SupplierContact[]
-}
-
 class SupplierContactService {
     private config = {
         host: appConfig.inventoryApiHost || 'http://localhost:3000',
     }
 
     async getSupplierContacts(supplierId: number) {
-        return ApiService.fetchData<SupplierContactsResponse>({
+        return ApiService.fetchData<DataResponse<SupplierContact[]>>({
             url: `${this.config.host}/suppliers/${supplierId}/contacts`,
             method: 'get',
         })
     }
 
     async getSupplierContact(id: number) {
-        return ApiService.fetchData<SupplierContact>({
+        return ApiService.fetchData<DataResponse<SupplierContact>>({
             url: `${this.config.host}/supplier-contacts/${id}`,
             method: 'get',
         })
@@ -44,7 +41,7 @@ class SupplierContactService {
         supplierId: number,
         contact: SupplierContactInput
     ) {
-        return ApiService.fetchData<SupplierContact>({
+        return ApiService.fetchData<DataResponse<SupplierContact>>({
             url: `${this.config.host}/suppliers/${supplierId}/contacts`,
             method: 'post',
             data: contact,
@@ -52,7 +49,7 @@ class SupplierContactService {
     }
 
     async updateSupplierContact(id: number, contact: SupplierContactInput) {
-        return ApiService.fetchData<SupplierContact>({
+        return ApiService.fetchData<DataResponse<SupplierContact>>({
             url: `${this.config.host}/supplier-contacts/${id}`,
             method: 'put',
             data: contact,

--- a/src/services/SupplierProductService.ts
+++ b/src/services/SupplierProductService.ts
@@ -1,5 +1,6 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type { DataResponse } from '@/@types/api'
 
 export interface SupplierProduct {
     id: number
@@ -24,17 +25,13 @@ export interface SupplierProductInput {
     isPreferred?: boolean
 }
 
-export interface SupplierProductsResponse {
-    data: SupplierProduct[]
-}
-
 class SupplierProductService {
     private config = {
         host: appConfig.inventoryApiHost || 'http://localhost:3000',
     }
 
     async getSupplierProducts(supplierId: number) {
-        return ApiService.fetchData<SupplierProductsResponse>({
+        return ApiService.fetchData<DataResponse<SupplierProduct[]>>({
             url: `${this.config.host}/suppliers/${supplierId}/products`,
             method: 'get',
         })
@@ -44,7 +41,7 @@ class SupplierProductService {
         supplierId: number,
         product: SupplierProductInput
     ) {
-        return ApiService.fetchData<SupplierProduct>({
+        return ApiService.fetchData<DataResponse<SupplierProduct>>({
             url: `${this.config.host}/suppliers/${supplierId}/products`,
             method: 'post',
             data: product,
@@ -52,7 +49,7 @@ class SupplierProductService {
     }
 
     async updateSupplierProduct(id: number, product: SupplierProductInput) {
-        return ApiService.fetchData<SupplierProduct>({
+        return ApiService.fetchData<DataResponse<SupplierProduct>>({
             url: `${this.config.host}/supplier-products/${id}`,
             method: 'put',
             data: product,
@@ -67,7 +64,7 @@ class SupplierProductService {
     }
 
     async getSupplierProductsByProduct(productId: number) {
-        return ApiService.fetchData<SupplierProductsResponse>({
+        return ApiService.fetchData<DataResponse<SupplierProduct[]>>({
             url: `${this.config.host}/supplier-products/by-product/${productId}`,
             method: 'get',
         })

--- a/src/services/SupplierService.ts
+++ b/src/services/SupplierService.ts
@@ -1,7 +1,11 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type {
+    PaginatedResponse,
+    DataResponse,
+    PaginationParams,
+} from '@/@types/api'
 
-// TaxType enum: 1=RUC, 2=NATIONAL_ID, 3=PASSPORT, 4=FOREIGN_ID
 export type TaxType = 1 | 2 | 3 | 4
 
 export const TAX_TYPE_LABELS: Record<TaxType, string> = {
@@ -46,31 +50,36 @@ export interface SupplierInput {
     isActive?: boolean
 }
 
-export interface SuppliersResponse {
-    data: Supplier[]
-}
-
 class SupplierService {
     private config = {
         host: appConfig.inventoryApiHost || 'http://localhost:3000',
     }
 
-    async getSuppliers() {
-        return ApiService.fetchData<SuppliersResponse>({
-            url: `${this.config.host}/suppliers`,
+    async getSuppliers(params?: PaginationParams) {
+        const queryParams = new URLSearchParams()
+        if (params?.limit !== undefined)
+            queryParams.append('limit', params.limit.toString())
+        if (params?.offset !== undefined)
+            queryParams.append('offset', params.offset.toString())
+        const queryString = queryParams.toString()
+        const url = queryString
+            ? `${this.config.host}/suppliers?${queryString}`
+            : `${this.config.host}/suppliers`
+        return ApiService.fetchData<PaginatedResponse<Supplier>>({
+            url,
             method: 'get',
         })
     }
 
     async getSupplier(id: number) {
-        return ApiService.fetchData<Supplier>({
+        return ApiService.fetchData<DataResponse<Supplier>>({
             url: `${this.config.host}/suppliers/${id}`,
             method: 'get',
         })
     }
 
     async createSupplier(supplier: SupplierInput) {
-        return ApiService.fetchData<Supplier>({
+        return ApiService.fetchData<DataResponse<Supplier>>({
             url: `${this.config.host}/suppliers`,
             method: 'post',
             data: supplier,
@@ -78,7 +87,7 @@ class SupplierService {
     }
 
     async updateSupplier(id: number, supplier: SupplierInput) {
-        return ApiService.fetchData<Supplier>({
+        return ApiService.fetchData<DataResponse<Supplier>>({
             url: `${this.config.host}/suppliers/${id}`,
             method: 'put',
             data: supplier,
@@ -93,14 +102,14 @@ class SupplierService {
     }
 
     async activateSupplier(id: number) {
-        return ApiService.fetchData<Supplier>({
+        return ApiService.fetchData<DataResponse<Supplier>>({
             url: `${this.config.host}/suppliers/${id}/activate`,
             method: 'post',
         })
     }
 
     async deactivateSupplier(id: number) {
-        return ApiService.fetchData<Supplier>({
+        return ApiService.fetchData<DataResponse<Supplier>>({
             url: `${this.config.host}/suppliers/${id}/deactivate`,
             method: 'post',
         })

--- a/src/services/UnitOfMeasureService.ts
+++ b/src/services/UnitOfMeasureService.ts
@@ -1,5 +1,10 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type {
+    PaginatedResponse,
+    DataResponse,
+    PaginationParams,
+} from '@/@types/api'
 
 export interface UnitOfMeasure {
     id: number
@@ -17,6 +22,10 @@ export interface UnitOfMeasureInput {
     [key: string]: unknown
 }
 
+export interface UnitOfMeasureQueryParams extends PaginationParams {
+    isActive?: boolean
+}
+
 class UnitOfMeasureService {
     private host: string
 
@@ -26,23 +35,33 @@ class UnitOfMeasureService {
             : appConfig.inventoryApiHost || ''
     }
 
-    async getUnitsOfMeasure(params?: { isActive?: boolean }) {
-        return ApiService.fetchData<UnitOfMeasure[]>({
-            url: `${this.host}/units-of-measure`,
+    async getUnitsOfMeasure(params?: UnitOfMeasureQueryParams) {
+        const queryParams = new URLSearchParams()
+        if (params?.isActive !== undefined)
+            queryParams.append('isActive', params.isActive.toString())
+        if (params?.limit !== undefined)
+            queryParams.append('limit', params.limit.toString())
+        if (params?.offset !== undefined)
+            queryParams.append('offset', params.offset.toString())
+        const queryString = queryParams.toString()
+        const url = queryString
+            ? `${this.host}/units-of-measure?${queryString}`
+            : `${this.host}/units-of-measure`
+        return ApiService.fetchData<PaginatedResponse<UnitOfMeasure>>({
+            url,
             method: 'get',
-            params,
         })
     }
 
     async getUnitOfMeasureById(id: number) {
-        return ApiService.fetchData<UnitOfMeasure>({
+        return ApiService.fetchData<DataResponse<UnitOfMeasure>>({
             url: `${this.host}/units-of-measure/${id}`,
             method: 'get',
         })
     }
 
     async createUnitOfMeasure(data: UnitOfMeasureInput) {
-        return ApiService.fetchData<UnitOfMeasure>({
+        return ApiService.fetchData<DataResponse<UnitOfMeasure>>({
             url: `${this.host}/units-of-measure`,
             method: 'post',
             data,
@@ -50,7 +69,7 @@ class UnitOfMeasureService {
     }
 
     async updateUnitOfMeasure(id: number, data: Partial<UnitOfMeasureInput>) {
-        return ApiService.fetchData<UnitOfMeasure>({
+        return ApiService.fetchData<DataResponse<UnitOfMeasure>>({
             url: `${this.host}/units-of-measure/${id}`,
             method: 'put',
             data,

--- a/src/services/WarehouseService.ts
+++ b/src/services/WarehouseService.ts
@@ -1,5 +1,10 @@
 import ApiService from './ApiService'
 import appConfig from '@/configs/app.config'
+import type {
+    PaginatedResponse,
+    DataResponse,
+    PaginationParams,
+} from '@/@types/api'
 
 export interface Warehouse {
     id: number
@@ -29,6 +34,10 @@ export interface WarehouseInput {
     [key: string]: unknown
 }
 
+export interface WarehouseQueryParams extends PaginationParams {
+    isActive?: boolean
+}
+
 class WarehouseService {
     private host: string
 
@@ -38,23 +47,33 @@ class WarehouseService {
             : appConfig.inventoryApiHost || ''
     }
 
-    async getWarehouses(params?: { isActive?: boolean }) {
-        return ApiService.fetchData<Warehouse[]>({
-            url: `${this.host}/warehouses`,
+    async getWarehouses(params?: WarehouseQueryParams) {
+        const queryParams = new URLSearchParams()
+        if (params?.isActive !== undefined)
+            queryParams.append('isActive', params.isActive.toString())
+        if (params?.limit !== undefined)
+            queryParams.append('limit', params.limit.toString())
+        if (params?.offset !== undefined)
+            queryParams.append('offset', params.offset.toString())
+        const queryString = queryParams.toString()
+        const url = queryString
+            ? `${this.host}/warehouses?${queryString}`
+            : `${this.host}/warehouses`
+        return ApiService.fetchData<PaginatedResponse<Warehouse>>({
+            url,
             method: 'get',
-            params,
         })
     }
 
     async getWarehouseById(id: number) {
-        return ApiService.fetchData<Warehouse>({
+        return ApiService.fetchData<DataResponse<Warehouse>>({
             url: `${this.host}/warehouses/${id}`,
             method: 'get',
         })
     }
 
     async createWarehouse(data: WarehouseInput) {
-        return ApiService.fetchData<Warehouse>({
+        return ApiService.fetchData<DataResponse<Warehouse>>({
             url: `${this.host}/warehouses`,
             method: 'post',
             data,
@@ -62,7 +81,7 @@ class WarehouseService {
     }
 
     async updateWarehouse(id: number, data: Partial<WarehouseInput>) {
-        return ApiService.fetchData<Warehouse>({
+        return ApiService.fetchData<DataResponse<Warehouse>>({
             url: `${this.host}/warehouses/${id}`,
             method: 'put',
             data,

--- a/src/utils/getErrorMessage.ts
+++ b/src/utils/getErrorMessage.ts
@@ -2,12 +2,11 @@ import axios from 'axios'
 
 export function getErrorMessage(error: unknown, fallback: string): string {
     if (axios.isAxiosError(error)) {
-        return (
-            error.response?.data?.detail ||
-            error.response?.data?.message ||
-            error.message ||
-            fallback
-        )
+        const data = error.response?.data
+        if (data?.errors?.length > 0) {
+            return data.errors[0].message || fallback
+        }
+        return data?.detail || data?.message || error.message || fallback
     }
     if (error instanceof Error) {
         return error.message || fallback

--- a/src/views/inventory/CategoriesView/index.tsx
+++ b/src/views/inventory/CategoriesView/index.tsx
@@ -21,7 +21,13 @@ const CategoriesView = () => {
         category: Category | null
     }>({ open: false, category: null })
 
-    const { data: categories = [], isLoading } = useCategories()
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const offset = (pageIndex - 1) * pageSize
+
+    const { data, isLoading } = useCategories({ limit: pageSize, offset })
+    const categories = data?.items ?? []
+    const total = data?.pagination?.total ?? 0
     const deleteCategory = useDeleteCategory()
 
     const handleCreate = () => {
@@ -153,6 +159,12 @@ const CategoriesView = () => {
                         columns={columns}
                         data={categories}
                         loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
                     />
                 </div>
             </Card>

--- a/src/views/inventory/CustomersView/index.tsx
+++ b/src/views/inventory/CustomersView/index.tsx
@@ -6,14 +6,13 @@ import {
     useActivateCustomer,
     useDeactivateCustomer,
 } from '@/hooks'
+import DataTable, { ColumnDef } from '@/components/shared/DataTable'
 import Card from '@/components/ui/Card'
-import Table from '@/components/ui/Table'
 import Button from '@/components/ui/Button'
 import Dialog from '@/components/ui/Dialog'
 import Badge from '@/components/ui/Badge'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
-import type { ColumnDef } from '@tanstack/react-table'
 import type { Customer } from '@/services/CustomerService'
 import { TAX_TYPE_LABELS } from '@/services/CustomerService'
 import { getErrorMessage } from '@/utils/getErrorMessage'
@@ -27,11 +26,8 @@ import {
     HiOutlineEye,
 } from 'react-icons/hi'
 
-const { Tr, Th, Td, THead, TBody } = Table
-
 const CustomersView = () => {
     const navigate = useNavigate()
-    const { data: customers = [], isLoading } = useCustomers()
     const deleteCustomer = useDeleteCustomer()
     const activateCustomer = useActivateCustomer()
     const deactivateCustomer = useDeactivateCustomer()
@@ -44,6 +40,14 @@ const CustomersView = () => {
     const [customerToDelete, setCustomerToDelete] = useState<Customer | null>(
         null
     )
+
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const offset = (pageIndex - 1) * pageSize
+
+    const { data, isLoading } = useCustomers({ limit: pageSize, offset })
+    const customers = data?.items ?? []
+    const total = data?.pagination?.total ?? 0
 
     const handleEdit = (customer: Customer) => {
         setSelectedCustomer(customer)
@@ -124,10 +128,20 @@ const CustomersView = () => {
         {
             header: 'ID',
             accessorKey: 'id',
+            cell: (props) => {
+                const { row } = props
+                return <span className="font-medium">#{row.original.id}</span>
+            },
         },
         {
             header: 'Nombre',
             accessorKey: 'name',
+            cell: (props) => {
+                const { row } = props
+                return (
+                    <span className="font-semibold">{row.original.name}</span>
+                )
+            },
         },
         {
             header: 'Tax ID',
@@ -136,9 +150,7 @@ const CustomersView = () => {
         {
             header: 'Tipo',
             accessorKey: 'taxType',
-            cell: ({ row }) => {
-                return TAX_TYPE_LABELS[row.original.taxType]
-            },
+            cell: ({ row }) => TAX_TYPE_LABELS[row.original.taxType],
         },
         {
             header: 'Email',
@@ -158,184 +170,104 @@ const CustomersView = () => {
         {
             header: 'Estado',
             accessorKey: 'isActive',
-            cell: ({ row }) => {
-                return (
-                    <Badge
-                        content={row.original.isActive ? 'Activo' : 'Inactivo'}
-                        className={
-                            row.original.isActive
-                                ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300'
-                                : 'bg-gray-100 text-gray-700 dark:bg-gray-500/20 dark:text-gray-300'
-                        }
-                    />
-                )
-            },
+            cell: ({ row }) => (
+                <Badge
+                    content={row.original.isActive ? 'Activo' : 'Inactivo'}
+                    className={
+                        row.original.isActive
+                            ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300'
+                            : 'bg-gray-100 text-gray-700 dark:bg-gray-500/20 dark:text-gray-300'
+                    }
+                />
+            ),
         },
         {
             header: 'Acciones',
-            cell: ({ row }) => {
-                return (
-                    <div className="flex gap-2">
-                        <Button
-                            size="sm"
-                            variant="plain"
-                            icon={<HiOutlineEye />}
-                            onClick={() =>
-                                navigate(`/customers/${row.original.id}`)
-                            }
-                        />
-                        <Button
-                            size="sm"
-                            variant="plain"
-                            icon={<HiOutlinePencil />}
-                            onClick={() => handleEdit(row.original)}
-                        />
-                        <Button
-                            size="sm"
-                            variant="plain"
-                            icon={
-                                row.original.isActive ? (
-                                    <HiOutlineXCircle />
-                                ) : (
-                                    <HiOutlineCheckCircle />
-                                )
-                            }
-                            onClick={() => handleToggleStatus(row.original)}
-                        />
-                        <Button
-                            size="sm"
-                            variant="plain"
-                            icon={<HiOutlineTrash />}
-                            onClick={() => handleDeleteClick(row.original)}
-                        />
-                    </div>
-                )
-            },
+            id: 'actions',
+            cell: ({ row }) => (
+                <div className="flex gap-2">
+                    <Button
+                        size="sm"
+                        variant="plain"
+                        icon={<HiOutlineEye />}
+                        onClick={() =>
+                            navigate(`/customers/${row.original.id}`)
+                        }
+                    />
+                    <Button
+                        size="sm"
+                        variant="plain"
+                        icon={<HiOutlinePencil />}
+                        onClick={() => handleEdit(row.original)}
+                    />
+                    <Button
+                        size="sm"
+                        variant="plain"
+                        icon={
+                            row.original.isActive ? (
+                                <HiOutlineXCircle />
+                            ) : (
+                                <HiOutlineCheckCircle />
+                            )
+                        }
+                        onClick={() => handleToggleStatus(row.original)}
+                    />
+                    <Button
+                        size="sm"
+                        variant="plain"
+                        icon={<HiOutlineTrash />}
+                        onClick={() => handleDeleteClick(row.original)}
+                    />
+                </div>
+            ),
         },
     ]
 
     return (
-        <div className="flex flex-col gap-4">
-            <div className="flex items-center justify-between">
-                <h3>Clientes</h3>
-                <Button
-                    variant="solid"
-                    icon={<HiOutlinePlus />}
-                    onClick={handleCreate}
-                >
-                    Nuevo Cliente
-                </Button>
-            </div>
-
+        <>
             <Card>
-                {isLoading ? (
-                    <div className="flex justify-center items-center h-48">
-                        <div>Cargando...</div>
+                <div className="p-4">
+                    <div className="flex justify-between items-center mb-4">
+                        <div>
+                            <h4 className="text-lg font-semibold">Clientes</h4>
+                            <p className="text-sm text-gray-500 mt-1">
+                                Gestiona los clientes registrados
+                            </p>
+                        </div>
+                        <Button
+                            variant="solid"
+                            size="sm"
+                            icon={<HiOutlinePlus />}
+                            onClick={handleCreate}
+                        >
+                            Nuevo Cliente
+                        </Button>
                     </div>
-                ) : (
-                    <Table>
-                        <THead>
-                            <Tr>
-                                {columns.map((column) => (
-                                    <Th key={column.header as string}>
-                                        {column.header as string}
-                                    </Th>
-                                ))}
-                            </Tr>
-                        </THead>
-                        <TBody>
-                            {customers.length === 0 ? (
-                                <Tr>
-                                    <Td
-                                        colSpan={columns.length}
-                                        className="text-center py-8"
-                                    >
-                                        No hay clientes registrados
-                                    </Td>
-                                </Tr>
-                            ) : (
-                                customers.map((customer) => (
-                                    <Tr key={customer.id}>
-                                        <Td>{customer.id}</Td>
-                                        <Td>{customer.name}</Td>
-                                        <Td>{customer.taxId}</Td>
-                                        <Td>
-                                            {TAX_TYPE_LABELS[customer.taxType]}
-                                        </Td>
-                                        <Td>{customer.email || '-'}</Td>
-                                        <Td>{customer.phone || '-'}</Td>
-                                        <Td>{customer.city || '-'}</Td>
-                                        <Td>
-                                            <Badge
-                                                content={
-                                                    customer.isActive
-                                                        ? 'Activo'
-                                                        : 'Inactivo'
-                                                }
-                                                className={
-                                                    customer.isActive
-                                                        ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300'
-                                                        : 'bg-gray-100 text-gray-700 dark:bg-gray-500/20 dark:text-gray-300'
-                                                }
-                                            />
-                                        </Td>
-                                        <Td>
-                                            <div className="flex gap-2">
-                                                <Button
-                                                    size="sm"
-                                                    variant="plain"
-                                                    icon={<HiOutlinePencil />}
-                                                    onClick={() =>
-                                                        handleEdit(customer)
-                                                    }
-                                                />
-                                                <Button
-                                                    size="sm"
-                                                    variant="plain"
-                                                    icon={
-                                                        customer.isActive ? (
-                                                            <HiOutlineXCircle />
-                                                        ) : (
-                                                            <HiOutlineCheckCircle />
-                                                        )
-                                                    }
-                                                    onClick={() =>
-                                                        handleToggleStatus(
-                                                            customer
-                                                        )
-                                                    }
-                                                />
-                                                <Button
-                                                    size="sm"
-                                                    variant="plain"
-                                                    icon={<HiOutlineTrash />}
-                                                    onClick={() =>
-                                                        handleDeleteClick(
-                                                            customer
-                                                        )
-                                                    }
-                                                />
-                                            </div>
-                                        </Td>
-                                    </Tr>
-                                ))
-                            )}
-                        </TBody>
-                    </Table>
-                )}
+
+                    <DataTable
+                        columns={columns}
+                        data={customers}
+                        loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
+                    />
+                </div>
             </Card>
 
-            {/* Form Modal */}
             <CustomerForm
                 open={formOpen}
                 customer={selectedCustomer}
                 onClose={handleCloseForm}
             />
 
-            {/* Delete Confirmation Dialog */}
             <Dialog
                 isOpen={deleteDialogOpen}
                 onClose={() => setDeleteDialogOpen(false)}
+                onRequestClose={() => setDeleteDialogOpen(false)}
             >
                 <h5 className="mb-4">Confirmar eliminación</h5>
                 <p className="mb-6">
@@ -359,7 +291,7 @@ const CustomersView = () => {
                     </Button>
                 </div>
             </Dialog>
-        </div>
+        </>
     )
 }
 

--- a/src/views/inventory/LocationsView/LocationForm.tsx
+++ b/src/views/inventory/LocationsView/LocationForm.tsx
@@ -40,7 +40,8 @@ const LocationForm = ({ open, onClose, location }: LocationFormProps) => {
 
     const createLocation = useCreateLocation()
     const updateLocation = useUpdateLocation()
-    const { data: warehouses = [] } = useWarehouses({ isActive: true })
+    const { data: warehousesData } = useWarehouses({ isActive: true })
+    const warehouses = warehousesData?.items ?? []
 
     const isEdit = !!location
 

--- a/src/views/inventory/LocationsView/index.tsx
+++ b/src/views/inventory/LocationsView/index.tsx
@@ -30,8 +30,16 @@ const LocationsView = () => {
         location: Location | null
     }>({ open: false, location: null })
 
-    const { data: locations = [], isLoading } = useLocations()
-    const { data: warehouses = [] } = useWarehouses()
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const offset = (pageIndex - 1) * pageSize
+
+    const { data, isLoading } = useLocations({ limit: pageSize, offset })
+    const locations = data?.items ?? []
+    const total = data?.pagination?.total ?? 0
+
+    const { data: warehousesData } = useWarehouses()
+    const warehouses = warehousesData?.items ?? []
     const deleteLocation = useDeleteLocation()
 
     const warehouseMap = new Map(warehouses.map((w) => [w.id, w.name]))
@@ -224,6 +232,12 @@ const LocationsView = () => {
                         columns={columns}
                         data={locations}
                         loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
                     />
                 </div>
             </Card>

--- a/src/views/inventory/LotsView/index.tsx
+++ b/src/views/inventory/LotsView/index.tsx
@@ -23,13 +23,20 @@ const LotsView = () => {
 
     const [productId, setProductId] = useState<string>('')
     const [expiringInDays, setExpiringInDays] = useState<string>('')
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const offset = (pageIndex - 1) * pageSize
 
     const queryParams: LotQueryParams = {
         productId: productId ? parseInt(productId) : undefined,
         expiringInDays: expiringInDays ? parseInt(expiringInDays) : undefined,
+        limit: pageSize,
+        offset,
     }
 
-    const { data: lots = [], isLoading } = useLots(queryParams)
+    const { data, isLoading } = useLots(queryParams)
+    const lots = data?.items ?? []
+    const total = data?.pagination?.total ?? 0
     const deleteLot = useDeleteLot()
 
     const handleCreate = () => {
@@ -81,6 +88,7 @@ const LotsView = () => {
     const handleReset = () => {
         setProductId('')
         setExpiringInDays('')
+        setPageIndex(1)
     }
 
     const getExpiryBadge = (lot: Lot) => {
@@ -296,6 +304,12 @@ const LotsView = () => {
                         columns={columns}
                         data={lots}
                         loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
                     />
                 </div>
             </Card>

--- a/src/views/inventory/MovementsView/index.tsx
+++ b/src/views/inventory/MovementsView/index.tsx
@@ -1,41 +1,46 @@
 import { useState } from 'react'
 import { useMovements } from '@/hooks'
+import DataTable, { ColumnDef } from '@/components/shared/DataTable'
 import Card from '@/components/ui/Card'
-import Table from '@/components/ui/Table'
 import Button from '@/components/ui/Button'
 import Input from '@/components/ui/Input'
 import Select from '@/components/ui/Select'
-import type { ColumnDef } from '@tanstack/react-table'
 import type { Movement } from '@/services/MovementService'
 import MovementForm from './MovementForm'
 import { HiOutlinePlus } from 'react-icons/hi'
-
-const { Tr, Th, Td, THead, TBody } = Table
 
 const MovementsView = () => {
     const [productId, setProductId] = useState<string>('')
     const [type, setType] = useState<string>('')
     const [fromDate, setFromDate] = useState<string>('')
     const [toDate, setToDate] = useState<string>('')
-    const [limit, setLimit] = useState<string>('100')
-    const [offset, setOffset] = useState<string>('0')
     const [formOpen, setFormOpen] = useState(false)
+
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const offset = (pageIndex - 1) * pageSize
 
     const queryParams = {
         productId: productId ? parseInt(productId) : undefined,
         type: type ? (type as 'in' | 'out') : undefined,
         fromDate: fromDate || undefined,
         toDate: toDate || undefined,
-        limit: limit ? parseInt(limit) : 100,
-        offset: offset ? parseInt(offset) : 0,
+        limit: pageSize,
+        offset,
     }
 
-    const { data: movements = [], isLoading } = useMovements(queryParams)
+    const { data, isLoading } = useMovements(queryParams)
+    const movements = data?.items ?? []
+    const total = data?.pagination?.total ?? 0
 
     const columns: ColumnDef<Movement>[] = [
         {
             header: 'ID',
             accessorKey: 'id',
+            cell: (props) => {
+                const { row } = props
+                return <span className="font-medium">#{row.original.id}</span>
+            },
         },
         {
             header: 'ID Producto',
@@ -81,13 +86,10 @@ const MovementsView = () => {
         {
             header: 'Motivo',
             accessorKey: 'reason',
-            cell: ({ row }) => {
-                return (
-                    row.original.reason || (
-                        <span className="text-gray-400 italic">Sin motivo</span>
-                    )
-                )
-            },
+            cell: ({ row }) =>
+                row.original.reason || (
+                    <span className="text-gray-400 italic">Sin motivo</span>
+                ),
         },
         {
             header: 'Fecha',
@@ -111,8 +113,7 @@ const MovementsView = () => {
         setType('')
         setFromDate('')
         setToDate('')
-        setLimit('100')
-        setOffset('0')
+        setPageIndex(1)
     }
 
     const typeOptions = [
@@ -122,193 +123,101 @@ const MovementsView = () => {
     ]
 
     return (
-        <div className="flex flex-col gap-4">
-            <div className="flex items-center justify-between">
-                <h3>Movimientos</h3>
-                <Button
-                    variant="solid"
-                    icon={<HiOutlinePlus />}
-                    onClick={() => setFormOpen(true)}
-                >
-                    Nuevo Movimiento
-                </Button>
-            </div>
-
-            {/* Filters */}
-            <Card>
-                <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            ID Producto
-                        </label>
-                        <Input
-                            type="number"
-                            placeholder="Filtrar por producto"
-                            value={productId}
-                            onChange={(e) => setProductId(e.target.value)}
-                        />
+        <>
+            <Card className="mb-4">
+                <div className="p-4">
+                    <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                ID Producto
+                            </label>
+                            <Input
+                                type="number"
+                                placeholder="Filtrar por producto"
+                                value={productId}
+                                onChange={(e) => setProductId(e.target.value)}
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Tipo
+                            </label>
+                            <Select
+                                value={typeOptions.find(
+                                    (opt) => opt.value === type
+                                )}
+                                options={typeOptions}
+                                onChange={(option) =>
+                                    setType(option?.value || '')
+                                }
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Desde
+                            </label>
+                            <Input
+                                type="datetime-local"
+                                value={fromDate}
+                                onChange={(e) => setFromDate(e.target.value)}
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Hasta
+                            </label>
+                            <Input
+                                type="datetime-local"
+                                value={toDate}
+                                onChange={(e) => setToDate(e.target.value)}
+                            />
+                        </div>
+                        <div className="flex items-end">
+                            <Button variant="plain" onClick={handleReset}>
+                                Limpiar Filtros
+                            </Button>
+                        </div>
                     </div>
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Tipo
-                        </label>
-                        <Select
-                            value={typeOptions.find(
-                                (opt) => opt.value === type
-                            )}
-                            options={typeOptions}
-                            onChange={(option) => setType(option?.value || '')}
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Desde
-                        </label>
-                        <Input
-                            type="datetime-local"
-                            value={fromDate}
-                            onChange={(e) => setFromDate(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Hasta
-                        </label>
-                        <Input
-                            type="datetime-local"
-                            value={toDate}
-                            onChange={(e) => setToDate(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Límite
-                        </label>
-                        <Input
-                            type="number"
-                            placeholder="100"
-                            value={limit}
-                            min="1"
-                            max="1000"
-                            onChange={(e) => setLimit(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Offset
-                        </label>
-                        <Input
-                            type="number"
-                            placeholder="0"
-                            value={offset}
-                            min="0"
-                            onChange={(e) => setOffset(e.target.value)}
-                        />
-                    </div>
-                </div>
-                <div className="flex items-center justify-between">
-                    <div className="text-sm text-gray-600">
-                        Mostrando {movements.length} movimiento(s)
-                        {productId && ` del producto ${productId}`}
-                        {type &&
-                            ` tipo ${type === 'in' ? 'entrada' : 'salida'}`}
-                    </div>
-                    <Button variant="plain" onClick={handleReset}>
-                        Limpiar Filtros
-                    </Button>
                 </div>
             </Card>
 
-            {/* Table */}
             <Card>
-                {isLoading ? (
-                    <div className="flex justify-center items-center h-48">
-                        <div>Cargando...</div>
+                <div className="p-4">
+                    <div className="flex justify-between items-center mb-4">
+                        <div>
+                            <h4 className="text-lg font-semibold">
+                                Movimientos
+                            </h4>
+                            <p className="text-sm text-gray-500 mt-1">
+                                Gestiona los movimientos de inventario
+                            </p>
+                        </div>
+                        <Button
+                            variant="solid"
+                            size="sm"
+                            icon={<HiOutlinePlus />}
+                            onClick={() => setFormOpen(true)}
+                        >
+                            Nuevo Movimiento
+                        </Button>
                     </div>
-                ) : (
-                    <Table>
-                        <THead>
-                            <Tr>
-                                {columns.map((column) => (
-                                    <Th key={column.header as string}>
-                                        {column.header as string}
-                                    </Th>
-                                ))}
-                            </Tr>
-                        </THead>
-                        <TBody>
-                            {movements.length === 0 ? (
-                                <Tr>
-                                    <Td
-                                        colSpan={columns.length}
-                                        className="text-center py-8"
-                                    >
-                                        No hay movimientos registrados
-                                    </Td>
-                                </Tr>
-                            ) : (
-                                movements.map((movement) => (
-                                    <Tr key={movement.id}>
-                                        <Td>{movement.id}</Td>
-                                        <Td>{movement.productId}</Td>
-                                        <Td>
-                                            <span
-                                                className={`px-2 py-1 rounded text-xs font-semibold ${
-                                                    movement.type === 'in'
-                                                        ? 'bg-green-100 text-green-800'
-                                                        : 'bg-red-100 text-red-800'
-                                                }`}
-                                            >
-                                                {movement.type === 'in'
-                                                    ? 'Entrada'
-                                                    : 'Salida'}
-                                            </span>
-                                        </Td>
-                                        <Td>
-                                            <span
-                                                className={
-                                                    movement.quantity > 0
-                                                        ? 'text-green-600 font-semibold'
-                                                        : 'text-red-600 font-semibold'
-                                                }
-                                            >
-                                                {movement.quantity > 0
-                                                    ? '+'
-                                                    : ''}
-                                                {movement.quantity}
-                                            </span>
-                                        </Td>
-                                        <Td>
-                                            {movement.reason || (
-                                                <span className="text-gray-400 italic">
-                                                    Sin motivo
-                                                </span>
-                                            )}
-                                        </Td>
-                                        <Td>
-                                            {movement.date
-                                                ? new Date(
-                                                      movement.date
-                                                  ).toLocaleString('es-ES', {
-                                                      year: 'numeric',
-                                                      month: '2-digit',
-                                                      day: '2-digit',
-                                                      hour: '2-digit',
-                                                      minute: '2-digit',
-                                                  })
-                                                : '-'}
-                                        </Td>
-                                    </Tr>
-                                ))
-                            )}
-                        </TBody>
-                    </Table>
-                )}
+
+                    <DataTable
+                        columns={columns}
+                        data={movements}
+                        loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
+                    />
+                </div>
             </Card>
 
-            {/* Form Modal */}
             <MovementForm open={formOpen} onClose={() => setFormOpen(false)} />
-        </div>
+        </>
     )
 }
 

--- a/src/views/inventory/ProductsView/ProductForm.tsx
+++ b/src/views/inventory/ProductsView/ProductForm.tsx
@@ -28,8 +28,10 @@ const ProductForm = ({ open, onClose, product }: ProductFormProps) => {
 
     const createProduct = useCreateProduct()
     const updateProduct = useUpdateProduct()
-    const { data: categories = [] } = useCategories()
-    const { data: unitsOfMeasure = [] } = useUnitsOfMeasure()
+    const { data: categoriesData } = useCategories()
+    const categories = categoriesData?.items ?? []
+    const { data: unitsData } = useUnitsOfMeasure()
+    const unitsOfMeasure = unitsData?.items ?? []
 
     const isEdit = !!product
 

--- a/src/views/inventory/ProductsView/index.tsx
+++ b/src/views/inventory/ProductsView/index.tsx
@@ -21,24 +21,31 @@ const ProductsView = () => {
         product: Product | null
     }>({ open: false, product: null })
 
-    const { data: products = [], isLoading } = useProducts()
-    const { data: categories = [] } = useCategories()
-    const { data: unitsOfMeasure = [] } = useUnitsOfMeasure()
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const offset = (pageIndex - 1) * pageSize
+
+    const { data, isLoading } = useProducts({ limit: pageSize, offset })
+    const items = data?.items ?? []
+    const total = data?.pagination?.total ?? 0
+
+    const { data: categoriesData } = useCategories()
+    const { data: unitsData } = useUnitsOfMeasure()
     const deleteProduct = useDeleteProduct()
 
-    // Create a lookup map for category ID to name
     const categoryMap = useMemo(() => {
+        const categories = categoriesData?.items ?? []
         const map = new Map<number, string>()
         categories.forEach((cat) => map.set(cat.id, cat.name))
         return map
-    }, [categories])
+    }, [categoriesData])
 
-    // Create a lookup map for unit of measure ID to symbol
     const unitMap = useMemo(() => {
+        const unitsOfMeasure = unitsData?.items ?? []
         const map = new Map<number, string>()
         unitsOfMeasure.forEach((u) => map.set(u.id, u.symbol))
         return map
-    }, [unitsOfMeasure])
+    }, [unitsData])
 
     const handleCreate = () => {
         setSelectedProduct(null)
@@ -213,20 +220,24 @@ const ProductsView = () => {
 
                     <DataTable
                         columns={columns}
-                        data={products}
+                        data={items}
                         loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
                     />
                 </div>
             </Card>
 
-            {/* Form Modal */}
             <ProductForm
                 open={isFormOpen}
                 product={selectedProduct}
                 onClose={handleFormClose}
             />
 
-            {/* Delete Confirmation Dialog */}
             <Dialog
                 isOpen={deleteDialog.open}
                 onClose={() => setDeleteDialog({ open: false, product: null })}

--- a/src/views/inventory/SerialNumbersView/index.tsx
+++ b/src/views/inventory/SerialNumbersView/index.tsx
@@ -66,15 +66,22 @@ const SerialNumbersView = () => {
     const [statusFilter, setStatusFilter] = useState<string>('')
     const [lotId, setLotId] = useState<string>('')
     const [locationId, setLocationId] = useState<string>('')
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const offset = (pageIndex - 1) * pageSize
 
     const queryParams: SerialNumberQueryParams = {
         productId: productId ? parseInt(productId) : undefined,
         status: (statusFilter as SerialStatus) || undefined,
         lotId: lotId ? parseInt(lotId) : undefined,
         locationId: locationId ? parseInt(locationId) : undefined,
+        limit: pageSize,
+        offset,
     }
 
-    const { data: serials = [], isLoading } = useSerialNumbers(queryParams)
+    const { data, isLoading } = useSerialNumbers(queryParams)
+    const serials = data?.items ?? []
+    const total = data?.pagination?.total ?? 0
     const deleteSerial = useDeleteSerialNumber()
 
     const handleCreate = () => {
@@ -141,6 +148,7 @@ const SerialNumbersView = () => {
         setStatusFilter('')
         setLotId('')
         setLocationId('')
+        setPageIndex(1)
     }
 
     const columns: ColumnDef<SerialNumber>[] = [
@@ -327,6 +335,12 @@ const SerialNumbersView = () => {
                         columns={columns}
                         data={serials}
                         loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
                     />
                 </div>
             </Card>

--- a/src/views/inventory/StockView/index.tsx
+++ b/src/views/inventory/StockView/index.tsx
@@ -1,31 +1,36 @@
 import { useState } from 'react'
 import { useStock } from '@/hooks'
+import DataTable, { ColumnDef } from '@/components/shared/DataTable'
 import Card from '@/components/ui/Card'
-import Table from '@/components/ui/Table'
 import Input from '@/components/ui/Input'
 import Button from '@/components/ui/Button'
-import type { ColumnDef } from '@tanstack/react-table'
 import type { Stock } from '@/services/StockService'
-
-const { Tr, Th, Td, THead, TBody } = Table
 
 const StockView = () => {
     const [productId, setProductId] = useState<string>('')
-    const [limit, setLimit] = useState<string>('100')
-    const [offset, setOffset] = useState<string>('0')
+
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const offset = (pageIndex - 1) * pageSize
 
     const queryParams = {
         productId: productId ? parseInt(productId) : undefined,
-        limit: limit ? parseInt(limit) : 100,
-        offset: offset ? parseInt(offset) : 0,
+        limit: pageSize,
+        offset,
     }
 
-    const { data: stock = [], isLoading } = useStock(queryParams)
+    const { data, isLoading } = useStock(queryParams)
+    const stock = data?.items ?? []
+    const total = data?.pagination?.total ?? 0
 
     const columns: ColumnDef<Stock>[] = [
         {
             header: 'ID',
             accessorKey: 'id',
+            cell: (props) => {
+                const { row } = props
+                return <span className="font-medium">#{row.original.id}</span>
+            },
         },
         {
             header: 'ID Producto',
@@ -54,143 +59,68 @@ const StockView = () => {
         {
             header: 'Ubicación',
             accessorKey: 'location',
-            cell: ({ row }) => {
-                return (
-                    row.original.location || (
-                        <span className="text-gray-400 italic">
-                            Sin ubicación
-                        </span>
-                    )
-                )
-            },
+            cell: ({ row }) =>
+                row.original.location || (
+                    <span className="text-gray-400 italic">Sin ubicación</span>
+                ),
         },
     ]
 
     const handleReset = () => {
         setProductId('')
-        setLimit('100')
-        setOffset('0')
+        setPageIndex(1)
     }
 
     return (
-        <div className="flex flex-col gap-4">
-            <div className="flex items-center justify-between">
-                <h3>Stock</h3>
-            </div>
-
-            {/* Filters */}
-            <Card>
-                <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            ID Producto
-                        </label>
-                        <Input
-                            type="number"
-                            placeholder="Filtrar por producto"
-                            value={productId}
-                            onChange={(e) => setProductId(e.target.value)}
-                        />
+        <>
+            <Card className="mb-4">
+                <div className="p-4">
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                ID Producto
+                            </label>
+                            <Input
+                                type="number"
+                                placeholder="Filtrar por producto"
+                                value={productId}
+                                onChange={(e) => setProductId(e.target.value)}
+                            />
+                        </div>
+                        <div className="flex items-end">
+                            <Button variant="plain" onClick={handleReset}>
+                                Limpiar Filtros
+                            </Button>
+                        </div>
                     </div>
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Límite
-                        </label>
-                        <Input
-                            type="number"
-                            placeholder="100"
-                            value={limit}
-                            min="1"
-                            max="1000"
-                            onChange={(e) => setLimit(e.target.value)}
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Desplazamiento
-                        </label>
-                        <Input
-                            type="number"
-                            placeholder="0"
-                            value={offset}
-                            min="0"
-                            onChange={(e) => setOffset(e.target.value)}
-                        />
-                    </div>
-                    <div className="flex items-end">
-                        <Button variant="plain" onClick={handleReset}>
-                            Limpiar Filtros
-                        </Button>
-                    </div>
-                </div>
-
-                {/* Summary */}
-                <div className="text-sm text-gray-600 mb-2">
-                    Mostrando {stock.length} registro(s)
-                    {productId && ` para el producto ${productId}`}
                 </div>
             </Card>
 
-            {/* Table */}
             <Card>
-                {isLoading ? (
-                    <div className="flex justify-center items-center h-48">
-                        <div>Cargando...</div>
+                <div className="p-4">
+                    <div className="flex justify-between items-center mb-4">
+                        <div>
+                            <h4 className="text-lg font-semibold">Stock</h4>
+                            <p className="text-sm text-gray-500 mt-1">
+                                Consulta el stock disponible por producto
+                            </p>
+                        </div>
                     </div>
-                ) : (
-                    <Table>
-                        <THead>
-                            <Tr>
-                                {columns.map((column) => (
-                                    <Th key={column.header as string}>
-                                        {column.header as string}
-                                    </Th>
-                                ))}
-                            </Tr>
-                        </THead>
-                        <TBody>
-                            {stock.length === 0 ? (
-                                <Tr>
-                                    <Td
-                                        colSpan={columns.length}
-                                        className="text-center py-8"
-                                    >
-                                        No hay registros de stock
-                                    </Td>
-                                </Tr>
-                            ) : (
-                                stock.map((item) => (
-                                    <Tr key={item.id}>
-                                        <Td>{item.id}</Td>
-                                        <Td>{item.productId}</Td>
-                                        <Td>
-                                            <span
-                                                className={
-                                                    item.quantity < 50
-                                                        ? 'text-red-600 font-semibold'
-                                                        : item.quantity < 100
-                                                        ? 'text-yellow-600 font-semibold'
-                                                        : 'text-green-600 font-semibold'
-                                                }
-                                            >
-                                                {item.quantity}
-                                            </span>
-                                        </Td>
-                                        <Td>
-                                            {item.location || (
-                                                <span className="text-gray-400 italic">
-                                                    Sin ubicación
-                                                </span>
-                                            )}
-                                        </Td>
-                                    </Tr>
-                                ))
-                            )}
-                        </TBody>
-                    </Table>
-                )}
+
+                    <DataTable
+                        columns={columns}
+                        data={stock}
+                        loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
+                    />
+                </div>
             </Card>
-        </div>
+        </>
     )
 }
 

--- a/src/views/inventory/SupplierDetailView/SupplierProductForm.tsx
+++ b/src/views/inventory/SupplierDetailView/SupplierProductForm.tsx
@@ -41,7 +41,8 @@ const SupplierProductForm = ({
 
     const createSupplierProduct = useCreateSupplierProduct()
     const updateSupplierProduct = useUpdateSupplierProduct()
-    const { data: products = [] } = useProducts()
+    const { data: productsData } = useProducts()
+    const products = productsData?.items ?? []
 
     const isEdit = !!supplierProduct
 

--- a/src/views/inventory/SupplierDetailView/index.tsx
+++ b/src/views/inventory/SupplierDetailView/index.tsx
@@ -45,7 +45,8 @@ const SupplierDetailView = () => {
         useSupplierContacts(supplierId)
     const { data: supplierProducts = [], isLoading: productsLoading } =
         useSupplierProducts(supplierId)
-    const { data: products = [] } = useProducts()
+    const { data: productsData } = useProducts()
+    const products = productsData?.items ?? []
     const deleteContact = useDeleteSupplierContact()
     const deleteSupplierProduct = useDeleteSupplierProduct()
 

--- a/src/views/inventory/SuppliersView/index.tsx
+++ b/src/views/inventory/SuppliersView/index.tsx
@@ -6,8 +6,8 @@ import {
     useActivateSupplier,
     useDeactivateSupplier,
 } from '@/hooks'
+import DataTable, { ColumnDef } from '@/components/shared/DataTable'
 import Card from '@/components/ui/Card'
-import Table from '@/components/ui/Table'
 import Button from '@/components/ui/Button'
 import Dialog from '@/components/ui/Dialog'
 import Badge from '@/components/ui/Badge'
@@ -26,11 +26,8 @@ import {
     HiOutlineEye,
 } from 'react-icons/hi'
 
-const { Tr, Th, Td, THead, TBody } = Table
-
 const SuppliersView = () => {
     const navigate = useNavigate()
-    const { data: suppliers = [], isLoading } = useSuppliers()
     const deleteSupplier = useDeleteSupplier()
     const activateSupplier = useActivateSupplier()
     const deactivateSupplier = useDeactivateSupplier()
@@ -43,6 +40,14 @@ const SuppliersView = () => {
     const [supplierToDelete, setSupplierToDelete] = useState<Supplier | null>(
         null
     )
+
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const offset = (pageIndex - 1) * pageSize
+
+    const { data, isLoading } = useSuppliers({ limit: pageSize, offset })
+    const suppliers = data?.items ?? []
+    const total = data?.pagination?.total ?? 0
 
     const handleEdit = (supplier: Supplier) => {
         setSelectedSupplier(supplier)
@@ -119,142 +124,152 @@ const SuppliersView = () => {
         }
     }
 
-    return (
-        <div className="flex flex-col gap-4">
-            <div className="flex items-center justify-between">
-                <h3>Proveedores</h3>
-                <Button
-                    variant="solid"
-                    icon={<HiOutlinePlus />}
-                    onClick={handleCreate}
-                >
-                    Nuevo Proveedor
-                </Button>
-            </div>
-
-            <Card>
-                {isLoading ? (
-                    <div className="flex justify-center items-center h-48">
-                        <div>Cargando...</div>
-                    </div>
-                ) : (
-                    <Table>
-                        <THead>
-                            <Tr>
-                                <Th>ID</Th>
-                                <Th>Nombre</Th>
-                                <Th>Tax ID</Th>
-                                <Th>Tipo</Th>
-                                <Th>Email</Th>
-                                <Th>Teléfono</Th>
-                                <Th>Ciudad</Th>
-                                <Th>Estado</Th>
-                                <Th>Acciones</Th>
-                            </Tr>
-                        </THead>
-                        <TBody>
-                            {suppliers.length === 0 ? (
-                                <Tr>
-                                    <Td
-                                        colSpan={9}
-                                        className="text-center py-8"
-                                    >
-                                        No hay proveedores registrados
-                                    </Td>
-                                </Tr>
+    const columns: ColumnDef<Supplier>[] = [
+        {
+            header: 'ID',
+            accessorKey: 'id',
+            cell: (props) => {
+                const { row } = props
+                return <span className="font-medium">#{row.original.id}</span>
+            },
+        },
+        {
+            header: 'Nombre',
+            accessorKey: 'name',
+            cell: (props) => {
+                const { row } = props
+                return (
+                    <span className="font-semibold">{row.original.name}</span>
+                )
+            },
+        },
+        {
+            header: 'Tax ID',
+            accessorKey: 'taxId',
+        },
+        {
+            header: 'Tipo',
+            accessorKey: 'taxType',
+            cell: ({ row }) => TAX_TYPE_LABELS[row.original.taxType],
+        },
+        {
+            header: 'Email',
+            accessorKey: 'email',
+            cell: ({ row }) => row.original.email || '-',
+        },
+        {
+            header: 'Teléfono',
+            accessorKey: 'phone',
+            cell: ({ row }) => row.original.phone || '-',
+        },
+        {
+            header: 'Ciudad',
+            accessorKey: 'city',
+            cell: ({ row }) => row.original.city || '-',
+        },
+        {
+            header: 'Estado',
+            accessorKey: 'isActive',
+            cell: ({ row }) => (
+                <Badge
+                    content={row.original.isActive ? 'Activo' : 'Inactivo'}
+                    className={
+                        row.original.isActive
+                            ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300'
+                            : 'bg-gray-100 text-gray-700 dark:bg-gray-500/20 dark:text-gray-300'
+                    }
+                />
+            ),
+        },
+        {
+            header: 'Acciones',
+            id: 'actions',
+            cell: ({ row }) => (
+                <div className="flex gap-2">
+                    <Button
+                        size="sm"
+                        variant="plain"
+                        icon={<HiOutlineEye />}
+                        onClick={() =>
+                            navigate(`/suppliers/${row.original.id}`)
+                        }
+                    />
+                    <Button
+                        size="sm"
+                        variant="plain"
+                        icon={<HiOutlinePencil />}
+                        onClick={() => handleEdit(row.original)}
+                    />
+                    <Button
+                        size="sm"
+                        variant="plain"
+                        icon={
+                            row.original.isActive ? (
+                                <HiOutlineXCircle />
                             ) : (
-                                suppliers.map((supplier) => (
-                                    <Tr key={supplier.id}>
-                                        <Td>{supplier.id}</Td>
-                                        <Td>{supplier.name}</Td>
-                                        <Td>{supplier.taxId}</Td>
-                                        <Td>
-                                            {TAX_TYPE_LABELS[supplier.taxType]}
-                                        </Td>
-                                        <Td>{supplier.email || '-'}</Td>
-                                        <Td>{supplier.phone || '-'}</Td>
-                                        <Td>{supplier.city || '-'}</Td>
-                                        <Td>
-                                            <Badge
-                                                content={
-                                                    supplier.isActive
-                                                        ? 'Activo'
-                                                        : 'Inactivo'
-                                                }
-                                                className={
-                                                    supplier.isActive
-                                                        ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300'
-                                                        : 'bg-gray-100 text-gray-700 dark:bg-gray-500/20 dark:text-gray-300'
-                                                }
-                                            />
-                                        </Td>
-                                        <Td>
-                                            <div className="flex gap-2">
-                                                <Button
-                                                    size="sm"
-                                                    variant="plain"
-                                                    icon={<HiOutlineEye />}
-                                                    onClick={() =>
-                                                        navigate(
-                                                            `/suppliers/${supplier.id}`
-                                                        )
-                                                    }
-                                                />
-                                                <Button
-                                                    size="sm"
-                                                    variant="plain"
-                                                    icon={<HiOutlinePencil />}
-                                                    onClick={() =>
-                                                        handleEdit(supplier)
-                                                    }
-                                                />
-                                                <Button
-                                                    size="sm"
-                                                    variant="plain"
-                                                    icon={
-                                                        supplier.isActive ? (
-                                                            <HiOutlineXCircle />
-                                                        ) : (
-                                                            <HiOutlineCheckCircle />
-                                                        )
-                                                    }
-                                                    onClick={() =>
-                                                        handleToggleStatus(
-                                                            supplier
-                                                        )
-                                                    }
-                                                />
-                                                <Button
-                                                    size="sm"
-                                                    variant="plain"
-                                                    icon={<HiOutlineTrash />}
-                                                    onClick={() =>
-                                                        handleDeleteClick(
-                                                            supplier
-                                                        )
-                                                    }
-                                                />
-                                            </div>
-                                        </Td>
-                                    </Tr>
-                                ))
-                            )}
-                        </TBody>
-                    </Table>
-                )}
+                                <HiOutlineCheckCircle />
+                            )
+                        }
+                        onClick={() => handleToggleStatus(row.original)}
+                    />
+                    <Button
+                        size="sm"
+                        variant="plain"
+                        icon={<HiOutlineTrash />}
+                        onClick={() => handleDeleteClick(row.original)}
+                    />
+                </div>
+            ),
+        },
+    ]
+
+    return (
+        <>
+            <Card>
+                <div className="p-4">
+                    <div className="flex justify-between items-center mb-4">
+                        <div>
+                            <h4 className="text-lg font-semibold">
+                                Proveedores
+                            </h4>
+                            <p className="text-sm text-gray-500 mt-1">
+                                Gestiona los proveedores registrados
+                            </p>
+                        </div>
+                        <Button
+                            variant="solid"
+                            size="sm"
+                            icon={<HiOutlinePlus />}
+                            onClick={handleCreate}
+                        >
+                            Nuevo Proveedor
+                        </Button>
+                    </div>
+
+                    <DataTable
+                        columns={columns}
+                        data={suppliers}
+                        loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
+                    />
+                </div>
             </Card>
 
-            {/* Form Modal */}
             <SupplierForm
                 open={formOpen}
                 supplier={selectedSupplier}
                 onClose={handleCloseForm}
             />
 
-            {/* Delete Confirmation Dialog */}
             <Dialog
                 isOpen={deleteDialogOpen}
                 onClose={() => setDeleteDialogOpen(false)}
+                onRequestClose={() => setDeleteDialogOpen(false)}
             >
                 <h5 className="mb-4">Confirmar eliminación</h5>
                 <p className="mb-6">
@@ -278,7 +293,7 @@ const SuppliersView = () => {
                     </Button>
                 </div>
             </Dialog>
-        </div>
+        </>
     )
 }
 

--- a/src/views/inventory/UnitsOfMeasureView/index.tsx
+++ b/src/views/inventory/UnitsOfMeasureView/index.tsx
@@ -24,7 +24,13 @@ const UnitsOfMeasureView = () => {
         unit: UnitOfMeasure | null
     }>({ open: false, unit: null })
 
-    const { data: units = [], isLoading } = useUnitsOfMeasure()
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const offset = (pageIndex - 1) * pageSize
+
+    const { data, isLoading } = useUnitsOfMeasure({ limit: pageSize, offset })
+    const units = data?.items ?? []
+    const total = data?.pagination?.total ?? 0
     const deleteUnit = useDeleteUnitOfMeasure()
 
     const handleCreate = () => {
@@ -186,6 +192,12 @@ const UnitsOfMeasureView = () => {
                         columns={columns}
                         data={units}
                         loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
                     />
                 </div>
             </Card>

--- a/src/views/inventory/WarehousesView/index.tsx
+++ b/src/views/inventory/WarehousesView/index.tsx
@@ -21,7 +21,13 @@ const WarehousesView = () => {
         warehouse: Warehouse | null
     }>({ open: false, warehouse: null })
 
-    const { data: warehouses = [], isLoading } = useWarehouses()
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const offset = (pageIndex - 1) * pageSize
+
+    const { data, isLoading } = useWarehouses({ limit: pageSize, offset })
+    const warehouses = data?.items ?? []
+    const total = data?.pagination?.total ?? 0
     const deleteWarehouse = useDeleteWarehouse()
 
     const handleCreate = () => {
@@ -205,6 +211,12 @@ const WarehousesView = () => {
                         columns={columns}
                         data={warehouses}
                         loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
                     />
                 </div>
             </Card>


### PR DESCRIPTION
## Descripción

  - Create shared API types (DataResponse, PaginatedResponse, ErrorResponse)
  - Update all 14 services to use envelope types and pagination params
  - Update all 14 hooks to unwrap API envelope responses
  - Migrate CustomersView, SuppliersView, MovementsView, and StockView from raw Table to DataTable
  - Add server-side pagination (limit/offset) to all list views
  - Update error handling to support new errors[] array format
  - Fix form components (ProductForm, LocationForm, SupplierProductForm) data access

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
