### PR TITLE
fix: add scrollable content area to all form modals for small screens

### DIFF
--- a/src/views/inventory/CategoriesView/CategoryForm.tsx
+++ b/src/views/inventory/CategoriesView/CategoryForm.tsx
@@ -94,66 +94,68 @@ const CategoryForm = ({ open, onClose, category }: CategoryFormProps) => {
             onClose={onClose}
             onRequestClose={onClose}
         >
-            <h5 className="mb-4">
-                {isEditMode ? 'Editar Categoría' : 'Nueva Categoría'}
-            </h5>
+            <div className="flex flex-col h-full justify-between">
+                <h5 className="mb-4">
+                    {isEditMode ? 'Editar Categoría' : 'Nueva Categoría'}
+                </h5>
 
-            <form onSubmit={handleSubmit}>
-                <div className="space-y-4">
-                    {/* Name */}
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Nombre <span className="text-red-500">*</span>
-                        </label>
-                        <Input
-                            required
-                            placeholder="Nombre de la categoría"
-                            value={formData.name}
-                            disabled={isPending}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    name: e.target.value,
-                                })
-                            }
-                        />
+                <form className="flex-1" onSubmit={handleSubmit}>
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
+                        {/* Name */}
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Nombre <span className="text-red-500">*</span>
+                            </label>
+                            <Input
+                                required
+                                placeholder="Nombre de la categoría"
+                                value={formData.name}
+                                disabled={isPending}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        name: e.target.value,
+                                    })
+                                }
+                            />
+                        </div>
+
+                        {/* Description */}
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Descripción
+                            </label>
+                            <Input
+                                textArea
+                                placeholder="Descripción de la categoría"
+                                value={formData.description}
+                                style={{ minHeight: '80px' }}
+                                disabled={isPending}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        description: e.target.value,
+                                    })
+                                }
+                            />
+                        </div>
                     </div>
 
-                    {/* Description */}
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Descripción
-                        </label>
-                        <Input
-                            textArea
-                            placeholder="Descripción de la categoría"
-                            value={formData.description}
-                            style={{ minHeight: '80px' }}
+                    <div className="flex justify-end gap-2 mt-6">
+                        <Button
+                            type="button"
+                            variant="plain"
                             disabled={isPending}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    description: e.target.value,
-                                })
-                            }
-                        />
+                            onClick={onClose}
+                        >
+                            Cancelar
+                        </Button>
+                        <Button type="submit" variant="solid" loading={isPending}>
+                            {isEditMode ? 'Actualizar' : 'Crear'}
+                        </Button>
                     </div>
-                </div>
-
-                <div className="flex justify-end gap-2 mt-6">
-                    <Button
-                        type="button"
-                        variant="plain"
-                        disabled={isPending}
-                        onClick={onClose}
-                    >
-                        Cancelar
-                    </Button>
-                    <Button type="submit" variant="solid" loading={isPending}>
-                        {isEditMode ? 'Actualizar' : 'Crear'}
-                    </Button>
-                </div>
-            </form>
+                </form>
+            </div>
         </Dialog>
     )
 }

