### PR TITLE
feat: add sales read-only module with list and detail views

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -25,6 +25,7 @@
 | Números de serie | ✅ | ✅ | ✅ | CRUD con filtros + cambio de estado |
 | Ajustes de inventario | ✅ | ✅ | ✅ | CRUD + confirm/cancel + items CRUD, ciclo DRAFT→CONFIRMED/CANCELLED |
 | Transferencias | ✅ | ✅ | ✅ | CRUD + confirm/receive/cancel + items CRUD, ciclo DRAFT→CONFIRMED→RECEIVED/CANCELLED |
+| Ventas | ✅ | ✅ | ✅ | Solo lectura: listado con filtros (customerId, status, paginación) + detalle con items y pagos en tabs |
 
 ### Módulos pendientes
 
@@ -40,9 +41,9 @@
 | ~~8~~ | ~~Números de serie~~ | ~~Media~~ | ~~Completado en Sesión 5~~ |
 | ~~9~~ | ~~Ajustes de inventario~~ | ~~Alta~~ | ~~Completado en Sesión 6~~ |
 | ~~10~~ | ~~Transferencias~~ | ~~Alta~~ | ~~Completado en Sesión 7~~ |
-| 11 | Órdenes de compra | Alta | Proveedores, Productos |
+| ~~11~~ | ~~Órdenes de compra~~ | ~~Alta~~ | ~~Completado en Sesión 8~~ |
 | 12 | Alertas | Baja | Bodegas |
-| 13 | Ventas (solo lectura) | Media | Clientes |
+| ~~13~~ | ~~Ventas (solo lectura)~~ | ~~Media~~ | ~~Completado en Sesión 9~~ |
 | 14 | Reportes de inventario | Media | Bodegas |
 
 ---

--- a/src/configs/navigation-icon.config.tsx
+++ b/src/configs/navigation-icon.config.tsx
@@ -10,6 +10,7 @@ import {
     HiOutlineOfficeBuilding,
     HiOutlineQrcode,
     HiOutlineScale,
+    HiOutlineShoppingCart,
     HiOutlineSwitchHorizontal,
     HiOutlineSwitchVertical,
     HiOutlineTruck,
@@ -34,6 +35,7 @@ const navigationIcon: NavigationIcons = {
     purchasesPurchaseOrders: <HiOutlineDocumentText />,
     inventoryAdjustments: <HiOutlineClipboardCheck />,
     inventoryTransfers: <HiOutlineSwitchVertical />,
+    salesSales: <HiOutlineShoppingCart />,
     groupCollapseMenu: <HiOutlineColorSwatch />,
 }
 

--- a/src/configs/navigation.config/index.ts
+++ b/src/configs/navigation.config/index.ts
@@ -198,6 +198,16 @@ const navigationConfig: NavigationTree[] = [
                 authority: [],
                 subMenu: [],
             },
+            {
+                key: 'sales.sales',
+                path: '/sales',
+                title: 'Sales',
+                translateKey: 'nav.sales.sales',
+                icon: 'salesSales',
+                type: NAV_ITEM_TYPE_ITEM,
+                authority: [],
+                subMenu: [],
+            },
         ],
     },
     {

--- a/src/configs/routes.config/routes.config.ts
+++ b/src/configs/routes.config/routes.config.ts
@@ -146,6 +146,18 @@ export const protectedRoutes = [
         authority: [],
     },
     {
+        key: 'sales.sales',
+        path: '/sales',
+        component: lazy(() => import('@/views/sales/SalesView')),
+        authority: [],
+    },
+    {
+        key: 'sales.saleDetail',
+        path: '/sales/:id',
+        component: lazy(() => import('@/views/sales/SaleDetailView')),
+        authority: [],
+    },
+    {
         key: 'groupMenu.collapse.item1',
         path: '/group-collapse-menu-item-view-1',
         component: lazy(

--- a/src/hooks/useSales.ts
+++ b/src/hooks/useSales.ts
@@ -1,0 +1,47 @@
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
+import SaleService, { type SaleQueryParams } from '@/services/SaleService'
+
+export function useSales(params?: SaleQueryParams) {
+    return useQuery({
+        queryKey: ['sales', params],
+        queryFn: async () => {
+            const response = await SaleService.getSales(params)
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
+        },
+        placeholderData: keepPreviousData,
+    })
+}
+
+export function useSale(id: number) {
+    return useQuery({
+        queryKey: ['sales', id],
+        queryFn: async () => {
+            const response = await SaleService.getSale(id)
+            return response.data.data
+        },
+        enabled: id > 0,
+    })
+}
+
+export function useSaleItems(saleId: number) {
+    return useQuery({
+        queryKey: ['saleItems', saleId],
+        queryFn: async () => {
+            const response = await SaleService.getSaleItems(saleId)
+            return response.data.data
+        },
+        enabled: saleId > 0,
+    })
+}
+
+export function useSalePayments(saleId: number) {
+    return useQuery({
+        queryKey: ['salePayments', saleId],
+        queryFn: async () => {
+            const response = await SaleService.getSalePayments(saleId)
+            return response.data.data
+        },
+        enabled: saleId > 0,
+    })
+}

--- a/src/services/SaleService.ts
+++ b/src/services/SaleService.ts
@@ -1,0 +1,155 @@
+import ApiService from './ApiService'
+import appConfig from '@/configs/app.config'
+import type {
+    PaginatedResponse,
+    DataResponse,
+    PaginationParams,
+} from '@/@types/api'
+
+export type SaleStatus = 'DRAFT' | 'CONFIRMED' | 'INVOICED' | 'CANCELLED'
+export type PaymentStatus = 'PENDING' | 'PARTIAL' | 'PAID'
+export type PaymentMethod = 'CASH' | 'CARD' | 'TRANSFER' | 'CREDIT'
+
+export const SALE_STATUS_LABELS: Record<SaleStatus, string> = {
+    DRAFT: 'Borrador',
+    CONFIRMED: 'Confirmada',
+    INVOICED: 'Facturada',
+    CANCELLED: 'Cancelada',
+}
+
+export const SALE_STATUS_CLASSES: Record<SaleStatus, string> = {
+    DRAFT: 'bg-gray-100 text-gray-700 dark:bg-gray-500/20 dark:text-gray-300',
+    CONFIRMED:
+        'bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300',
+    INVOICED:
+        'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300',
+    CANCELLED: 'bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-300',
+}
+
+export const PAYMENT_STATUS_LABELS: Record<PaymentStatus, string> = {
+    PENDING: 'Pendiente',
+    PARTIAL: 'Parcial',
+    PAID: 'Pagado',
+}
+
+export const PAYMENT_STATUS_CLASSES: Record<PaymentStatus, string> = {
+    PENDING:
+        'bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-300',
+    PARTIAL: 'bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300',
+    PAID: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300',
+}
+
+export const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
+    CASH: 'Efectivo',
+    CARD: 'Tarjeta',
+    TRANSFER: 'Transferencia',
+    CREDIT: 'Crédito',
+}
+
+export interface Sale {
+    id: number
+    customerId: number
+    status: SaleStatus
+    saleDate: string | null
+    subtotal: number
+    tax: number
+    discount: number
+    total: number
+    paymentStatus: PaymentStatus
+    notes: string | null
+    createdBy: string | null
+    createdAt: string
+    updatedAt: string | null
+}
+
+export interface SaleItem {
+    id: number
+    saleId: number
+    productId: number
+    quantity: number
+    unitPrice: number
+    discount: number
+    subtotal: number
+}
+
+export interface Payment {
+    id: number
+    saleId: number
+    amount: number
+    paymentMethod: PaymentMethod
+    paymentDate: string | null
+    reference: string | null
+    notes: string | null
+    createdAt: string
+}
+
+export interface SaleQueryParams extends PaginationParams {
+    customerId?: number
+    status?: SaleStatus
+}
+
+interface SaleItemsResponse {
+    data: SaleItem[]
+    meta: { requestId: string; timestamp: string }
+}
+
+interface PaymentsResponse {
+    data: Payment[]
+    meta: { requestId: string; timestamp: string }
+}
+
+class SaleService {
+    private config = {
+        host: appConfig.inventoryApiHost || 'http://localhost:3000',
+    }
+
+    async getSales(params?: SaleQueryParams) {
+        const queryParams = new URLSearchParams()
+
+        if (params?.customerId !== undefined) {
+            queryParams.append('customerId', params.customerId.toString())
+        }
+        if (params?.status) {
+            queryParams.append('status', params.status)
+        }
+        if (params?.limit !== undefined) {
+            queryParams.append('limit', params.limit.toString())
+        }
+        if (params?.offset !== undefined) {
+            queryParams.append('offset', params.offset.toString())
+        }
+
+        const queryString = queryParams.toString()
+        const url = queryString
+            ? `${this.config.host}/sales?${queryString}`
+            : `${this.config.host}/sales`
+
+        return ApiService.fetchData<PaginatedResponse<Sale>>({
+            url,
+            method: 'get',
+        })
+    }
+
+    async getSale(id: number) {
+        return ApiService.fetchData<DataResponse<Sale>>({
+            url: `${this.config.host}/sales/${id}`,
+            method: 'get',
+        })
+    }
+
+    async getSaleItems(saleId: number) {
+        return ApiService.fetchData<SaleItemsResponse>({
+            url: `${this.config.host}/sales/${saleId}/items`,
+            method: 'get',
+        })
+    }
+
+    async getSalePayments(saleId: number) {
+        return ApiService.fetchData<PaymentsResponse>({
+            url: `${this.config.host}/sales/${saleId}/payments`,
+            method: 'get',
+        })
+    }
+}
+
+export default new SaleService()

--- a/src/views/sales/SaleDetailView/index.tsx
+++ b/src/views/sales/SaleDetailView/index.tsx
@@ -1,0 +1,344 @@
+import { useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useSale, useSaleItems, useSalePayments } from '@/hooks/useSales'
+import { useProducts } from '@/hooks/useProducts'
+import { useCustomers } from '@/hooks/useCustomers'
+import Card from '@/components/ui/Card'
+import Button from '@/components/ui/Button'
+import Badge from '@/components/ui/Badge'
+import Table from '@/components/ui/Table'
+import Tabs from '@/components/ui/Tabs'
+import {
+    SALE_STATUS_LABELS,
+    SALE_STATUS_CLASSES,
+    PAYMENT_STATUS_LABELS,
+    PAYMENT_STATUS_CLASSES,
+    PAYMENT_METHOD_LABELS,
+} from '@/services/SaleService'
+import { HiOutlineArrowLeft } from 'react-icons/hi'
+
+const { Tr, Th, Td, THead, TBody, TFoot } = Table
+const { TabList, TabNav, TabContent } = Tabs
+
+const SaleDetailView = () => {
+    const { id } = useParams<{ id: string }>()
+    const navigate = useNavigate()
+    const saleId = parseInt(id || '0')
+
+    const [activeTab, setActiveTab] = useState('items')
+
+    const { data: sale, isLoading: saleLoading } = useSale(saleId)
+    const { data: items = [], isLoading: itemsLoading } = useSaleItems(saleId)
+    const { data: payments = [], isLoading: paymentsLoading } =
+        useSalePayments(saleId)
+
+    const { data: productsData } = useProducts()
+    const products = productsData?.items ?? []
+
+    const { data: customersData } = useCustomers({ limit: 100 })
+    const customers = customersData?.items ?? []
+
+    const getProductName = (productId: number) => {
+        const p = products.find((p) => p.id === productId)
+        return p ? `${p.name} (${p.sku})` : `#${productId}`
+    }
+
+    const getCustomerName = (customerId: number) => {
+        const c = customers.find((c) => c.id === customerId)
+        return c ? c.name : `#${customerId}`
+    }
+
+    const formatCurrency = (value: number) => {
+        return new Intl.NumberFormat('es-EC', {
+            style: 'currency',
+            currency: 'USD',
+        }).format(value)
+    }
+
+    const formatDate = (date: string | null) => {
+        if (!date) return '-'
+        return new Date(date).toLocaleDateString('es-EC')
+    }
+
+    const formatDateTime = (date: string | null) => {
+        if (!date) return '-'
+        return new Date(date).toLocaleString('es-EC')
+    }
+
+    if (saleLoading) {
+        return (
+            <div className="flex justify-center items-center h-96">
+                <div>Cargando...</div>
+            </div>
+        )
+    }
+
+    if (!sale) {
+        return (
+            <div className="flex flex-col items-center justify-center h-96">
+                <h4 className="mb-4">Venta no encontrada</h4>
+                <Button
+                    variant="solid"
+                    icon={<HiOutlineArrowLeft />}
+                    onClick={() => navigate('/sales')}
+                >
+                    Volver a Ventas
+                </Button>
+            </div>
+        )
+    }
+
+    const itemsTotal = items.reduce((sum, item) => sum + item.subtotal, 0)
+    const paymentsTotal = payments.reduce((sum, p) => sum + p.amount, 0)
+
+    return (
+        <div className="flex flex-col gap-4">
+            {/* Header */}
+            <div className="flex items-center gap-4">
+                <Button
+                    variant="plain"
+                    icon={<HiOutlineArrowLeft />}
+                    onClick={() => navigate('/sales')}
+                />
+                <h3>Venta #{sale.id}</h3>
+                <Badge
+                    content={SALE_STATUS_LABELS[sale.status]}
+                    className={SALE_STATUS_CLASSES[sale.status]}
+                />
+                <Badge
+                    content={PAYMENT_STATUS_LABELS[sale.paymentStatus]}
+                    className={PAYMENT_STATUS_CLASSES[sale.paymentStatus]}
+                />
+            </div>
+
+            {/* Sale Info */}
+            <Card>
+                <h5 className="mb-4">Información de la Venta</h5>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                    <div>
+                        <p className="text-sm text-gray-500">Cliente</p>
+                        <p className="font-medium">
+                            {getCustomerName(sale.customerId)}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-sm text-gray-500">Fecha de Venta</p>
+                        <p className="font-medium">
+                            {formatDate(sale.saleDate)}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-sm text-gray-500">Creado por</p>
+                        <p className="font-medium">{sale.createdBy ?? '-'}</p>
+                    </div>
+                    <div>
+                        <p className="text-sm text-gray-500">
+                            Fecha de Creación
+                        </p>
+                        <p className="font-medium">
+                            {formatDateTime(sale.createdAt)}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-sm text-gray-500">
+                            Última Actualización
+                        </p>
+                        <p className="font-medium">
+                            {formatDateTime(sale.updatedAt)}
+                        </p>
+                    </div>
+                </div>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4 pt-4 border-t dark:border-gray-600">
+                    <div>
+                        <p className="text-sm text-gray-500">Subtotal</p>
+                        <p className="font-medium">
+                            {formatCurrency(sale.subtotal)}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-sm text-gray-500">Descuento</p>
+                        <p className="font-medium">
+                            {formatCurrency(sale.discount)}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-sm text-gray-500">Impuestos</p>
+                        <p className="font-medium">
+                            {formatCurrency(sale.tax)}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-sm text-gray-500">Total</p>
+                        <p className="text-lg font-semibold">
+                            {formatCurrency(sale.total)}
+                        </p>
+                    </div>
+                </div>
+                {sale.notes && (
+                    <div className="mt-4 pt-4 border-t dark:border-gray-600">
+                        <p className="text-sm text-gray-500">Notas</p>
+                        <p className="font-medium">{sale.notes}</p>
+                    </div>
+                )}
+            </Card>
+
+            {/* Items & Payments Tabs */}
+            <Card>
+                <Tabs value={activeTab} onChange={setActiveTab}>
+                    <TabList>
+                        <TabNav value="items">Items ({items.length})</TabNav>
+                        <TabNav value="payments">
+                            Pagos ({payments.length})
+                        </TabNav>
+                    </TabList>
+                    <div className="mt-4">
+                        <TabContent value="items">
+                            {itemsLoading ? (
+                                <div className="flex justify-center items-center h-32">
+                                    <div>Cargando items...</div>
+                                </div>
+                            ) : items.length === 0 ? (
+                                <div className="text-center py-8 text-gray-500">
+                                    No hay items en esta venta
+                                </div>
+                            ) : (
+                                <Table>
+                                    <THead>
+                                        <Tr>
+                                            <Th>Producto</Th>
+                                            <Th>Cantidad</Th>
+                                            <Th>Precio Unitario</Th>
+                                            <Th>Descuento (%)</Th>
+                                            <Th>Subtotal</Th>
+                                        </Tr>
+                                    </THead>
+                                    <TBody>
+                                        {items.map((item) => (
+                                            <Tr key={item.id}>
+                                                <Td>
+                                                    {getProductName(
+                                                        item.productId
+                                                    )}
+                                                </Td>
+                                                <Td>{item.quantity}</Td>
+                                                <Td>
+                                                    {formatCurrency(
+                                                        item.unitPrice
+                                                    )}
+                                                </Td>
+                                                <Td>
+                                                    {item.discount > 0
+                                                        ? `${item.discount}%`
+                                                        : '-'}
+                                                </Td>
+                                                <Td className="font-medium">
+                                                    {formatCurrency(
+                                                        item.subtotal
+                                                    )}
+                                                </Td>
+                                            </Tr>
+                                        ))}
+                                    </TBody>
+                                    <TFoot>
+                                        <Tr>
+                                            <Td
+                                                colSpan={4}
+                                                className="text-right font-medium"
+                                            >
+                                                Total Items
+                                            </Td>
+                                            <Td className="font-semibold">
+                                                {formatCurrency(itemsTotal)}
+                                            </Td>
+                                        </Tr>
+                                    </TFoot>
+                                </Table>
+                            )}
+                        </TabContent>
+                        <TabContent value="payments">
+                            {paymentsLoading ? (
+                                <div className="flex justify-center items-center h-32">
+                                    <div>Cargando pagos...</div>
+                                </div>
+                            ) : payments.length === 0 ? (
+                                <div className="text-center py-8 text-gray-500">
+                                    No hay pagos registrados
+                                </div>
+                            ) : (
+                                <>
+                                    <Table>
+                                        <THead>
+                                            <Tr>
+                                                <Th>Método</Th>
+                                                <Th>Monto</Th>
+                                                <Th>Fecha de Pago</Th>
+                                                <Th>Referencia</Th>
+                                                <Th>Notas</Th>
+                                            </Tr>
+                                        </THead>
+                                        <TBody>
+                                            {payments.map((payment) => (
+                                                <Tr key={payment.id}>
+                                                    <Td>
+                                                        {
+                                                            PAYMENT_METHOD_LABELS[
+                                                                payment
+                                                                    .paymentMethod
+                                                            ]
+                                                        }
+                                                    </Td>
+                                                    <Td className="font-medium">
+                                                        {formatCurrency(
+                                                            payment.amount
+                                                        )}
+                                                    </Td>
+                                                    <Td>
+                                                        {formatDate(
+                                                            payment.paymentDate
+                                                        )}
+                                                    </Td>
+                                                    <Td>
+                                                        {payment.reference ??
+                                                            '-'}
+                                                    </Td>
+                                                    <Td>
+                                                        {payment.notes ?? '-'}
+                                                    </Td>
+                                                </Tr>
+                                            ))}
+                                        </TBody>
+                                        <TFoot>
+                                            <Tr>
+                                                <Td className="font-medium">
+                                                    Total Pagado
+                                                </Td>
+                                                <Td className="font-semibold">
+                                                    {formatCurrency(
+                                                        paymentsTotal
+                                                    )}
+                                                </Td>
+                                                <Td colSpan={3} />
+                                            </Tr>
+                                        </TFoot>
+                                    </Table>
+                                    {paymentsTotal < sale.total && (
+                                        <div className="mt-3 p-3 bg-amber-50 dark:bg-amber-500/10 rounded-lg text-sm text-amber-700 dark:text-amber-400">
+                                            Saldo pendiente:{' '}
+                                            <span className="font-semibold">
+                                                {formatCurrency(
+                                                    sale.total - paymentsTotal
+                                                )}
+                                            </span>
+                                        </div>
+                                    )}
+                                </>
+                            )}
+                        </TabContent>
+                    </div>
+                </Tabs>
+            </Card>
+        </div>
+    )
+}
+
+export default SaleDetailView

--- a/src/views/sales/SalesView/index.tsx
+++ b/src/views/sales/SalesView/index.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import DataTable, { ColumnDef } from '@/components/shared/DataTable'
+import Card from '@/components/ui/Card'
+import Button from '@/components/ui/Button'
+import Badge from '@/components/ui/Badge'
+import Select from '@/components/ui/Select'
+import { useSales } from '@/hooks/useSales'
+import { useCustomers } from '@/hooks/useCustomers'
+import {
+    SALE_STATUS_LABELS,
+    SALE_STATUS_CLASSES,
+    PAYMENT_STATUS_LABELS,
+    PAYMENT_STATUS_CLASSES,
+    type Sale,
+    type SaleQueryParams,
+    type SaleStatus,
+} from '@/services/SaleService'
+import { HiOutlineEye } from 'react-icons/hi'
+
+const statusOptions = [
+    { value: '', label: 'Todos' },
+    ...Object.entries(SALE_STATUS_LABELS).map(([value, label]) => ({
+        value,
+        label,
+    })),
+]
+
+const SalesView = () => {
+    const navigate = useNavigate()
+
+    const [statusFilter, setStatusFilter] = useState<string>('')
+    const [customerFilter, setCustomerFilter] = useState<string>('')
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const offset = (pageIndex - 1) * pageSize
+
+    const { data: customersData } = useCustomers({ limit: 100 })
+    const customers = customersData?.items ?? []
+
+    const customerOptions = [
+        { value: '', label: 'Todos' },
+        ...customers.map((c) => ({
+            value: c.id.toString(),
+            label: c.name,
+        })),
+    ]
+
+    const queryParams: SaleQueryParams = {
+        status: statusFilter ? (statusFilter as SaleStatus) : undefined,
+        customerId: customerFilter ? parseInt(customerFilter) : undefined,
+        limit: pageSize,
+        offset,
+    }
+
+    const { data, isLoading } = useSales(queryParams)
+    const sales = data?.items ?? []
+    const total = data?.pagination?.total ?? 0
+
+    const handleReset = () => {
+        setStatusFilter('')
+        setCustomerFilter('')
+        setPageIndex(1)
+    }
+
+    const getCustomerName = (customerId: number) => {
+        const customer = customers.find((c) => c.id === customerId)
+        return customer ? customer.name : `#${customerId}`
+    }
+
+    const formatCurrency = (value: number) => {
+        return new Intl.NumberFormat('es-EC', {
+            style: 'currency',
+            currency: 'USD',
+        }).format(value)
+    }
+
+    const columns: ColumnDef<Sale>[] = [
+        {
+            header: 'ID',
+            accessorKey: 'id',
+            cell: (props) => (
+                <span className="font-medium">#{props.row.original.id}</span>
+            ),
+        },
+        {
+            header: 'Cliente',
+            accessorKey: 'customerId',
+            cell: (props) => getCustomerName(props.row.original.customerId),
+        },
+        {
+            header: 'Estado',
+            accessorKey: 'status',
+            cell: (props) => {
+                const status = props.row.original.status
+                return (
+                    <Badge
+                        content={SALE_STATUS_LABELS[status]}
+                        className={SALE_STATUS_CLASSES[status]}
+                    />
+                )
+            },
+        },
+        {
+            header: 'Pago',
+            accessorKey: 'paymentStatus',
+            cell: (props) => {
+                const ps = props.row.original.paymentStatus
+                return (
+                    <Badge
+                        content={PAYMENT_STATUS_LABELS[ps]}
+                        className={PAYMENT_STATUS_CLASSES[ps]}
+                    />
+                )
+            },
+        },
+        {
+            header: 'Total',
+            accessorKey: 'total',
+            cell: (props) => (
+                <span className="font-medium">
+                    {formatCurrency(props.row.original.total)}
+                </span>
+            ),
+        },
+        {
+            header: 'Fecha de Venta',
+            accessorKey: 'saleDate',
+            cell: (props) => {
+                const date = props.row.original.saleDate
+                return (
+                    <span className="text-sm text-gray-600 dark:text-gray-400">
+                        {date
+                            ? new Date(date).toLocaleDateString('es-EC')
+                            : '-'}
+                    </span>
+                )
+            },
+        },
+        {
+            header: 'Creado por',
+            accessorKey: 'createdBy',
+            cell: (props) => (
+                <span className="text-sm text-gray-600 dark:text-gray-400">
+                    {props.row.original.createdBy ?? '-'}
+                </span>
+            ),
+        },
+        {
+            header: 'Acciones',
+            id: 'actions',
+            cell: (props) => (
+                <Button
+                    size="sm"
+                    variant="plain"
+                    icon={<HiOutlineEye />}
+                    onClick={() => navigate(`/sales/${props.row.original.id}`)}
+                />
+            ),
+        },
+    ]
+
+    return (
+        <>
+            <Card className="mb-4">
+                <div className="p-4">
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Estado
+                            </label>
+                            <Select
+                                placeholder="Filtrar por estado"
+                                options={statusOptions}
+                                value={statusOptions.find(
+                                    (o) => o.value === statusFilter
+                                )}
+                                onChange={(option) => {
+                                    setStatusFilter(option?.value || '')
+                                    setPageIndex(1)
+                                }}
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Cliente
+                            </label>
+                            <Select
+                                placeholder="Filtrar por cliente"
+                                options={customerOptions}
+                                value={customerOptions.find(
+                                    (o) => o.value === customerFilter
+                                )}
+                                onChange={(option) => {
+                                    setCustomerFilter(option?.value || '')
+                                    setPageIndex(1)
+                                }}
+                            />
+                        </div>
+                        <div className="flex items-end">
+                            <Button variant="plain" onClick={handleReset}>
+                                Limpiar Filtros
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            </Card>
+
+            <Card>
+                <div className="p-4">
+                    <div className="mb-4">
+                        <h4 className="text-lg font-semibold">Ventas</h4>
+                        <p className="text-sm text-gray-500 mt-1">
+                            Consulta el historial de ventas
+                        </p>
+                    </div>
+
+                    <DataTable
+                        columns={columns}
+                        data={sales}
+                        loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
+                    />
+                </div>
+            </Card>
+        </>
+    )
+}
+
+export default SalesView


### PR DESCRIPTION
## Descripción

  Adds a read-only sales module with list view (filters by status and customer, pagination)
  and detail view (sale info + items and payments in tabs).

  - SaleService: getSales, getSale, getSaleItems, getSalePayments
  - useSales hooks: useSales, useSale, useSaleItems, useSalePayments
  - SalesView: paginated list with status/customer filters
  - SaleDetailView: sale info card + items/payments tabs with totals
  - Routes: sales.sales → /sales, sales.saleDetail → /sales/:id
  - Navigation: Sales entry added to Sales section

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