--- a/src/views/inventory/CustomerDetailView/ContactForm.tsx
+++ b/src/views/inventory/CustomerDetailView/ContactForm.tsx
@@ -121,7 +121,7 @@ const ContactForm = ({
                 </h5>
 
                 <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4">
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
                         {/* Name */}
                         <div>
                             <label className="block text-sm font-medium mb-2">

--- a/src/views/inventory/CustomersView/CustomerForm.tsx
+++ b/src/views/inventory/CustomersView/CustomerForm.tsx
@@ -144,11 +144,8 @@ const CustomerForm = ({ open, onClose, customer }: CustomerFormProps) => {
                     {isEdit ? 'Editar Cliente' : 'Nuevo Cliente'}
                 </h5>
 
-                <form
-                    className="flex-1 overflow-y-auto"
-                    onSubmit={handleSubmit}
-                >
-                    <div className="space-y-4">
+                <form className="flex-1" onSubmit={handleSubmit}>
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
                         {/* Basic Information */}
                         <div>
                             <h6 className="mb-3 text-sm font-semibold">

--- a/src/views/inventory/LocationsView/LocationForm.tsx
+++ b/src/views/inventory/LocationsView/LocationForm.tsx
@@ -150,7 +150,7 @@ const LocationForm = ({ open, onClose, location }: LocationFormProps) => {
                 </h5>
 
                 <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4">
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
                         <div>
                             <label className="block text-sm font-medium mb-2">
                                 Bodega <span className="text-red-500">*</span>

--- a/src/views/inventory/LotsView/LotForm.tsx
+++ b/src/views/inventory/LotsView/LotForm.tsx
@@ -120,7 +120,7 @@ const LotForm = ({ open, onClose, lot }: LotFormProps) => {
                 </h5>
 
                 <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4">
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
                         <div className="grid grid-cols-2 gap-4">
                             <div>
                                 <label className="block text-sm font-medium mb-2">

--- a/src/views/inventory/MovementsView/MovementForm.tsx
+++ b/src/views/inventory/MovementsView/MovementForm.tsx
@@ -155,7 +155,7 @@ const MovementForm = ({ open, onClose }: MovementFormProps) => {
                 <h5 className="mb-4">Nuevo Movimiento</h5>
 
                 <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4">
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
                         {/* Product ID */}
                         <div>
                             <label className="block text-sm font-medium mb-2">

--- a/src/views/inventory/SerialNumbersView/SerialNumberForm.tsx
+++ b/src/views/inventory/SerialNumbersView/SerialNumberForm.tsx
@@ -145,7 +145,7 @@ const SerialNumberForm = ({
                 </h5>
 
                 <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4">
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
                         <div className="grid grid-cols-2 gap-4">
                             <div>
                                 <label className="block text-sm font-medium mb-2">

--- a/src/views/inventory/SupplierDetailView/ContactForm.tsx
+++ b/src/views/inventory/SupplierDetailView/ContactForm.tsx
@@ -121,7 +121,7 @@ const ContactForm = ({
                 </h5>
 
                 <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4">
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
                         {/* Name */}
                         <div>
                             <label className="block text-sm font-medium mb-2">

--- a/src/views/inventory/SupplierDetailView/SupplierProductForm.tsx
+++ b/src/views/inventory/SupplierDetailView/SupplierProductForm.tsx
@@ -142,7 +142,7 @@ const SupplierProductForm = ({
                 </h5>
 
                 <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4">
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
                         {/* Product */}
                         <div>
                             <label className="block text-sm font-medium mb-2">

--- a/src/views/inventory/SuppliersView/SupplierForm.tsx
+++ b/src/views/inventory/SuppliersView/SupplierForm.tsx
@@ -152,11 +152,8 @@ const SupplierForm = ({ open, onClose, supplier }: SupplierFormProps) => {
                     {isEdit ? 'Editar Proveedor' : 'Nuevo Proveedor'}
                 </h5>
 
-                <form
-                    className="flex-1 overflow-y-auto"
-                    onSubmit={handleSubmit}
-                >
-                    <div className="space-y-4">
+                <form className="flex-1" onSubmit={handleSubmit}>
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
                         {/* Basic Information */}
                         <div>
                             <h6 className="mb-3 text-sm font-semibold">

--- a/src/views/inventory/UnitsOfMeasureView/UnitOfMeasureForm.tsx
+++ b/src/views/inventory/UnitsOfMeasureView/UnitOfMeasureForm.tsx
@@ -119,7 +119,7 @@ const UnitOfMeasureForm = ({
                 </h5>
 
                 <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4">
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
                         <div>
                             <label className="block text-sm font-medium mb-2">
                                 Nombre <span className="text-red-500">*</span>

--- a/src/views/inventory/WarehousesView/WarehouseForm.tsx
+++ b/src/views/inventory/WarehousesView/WarehouseForm.tsx
@@ -126,7 +126,7 @@ const WarehouseForm = ({ open, onClose, warehouse }: WarehouseFormProps) => {
                 </h5>
 
                 <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4">
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
                         <div className="grid grid-cols-2 gap-4">
                             <div>
                                 <label className="block text-sm font-medium mb-2">


### PR DESCRIPTION
## Descripción

  Apply max-h-[60vh] overflow-y-auto to form fields container across all
  modals, replicating the pattern from ProductForm. This keeps the title
  and action buttons fixed while the form content scrolls on small screens.

## Tipo de cambio

- [x] 🐛 Bug fix
- [ ] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
