### PR TITLE
feat: add inventory reports module with 4 analytical views

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -27,6 +27,7 @@
 | Transferencias | ✅ | ✅ | ✅ | CRUD + confirm/receive/cancel + items CRUD, ciclo DRAFT→CONFIRMED→RECEIVED/CANCELLED |
 | Ventas | ✅ | ✅ | ✅ | Solo lectura: listado con filtros (customerId, status, paginación) + detalle con items y pagos en tabs |
 | Alertas | ✅ | ✅ | ✅ | Solo lectura: 4 tabs (stock bajo, sin stock, punto reorden, lotes por vencer) con contadores y filtros |
+| Reportes de inventario | ✅ | ✅ | ✅ | Solo lectura: 4 tabs (valorización, rotación, movimientos paginados, resumen por almacén) con filtros |
 
 ### Módulos pendientes
 
@@ -45,7 +46,7 @@
 | ~~11~~ | ~~Órdenes de compra~~ | ~~Alta~~ | ~~Completado en Sesión 8~~ |
 | ~~12~~ | ~~Alertas~~ | ~~Baja~~ | ~~Completado en Sesión 10~~ |
 | ~~13~~ | ~~Ventas (solo lectura)~~ | ~~Media~~ | ~~Completado en Sesión 9~~ |
-| 14 | Reportes de inventario | Media | Bodegas |
+| ~~14~~ | ~~Reportes de inventario~~ | ~~Media~~ | ~~Completado en Sesión 11~~ |
 
 ---
 

--- a/reports-spec.md
+++ b/reports-spec.md
@@ -1,0 +1,514 @@
+# Especificación del Módulo de Reportes de Inventario
+
+## Base URL
+
+```
+GET /api/admin/reports/inventory
+```
+
+Todos los endpoints son **solo lectura** (GET). No modifican estado.
+
+---
+
+## Estructura de Respuestas
+
+Todas las respuestas usan wrappers estándar. Los campos usan **camelCase** en JSON.
+
+### Meta (incluido en toda respuesta)
+
+```json
+{
+  "requestId": "uuid-string",
+  "timestamp": "2026-03-08T15:30:00"
+}
+```
+
+### DataResponse\<T\> — objeto único
+
+```json
+{
+  "data": { ... },
+  "meta": { "requestId": "...", "timestamp": "..." }
+}
+```
+
+### ListResponse\<T\> — lista sin paginación
+
+```json
+{
+  "data": [ { ... }, { ... } ],
+  "meta": { "requestId": "...", "timestamp": "..." }
+}
+```
+
+### PaginatedDataResponse\<T\> — lista con paginación
+
+```json
+{
+  "data": [ { ... }, { ... } ],
+  "meta": {
+    "requestId": "...",
+    "timestamp": "...",
+    "pagination": {
+      "total": 150,
+      "limit": 50,
+      "offset": 0
+    }
+  }
+}
+```
+
+### ErrorResponse (400 / 404 / 422)
+
+```json
+{
+  "errors": [
+    { "code": "VALIDATION_ERROR", "message": "...", "field": "warehouseId" }
+  ],
+  "meta": { "requestId": "...", "timestamp": "..." }
+}
+```
+
+---
+
+## 1. Valorización de Inventario
+
+Calcula el valor monetario del inventario actual o en una fecha histórica.
+
+### Request
+
+```
+GET /valuation
+```
+
+| Query Param   | Tipo     | Requerido | Default | Descripción                                                    |
+| ------------- | -------- | --------- | ------- | -------------------------------------------------------------- |
+| `warehouseId` | `int`    | No        | `null`  | Filtrar por almacén (≥ 1)                                      |
+| `asOfDate`    | `date`   | No        | `null`  | Fecha histórica (formato `YYYY-MM-DD`). Si se omite, usa stock actual |
+
+### Response — `DataResponse<InventoryValuation>`
+
+```json
+{
+  "data": {
+    "totalValue": 45230.50,
+    "asOfDate": "2026-03-08",
+    "items": [
+      {
+        "productId": 1,
+        "productName": "Producto A",
+        "sku": "PROD-001",
+        "quantity": 100,
+        "averageCost": 15.50,
+        "totalValue": 1550.00
+      }
+    ]
+  },
+  "meta": { "requestId": "...", "timestamp": "..." }
+}
+```
+
+### Campos de cada item
+
+| Campo         | Tipo      | Descripción                             |
+| ------------- | --------- | --------------------------------------- |
+| `productId`   | `int`     | ID del producto                         |
+| `productName` | `string`  | Nombre del producto                     |
+| `sku`         | `string`  | Código SKU                              |
+| `quantity`    | `int`     | Cantidad en stock                       |
+| `averageCost` | `number`  | Precio de compra (purchase_price)       |
+| `totalValue`  | `number`  | quantity × averageCost                  |
+
+### Campos del objeto principal
+
+| Campo        | Tipo                    | Descripción                          |
+| ------------ | ----------------------- | ------------------------------------ |
+| `totalValue` | `number`                | Suma total del valor de inventario   |
+| `asOfDate`   | `string` (YYYY-MM-DD)  | Fecha de la valorización             |
+| `items`      | `ValuationItem[]`       | Lista de productos valorizados       |
+
+### Lógica de negocio
+
+- **Sin `asOfDate`**: Usa la tabla de stock actual. Suma cantidades por producto agrupando todas las ubicaciones.
+- **Con `asOfDate`**: Reconstruye el stock histórico sumando movimientos IN y restando movimientos OUT hasta esa fecha.
+- Excluye productos marcados como servicio (`isService = true`).
+- Solo incluye productos con `purchasePrice > 0`.
+- Si se proporciona `warehouseId`, filtra ubicaciones pertenecientes a ese almacén.
+
+---
+
+## 2. Rotación de Productos
+
+Analiza la velocidad de rotación del inventario en un período de tiempo.
+
+### Request
+
+```
+GET /rotation
+```
+
+| Query Param   | Tipo   | Requerido | Default                    | Descripción                      |
+| ------------- | ------ | --------- | -------------------------- | -------------------------------- |
+| `fromDate`    | `date` | No        | 1er día del mes actual     | Inicio del período (YYYY-MM-DD)  |
+| `toDate`      | `date` | No        | Hoy                        | Fin del período (YYYY-MM-DD)     |
+| `warehouseId` | `int`  | No        | `null`                     | Filtrar por almacén (≥ 1)        |
+
+### Response — `ListResponse<ProductRotation>`
+
+```json
+{
+  "data": [
+    {
+      "productId": 1,
+      "productName": "Producto A",
+      "sku": "PROD-001",
+      "totalIn": 200,
+      "totalOut": 150,
+      "currentStock": 100,
+      "turnoverRate": 1.50,
+      "daysOfStock": 20
+    }
+  ],
+  "meta": { "requestId": "...", "timestamp": "..." }
+}
+```
+
+### Campos
+
+| Campo          | Tipo           | Descripción                                                         |
+| -------------- | -------------- | ------------------------------------------------------------------- |
+| `productId`    | `int`          | ID del producto                                                     |
+| `productName`  | `string`       | Nombre del producto                                                 |
+| `sku`          | `string`       | Código SKU                                                          |
+| `totalIn`      | `int`          | Total de movimientos de entrada en el período                       |
+| `totalOut`     | `int`          | Total de movimientos de salida en el período                        |
+| `currentStock` | `int`          | Stock actual del producto                                           |
+| `turnoverRate` | `number`       | Tasa de rotación: `totalOut / currentStock`                         |
+| `daysOfStock`  | `int \| null`  | Días de stock restantes: `currentStock / (totalOut / díasPeríodo)`. `null` si no hay salidas |
+
+### Lógica de negocio
+
+- Agrega movimientos IN y OUT por producto dentro del rango de fechas.
+- `turnoverRate` = `totalOut / currentStock` (solo si ambos > 0, caso contrario 0).
+- `daysOfStock` = `currentStock / promedioDiarioSalidas` donde `promedioDiarioSalidas = totalOut / díasDelPeríodo`. Es `null` si `totalOut = 0`.
+- Excluye servicios.
+
+---
+
+## 3. Historial de Movimientos
+
+Lista paginada de movimientos de inventario con filtros múltiples.
+
+### Request
+
+```
+GET /movements
+```
+
+| Query Param   | Tipo     | Requerido | Default | Validación    | Descripción                          |
+| ------------- | -------- | --------- | ------- | ------------- | ------------------------------------ |
+| `limit`       | `int`    | No        | `50`    | 1–500         | Tamaño de página                     |
+| `offset`      | `int`    | No        | `0`     | ≥ 0           | Desplazamiento para paginación       |
+| `productId`   | `int`    | No        | `null`  | ≥ 1           | Filtrar por producto                 |
+| `type`        | `string` | No        | `null`  | `"in"`, `"out"` | Filtrar por tipo de movimiento     |
+| `fromDate`    | `date`   | No        | `null`  |               | Fecha inicio (YYYY-MM-DD)            |
+| `toDate`      | `date`   | No        | `null`  |               | Fecha fin (YYYY-MM-DD)               |
+| `warehouseId` | `int`    | No        | `null`  | ≥ 1           | Filtrar por almacén                  |
+
+### Response — `PaginatedDataResponse<MovementHistoryItem>`
+
+```json
+{
+  "data": [
+    {
+      "id": 42,
+      "productId": 1,
+      "productName": "Producto A",
+      "sku": "PROD-001",
+      "quantity": 10,
+      "type": "out",
+      "locationId": 3,
+      "sourceLocationId": null,
+      "referenceType": "sale",
+      "referenceId": 15,
+      "reason": null,
+      "date": "2026-03-07T14:30:00",
+      "createdAt": "2026-03-07T14:30:05"
+    }
+  ],
+  "meta": {
+    "requestId": "...",
+    "timestamp": "...",
+    "pagination": {
+      "total": 150,
+      "limit": 50,
+      "offset": 0
+    }
+  }
+}
+```
+
+### Campos
+
+| Campo              | Tipo             | Descripción                                           |
+| ------------------ | ---------------- | ----------------------------------------------------- |
+| `id`               | `int`            | ID del movimiento                                     |
+| `productId`        | `int`            | ID del producto                                       |
+| `productName`      | `string`         | Nombre del producto                                   |
+| `sku`              | `string`         | Código SKU                                            |
+| `quantity`         | `int`            | Cantidad movida                                       |
+| `type`             | `string`         | `"in"` (entrada) o `"out"` (salida)                   |
+| `locationId`       | `int \| null`    | Ubicación destino                                     |
+| `sourceLocationId` | `int \| null`    | Ubicación origen (para transferencias)                |
+| `referenceType`    | `string \| null` | Tipo de referencia: `"sale"`, `"purchase_order"`, `"adjustment"`, `"transfer"` |
+| `referenceId`      | `int \| null`    | ID de la entidad que originó el movimiento            |
+| `reason`           | `string \| null` | Razón (para ajustes)                                  |
+| `date`             | `datetime \| null` | Fecha del movimiento (ISO 8601)                     |
+| `createdAt`        | `datetime \| null` | Fecha de creación del registro (ISO 8601)           |
+
+### Lógica de negocio
+
+- Todos los filtros se combinan con AND.
+- Ordenado por `date` descendente (más reciente primero).
+- `pagination.total` refleja el total de registros que cumplen los filtros (no solo la página actual).
+
+---
+
+## 4. Resumen por Almacén
+
+Vista consolidada del inventario por almacén.
+
+### Request
+
+```
+GET /summary
+```
+
+| Query Param   | Tipo  | Requerido | Default | Descripción                 |
+| ------------- | ----- | --------- | ------- | --------------------------- |
+| `warehouseId` | `int` | No        | `null`  | Filtrar almacén específico (≥ 1) |
+
+### Response — `ListResponse<WarehouseSummary>`
+
+```json
+{
+  "data": [
+    {
+      "warehouseId": 1,
+      "warehouseName": "Almacén Central",
+      "warehouseCode": "WH-001",
+      "totalProducts": 45,
+      "totalQuantity": 5000,
+      "reservedQuantity": 200,
+      "availableQuantity": 4800,
+      "totalValue": 75430.00
+    }
+  ],
+  "meta": { "requestId": "...", "timestamp": "..." }
+}
+```
+
+### Campos
+
+| Campo               | Tipo     | Descripción                                       |
+| ------------------- | -------- | ------------------------------------------------- |
+| `warehouseId`       | `int`    | ID del almacén                                    |
+| `warehouseName`     | `string` | Nombre del almacén                                |
+| `warehouseCode`     | `string` | Código del almacén                                |
+| `totalProducts`     | `int`    | Cantidad de productos distintos con stock          |
+| `totalQuantity`     | `int`    | Suma de todas las cantidades en stock              |
+| `reservedQuantity`  | `int`    | Suma de cantidades reservadas                     |
+| `availableQuantity` | `int`    | `totalQuantity - reservedQuantity`                |
+| `totalValue`        | `number` | Suma de `quantity × purchasePrice` por producto   |
+
+### Lógica de negocio
+
+- Agrega stock de todas las ubicaciones dentro de cada almacén.
+- Solo incluye almacenes activos (`isActive = true`).
+- Excluye servicios.
+- Solo incluye registros de stock con `quantity > 0`.
+- `totalValue` = Σ(quantity × product.purchasePrice).
+
+---
+
+## Notas para Implementación Frontend
+
+### Tipos TypeScript
+
+```typescript
+// --- Wrappers de respuesta ---
+
+interface Meta {
+  requestId: string;
+  timestamp: string;
+}
+
+interface PaginationMeta {
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+interface PaginatedMeta extends Meta {
+  pagination: PaginationMeta;
+}
+
+interface DataResponse<T> {
+  data: T;
+  meta: Meta;
+}
+
+interface ListResponse<T> {
+  data: T[];
+  meta: Meta;
+}
+
+interface PaginatedDataResponse<T> {
+  data: T[];
+  meta: PaginatedMeta;
+}
+
+// --- Valorización ---
+
+interface ValuationItem {
+  productId: number;
+  productName: string;
+  sku: string;
+  quantity: number;
+  averageCost: number;
+  totalValue: number;
+}
+
+interface InventoryValuation {
+  totalValue: number;
+  asOfDate: string; // YYYY-MM-DD
+  items: ValuationItem[];
+}
+
+interface ValuationParams {
+  warehouseId?: number;
+  asOfDate?: string; // YYYY-MM-DD
+}
+
+// --- Rotación ---
+
+interface ProductRotation {
+  productId: number;
+  productName: string;
+  sku: string;
+  totalIn: number;
+  totalOut: number;
+  currentStock: number;
+  turnoverRate: number;
+  daysOfStock: number | null;
+}
+
+interface RotationParams {
+  fromDate?: string;  // YYYY-MM-DD
+  toDate?: string;    // YYYY-MM-DD
+  warehouseId?: number;
+}
+
+// --- Historial de Movimientos ---
+
+interface MovementHistoryItem {
+  id: number;
+  productId: number;
+  productName: string;
+  sku: string;
+  quantity: number;
+  type: "in" | "out";
+  locationId: number | null;
+  sourceLocationId: number | null;
+  referenceType: string | null;
+  referenceId: number | null;
+  reason: string | null;
+  date: string | null;      // ISO 8601
+  createdAt: string | null;  // ISO 8601
+}
+
+interface MovementHistoryParams {
+  limit?: number;       // 1-500, default 50
+  offset?: number;      // >= 0, default 0
+  productId?: number;
+  type?: "in" | "out";
+  fromDate?: string;    // YYYY-MM-DD
+  toDate?: string;      // YYYY-MM-DD
+  warehouseId?: number;
+}
+
+// --- Resumen por Almacén ---
+
+interface WarehouseSummary {
+  warehouseId: number;
+  warehouseName: string;
+  warehouseCode: string;
+  totalProducts: number;
+  totalQuantity: number;
+  reservedQuantity: number;
+  availableQuantity: number;
+  totalValue: number;
+}
+
+interface SummaryParams {
+  warehouseId?: number;
+}
+```
+
+### Ejemplo de Servicios (fetch)
+
+```typescript
+const BASE_URL = "/api/admin/reports/inventory";
+
+async function getValuation(params?: ValuationParams): Promise<DataResponse<InventoryValuation>> {
+  const query = new URLSearchParams();
+  if (params?.warehouseId) query.set("warehouseId", String(params.warehouseId));
+  if (params?.asOfDate) query.set("asOfDate", params.asOfDate);
+  const res = await fetch(`${BASE_URL}/valuation?${query}`);
+  return res.json();
+}
+
+async function getRotation(params?: RotationParams): Promise<ListResponse<ProductRotation>> {
+  const query = new URLSearchParams();
+  if (params?.fromDate) query.set("fromDate", params.fromDate);
+  if (params?.toDate) query.set("toDate", params.toDate);
+  if (params?.warehouseId) query.set("warehouseId", String(params.warehouseId));
+  const res = await fetch(`${BASE_URL}/rotation?${query}`);
+  return res.json();
+}
+
+async function getMovementHistory(params?: MovementHistoryParams): Promise<PaginatedDataResponse<MovementHistoryItem>> {
+  const query = new URLSearchParams();
+  if (params?.limit) query.set("limit", String(params.limit));
+  if (params?.offset) query.set("offset", String(params.offset));
+  if (params?.productId) query.set("productId", String(params.productId));
+  if (params?.type) query.set("type", params.type);
+  if (params?.fromDate) query.set("fromDate", params.fromDate);
+  if (params?.toDate) query.set("toDate", params.toDate);
+  if (params?.warehouseId) query.set("warehouseId", String(params.warehouseId));
+  const res = await fetch(`${BASE_URL}/movements?${query}`);
+  return res.json();
+}
+
+async function getWarehouseSummary(params?: SummaryParams): Promise<ListResponse<WarehouseSummary>> {
+  const query = new URLSearchParams();
+  if (params?.warehouseId) query.set("warehouseId", String(params.warehouseId));
+  const res = await fetch(`${BASE_URL}/summary?${query}`);
+  return res.json();
+}
+```
+
+### Consideraciones de UI
+
+| Reporte       | Componente sugerido         | Filtros principales                  |
+| ------------- | --------------------------- | ------------------------------------ |
+| Valorización  | Tabla + tarjeta de total    | Almacén, fecha histórica             |
+| Rotación      | Tabla con badges de estado  | Rango de fechas, almacén             |
+| Movimientos   | Tabla paginada              | Producto, tipo, fechas, almacén      |
+| Resumen       | Cards por almacén o tabla   | Almacén                              |
+
+- **Decimales**: Los campos `number` (averageCost, totalValue, turnoverRate) se serializan como float JSON. Formatear con 2 decimales para moneda.
+- **Paginación**: Solo el historial de movimientos usa paginación. Los demás retornan listas completas.
+- **Fechas**: Las fechas de query params usan formato `YYYY-MM-DD`. Las fechas en respuestas datetime usan ISO 8601.
+- **Valores posibles de `referenceType`**: `"sale"`, `"purchase_order"`, `"adjustment"`, `"transfer"`.
+- **Valores de `type` en movimientos**: Solo `"in"` o `"out"`.

--- a/src/configs/navigation-icon.config.tsx
+++ b/src/configs/navigation-icon.config.tsx
@@ -17,6 +17,7 @@ import {
     HiOutlineUserGroup,
 } from 'react-icons/hi'
 
+
 export type NavigationIcons = Record<string, JSX.Element>
 
 const navigationIcon: NavigationIcons = {
@@ -35,6 +36,7 @@ const navigationIcon: NavigationIcons = {
     purchasesPurchaseOrders: <HiOutlineDocumentText />,
     inventoryAdjustments: <HiOutlineClipboardCheck />,
     inventoryTransfers: <HiOutlineSwitchVertical />,
+    inventoryReports: <HiOutlineDocumentText />,
     salesSales: <HiOutlineShoppingCart />,
     groupCollapseMenu: <HiOutlineColorSwatch />,
 }

--- a/src/configs/navigation.config/index.ts
+++ b/src/configs/navigation.config/index.ts
@@ -1,8 +1,9 @@
 import {
-    NAV_ITEM_TYPE_TITLE,
-    NAV_ITEM_TYPE_ITEM,
     NAV_ITEM_TYPE_COLLAPSE,
+    NAV_ITEM_TYPE_ITEM,
+    NAV_ITEM_TYPE_TITLE,
 } from '@/constants/navigation.constant'
+
 import type { NavigationTree } from '@/@types/navigation'
 
 const navigationConfig: NavigationTree[] = [
@@ -142,6 +143,16 @@ const navigationConfig: NavigationTree[] = [
                 title: 'Transfers',
                 translateKey: 'nav.inventory.transfers',
                 icon: 'inventoryTransfers',
+                type: NAV_ITEM_TYPE_ITEM,
+                authority: [],
+                subMenu: [],
+            },
+            {
+                key: 'inventory.reports',
+                path: '/reports/inventory',
+                title: 'Reports',
+                translateKey: 'nav.inventory.reports',
+                icon: 'inventoryReports',
                 type: NAV_ITEM_TYPE_ITEM,
                 authority: [],
                 subMenu: [],

--- a/src/configs/routes.config/routes.config.ts
+++ b/src/configs/routes.config/routes.config.ts
@@ -158,6 +158,12 @@ export const protectedRoutes = [
         authority: [],
     },
     {
+        key: 'reports.inventory',
+        path: '/reports/inventory',
+        component: lazy(() => import('@/views/reports/ReportsView')),
+        authority: [],
+    },
+    {
         key: 'groupMenu.collapse.item1',
         path: '/group-collapse-menu-item-view-1',
         component: lazy(

--- a/src/hooks/useReports.ts
+++ b/src/hooks/useReports.ts
@@ -1,0 +1,49 @@
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
+import ReportService, {
+    type ValuationParams,
+    type RotationParams,
+    type MovementHistoryParams,
+    type SummaryParams,
+} from '@/services/ReportService'
+
+export function useValuation(params?: ValuationParams) {
+    return useQuery({
+        queryKey: ['reports', 'valuation', params],
+        queryFn: async () => {
+            const response = await ReportService.getValuation(params)
+            return response.data.data
+        },
+    })
+}
+
+export function useRotation(params?: RotationParams) {
+    return useQuery({
+        queryKey: ['reports', 'rotation', params],
+        queryFn: async () => {
+            const response = await ReportService.getRotation(params)
+            return response.data.data
+        },
+    })
+}
+
+export function useMovementHistory(params?: MovementHistoryParams) {
+    return useQuery({
+        queryKey: ['reports', 'movements', params],
+        queryFn: async () => {
+            const response = await ReportService.getMovementHistory(params)
+            const body = response.data
+            return { items: body.data, pagination: body.meta.pagination }
+        },
+        placeholderData: keepPreviousData,
+    })
+}
+
+export function useWarehouseSummary(params?: SummaryParams) {
+    return useQuery({
+        queryKey: ['reports', 'summary', params],
+        queryFn: async () => {
+            const response = await ReportService.getWarehouseSummary(params)
+            return response.data.data
+        },
+    })
+}

--- a/src/locales/lang/es.json
+++ b/src/locales/lang/es.json
@@ -15,6 +15,9 @@
             "locations": "Ubicaciones",
             "lots": "Lotes",
             "serials": "Números de Serie",
+            "adjustments": "Ajustes",
+            "transfers": "Transferencias",
+            "reports": "Reportes",
             "collapse": {
                 "collapse": "Group collapse menu",
                 "item1": "Group collapse menu item 1",

--- a/src/services/ReportService.ts
+++ b/src/services/ReportService.ts
@@ -1,0 +1,149 @@
+import ApiService from './ApiService'
+import appConfig from '@/configs/app.config'
+import type {
+    DataResponse,
+    PaginatedResponse,
+    PaginationParams,
+} from '@/@types/api'
+
+export interface ValuationItem {
+    productId: number
+    productName: string
+    sku: string
+    quantity: number
+    averageCost: number
+    totalValue: number
+}
+
+export interface InventoryValuation {
+    totalValue: number
+    asOfDate: string
+    items: ValuationItem[]
+}
+
+export interface ValuationParams {
+    warehouseId?: number
+    asOfDate?: string
+}
+
+export interface ProductRotation {
+    productId: number
+    productName: string
+    sku: string
+    totalIn: number
+    totalOut: number
+    currentStock: number
+    turnoverRate: number
+    daysOfStock: number | null
+}
+
+export interface RotationParams {
+    fromDate?: string
+    toDate?: string
+    warehouseId?: number
+}
+
+export interface MovementHistoryItem {
+    id: number
+    productId: number
+    productName: string
+    sku: string
+    quantity: number
+    type: 'in' | 'out'
+    locationId: number | null
+    sourceLocationId: number | null
+    referenceType: string | null
+    referenceId: number | null
+    reason: string | null
+    date: string | null
+    createdAt: string | null
+}
+
+export interface MovementHistoryParams extends PaginationParams {
+    productId?: number
+    type?: 'in' | 'out'
+    fromDate?: string
+    toDate?: string
+    warehouseId?: number
+}
+
+export interface WarehouseSummary {
+    warehouseId: number
+    warehouseName: string
+    warehouseCode: string
+    totalProducts: number
+    totalQuantity: number
+    reservedQuantity: number
+    availableQuantity: number
+    totalValue: number
+}
+
+export interface SummaryParams {
+    warehouseId?: number
+}
+
+class ReportService {
+    private config = {
+        host: appConfig.inventoryApiHost || 'http://localhost:3000/api/admin',
+    }
+
+    private buildUrl(path: string, params: Record<string, string>): string {
+        const queryParams = new URLSearchParams(params)
+        const queryString = queryParams.toString()
+        const base = `${this.config.host}/reports/inventory/${path}`
+        return queryString ? `${base}?${queryString}` : base
+    }
+
+    async getValuation(params?: ValuationParams) {
+        const query: Record<string, string> = {}
+        if (params?.warehouseId !== undefined)
+            query.warehouseId = params.warehouseId.toString()
+        if (params?.asOfDate) query.asOfDate = params.asOfDate
+        return ApiService.fetchData<DataResponse<InventoryValuation>>({
+            url: this.buildUrl('valuation', query),
+            method: 'get',
+        })
+    }
+
+    async getRotation(params?: RotationParams) {
+        const query: Record<string, string> = {}
+        if (params?.fromDate) query.fromDate = params.fromDate
+        if (params?.toDate) query.toDate = params.toDate
+        if (params?.warehouseId !== undefined)
+            query.warehouseId = params.warehouseId.toString()
+        return ApiService.fetchData<DataResponse<ProductRotation[]>>({
+            url: this.buildUrl('rotation', query),
+            method: 'get',
+        })
+    }
+
+    async getMovementHistory(params?: MovementHistoryParams) {
+        const query: Record<string, string> = {}
+        if (params?.limit !== undefined) query.limit = params.limit.toString()
+        if (params?.offset !== undefined)
+            query.offset = params.offset.toString()
+        if (params?.productId !== undefined)
+            query.productId = params.productId.toString()
+        if (params?.type) query.type = params.type
+        if (params?.fromDate) query.fromDate = params.fromDate
+        if (params?.toDate) query.toDate = params.toDate
+        if (params?.warehouseId !== undefined)
+            query.warehouseId = params.warehouseId.toString()
+        return ApiService.fetchData<PaginatedResponse<MovementHistoryItem>>({
+            url: this.buildUrl('movements', query),
+            method: 'get',
+        })
+    }
+
+    async getWarehouseSummary(params?: SummaryParams) {
+        const query: Record<string, string> = {}
+        if (params?.warehouseId !== undefined)
+            query.warehouseId = params.warehouseId.toString()
+        return ApiService.fetchData<DataResponse<WarehouseSummary[]>>({
+            url: this.buildUrl('summary', query),
+            method: 'get',
+        })
+    }
+}
+
+export default new ReportService()

--- a/src/views/reports/ReportsView/index.tsx
+++ b/src/views/reports/ReportsView/index.tsx
@@ -1,0 +1,696 @@
+import { useState } from 'react'
+import Card from '@/components/ui/Card'
+import Badge from '@/components/ui/Badge'
+import Select from '@/components/ui/Select'
+import Tabs from '@/components/ui/Tabs'
+import DataTable, { ColumnDef } from '@/components/shared/DataTable'
+import {
+    useValuation,
+    useRotation,
+    useMovementHistory,
+    useWarehouseSummary,
+} from '@/hooks/useReports'
+import { useWarehouses } from '@/hooks/useWarehouses'
+import { useProducts } from '@/hooks/useProducts'
+import type {
+    ValuationItem,
+    ProductRotation,
+    MovementHistoryItem,
+    WarehouseSummary,
+    MovementHistoryParams,
+} from '@/services/ReportService'
+
+const { TabList, TabNav, TabContent } = Tabs
+
+const formatCurrency = (value: number) =>
+    new Intl.NumberFormat('es-EC', {
+        style: 'currency',
+        currency: 'USD',
+    }).format(value)
+
+const formatDate = (date: string | null) =>
+    date ? new Date(date).toLocaleDateString('es-EC') : '-'
+
+const formatDateTime = (date: string | null) =>
+    date ? new Date(date).toLocaleString('es-EC') : '-'
+
+const movementTypeOptions = [
+    { value: '', label: 'Todos' },
+    { value: 'in', label: 'Entrada' },
+    { value: 'out', label: 'Salida' },
+]
+
+const referenceTypeLabels: Record<string, string> = {
+    sale: 'Venta',
+    purchase_order: 'Orden de Compra',
+    adjustment: 'Ajuste',
+    transfer: 'Transferencia',
+}
+
+const ReportsView = () => {
+    const [activeTab, setActiveTab] = useState('valuation')
+
+    // Valuation filters
+    const [valuationWarehouse, setValuationWarehouse] = useState('')
+    const [valuationDate, setValuationDate] = useState('')
+
+    // Rotation filters
+    const [rotationWarehouse, setRotationWarehouse] = useState('')
+    const [rotationFromDate, setRotationFromDate] = useState('')
+    const [rotationToDate, setRotationToDate] = useState('')
+
+    // Movements filters + pagination
+    const [movWarehouse, setMovWarehouse] = useState('')
+    const [movProduct, setMovProduct] = useState('')
+    const [movType, setMovType] = useState('')
+    const [movFromDate, setMovFromDate] = useState('')
+    const [movToDate, setMovToDate] = useState('')
+    const [movPageIndex, setMovPageIndex] = useState(1)
+    const [movPageSize, setMovPageSize] = useState(50)
+
+    // Summary filter
+    const [summaryWarehouse, setSummaryWarehouse] = useState('')
+
+    const { data: warehousesData } = useWarehouses({ limit: 100 })
+    const warehouses = warehousesData?.items ?? []
+    const warehouseOptions = [
+        { value: '', label: 'Todos los almacenes' },
+        ...warehouses.map((w) => ({
+            value: w.id.toString(),
+            label: `${w.name} (${w.code})`,
+        })),
+    ]
+
+    const { data: productsData } = useProducts({ limit: 200 })
+    const products = productsData?.items ?? []
+    const productOptions = [
+        { value: '', label: 'Todos los productos' },
+        ...products.map((p) => ({
+            value: p.id.toString(),
+            label: `${p.name} (${p.sku})`,
+        })),
+    ]
+
+    // Hooks
+    const { data: valuation, isLoading: loadingValuation } = useValuation({
+        warehouseId: valuationWarehouse
+            ? parseInt(valuationWarehouse)
+            : undefined,
+        asOfDate: valuationDate || undefined,
+    })
+
+    const { data: rotation = [], isLoading: loadingRotation } = useRotation({
+        warehouseId: rotationWarehouse
+            ? parseInt(rotationWarehouse)
+            : undefined,
+        fromDate: rotationFromDate || undefined,
+        toDate: rotationToDate || undefined,
+    })
+
+    const movOffset = (movPageIndex - 1) * movPageSize
+    const movParams: MovementHistoryParams = {
+        limit: movPageSize,
+        offset: movOffset,
+        warehouseId: movWarehouse ? parseInt(movWarehouse) : undefined,
+        productId: movProduct ? parseInt(movProduct) : undefined,
+        type: movType ? (movType as 'in' | 'out') : undefined,
+        fromDate: movFromDate || undefined,
+        toDate: movToDate || undefined,
+    }
+    const { data: movData, isLoading: loadingMovements } =
+        useMovementHistory(movParams)
+    const movements = movData?.items ?? []
+    const movTotal = movData?.pagination?.total ?? 0
+
+    const { data: summary = [], isLoading: loadingSummary } =
+        useWarehouseSummary({
+            warehouseId: summaryWarehouse
+                ? parseInt(summaryWarehouse)
+                : undefined,
+        })
+
+    // Column definitions
+    const valuationColumns: ColumnDef<ValuationItem>[] = [
+        {
+            header: 'Producto',
+            accessorKey: 'productName',
+            cell: (props) => (
+                <span className="font-medium">
+                    {props.row.original.productName}
+                </span>
+            ),
+        },
+        {
+            header: 'SKU',
+            accessorKey: 'sku',
+            cell: (props) => (
+                <span className="text-sm font-mono text-gray-600 dark:text-gray-400">
+                    {props.row.original.sku}
+                </span>
+            ),
+        },
+        {
+            header: 'Cantidad',
+            accessorKey: 'quantity',
+            cell: (props) => (
+                <span className="font-medium">
+                    {props.row.original.quantity}
+                </span>
+            ),
+        },
+        {
+            header: 'Costo Promedio',
+            accessorKey: 'averageCost',
+            cell: (props) => formatCurrency(props.row.original.averageCost),
+        },
+        {
+            header: 'Valor Total',
+            accessorKey: 'totalValue',
+            cell: (props) => (
+                <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+                    {formatCurrency(props.row.original.totalValue)}
+                </span>
+            ),
+        },
+    ]
+
+    const rotationColumns: ColumnDef<ProductRotation>[] = [
+        {
+            header: 'Producto',
+            accessorKey: 'productName',
+            cell: (props) => (
+                <span className="font-medium">
+                    {props.row.original.productName}
+                </span>
+            ),
+        },
+        {
+            header: 'SKU',
+            accessorKey: 'sku',
+            cell: (props) => (
+                <span className="text-sm font-mono text-gray-600 dark:text-gray-400">
+                    {props.row.original.sku}
+                </span>
+            ),
+        },
+        {
+            header: 'Entradas',
+            accessorKey: 'totalIn',
+            cell: (props) => (
+                <span className="text-emerald-600 dark:text-emerald-400 font-medium">
+                    +{props.row.original.totalIn}
+                </span>
+            ),
+        },
+        {
+            header: 'Salidas',
+            accessorKey: 'totalOut',
+            cell: (props) => (
+                <span className="text-red-600 dark:text-red-400 font-medium">
+                    -{props.row.original.totalOut}
+                </span>
+            ),
+        },
+        {
+            header: 'Stock Actual',
+            accessorKey: 'currentStock',
+            cell: (props) => (
+                <span className="font-medium">
+                    {props.row.original.currentStock}
+                </span>
+            ),
+        },
+        {
+            header: 'Tasa de Rotación',
+            accessorKey: 'turnoverRate',
+            cell: (props) => {
+                const rate = props.row.original.turnoverRate
+                const isHigh = rate >= 2
+                const isMed = rate >= 1
+                return (
+                    <Badge
+                        content={rate.toFixed(2)}
+                        className={
+                            isHigh
+                                ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300'
+                                : isMed
+                                ? 'bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300'
+                                : 'bg-gray-100 text-gray-700 dark:bg-gray-500/20 dark:text-gray-300'
+                        }
+                    />
+                )
+            },
+        },
+        {
+            header: 'Días de Stock',
+            accessorKey: 'daysOfStock',
+            cell: (props) => {
+                const d = props.row.original.daysOfStock
+                if (d === null) return <span className="text-gray-400">-</span>
+                const isLow = d <= 7
+                return (
+                    <span
+                        className={
+                            isLow
+                                ? 'text-red-600 dark:text-red-400 font-medium'
+                                : 'text-gray-700 dark:text-gray-300'
+                        }
+                    >
+                        {d} días
+                    </span>
+                )
+            },
+        },
+    ]
+
+    const movementColumns: ColumnDef<MovementHistoryItem>[] = [
+        {
+            header: 'Producto',
+            accessorKey: 'productName',
+            cell: (props) => (
+                <span className="font-medium">
+                    {props.row.original.productName}
+                </span>
+            ),
+        },
+        {
+            header: 'SKU',
+            accessorKey: 'sku',
+            cell: (props) => (
+                <span className="text-sm font-mono text-gray-600 dark:text-gray-400">
+                    {props.row.original.sku}
+                </span>
+            ),
+        },
+        {
+            header: 'Tipo',
+            accessorKey: 'type',
+            cell: (props) => {
+                const type = props.row.original.type
+                return (
+                    <Badge
+                        content={type === 'in' ? 'Entrada' : 'Salida'}
+                        className={
+                            type === 'in'
+                                ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300'
+                                : 'bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-300'
+                        }
+                    />
+                )
+            },
+        },
+        {
+            header: 'Cantidad',
+            accessorKey: 'quantity',
+            cell: (props) => {
+                const { type, quantity } = props.row.original
+                return (
+                    <span
+                        className={
+                            type === 'in'
+                                ? 'text-emerald-600 dark:text-emerald-400 font-medium'
+                                : 'text-red-600 dark:text-red-400 font-medium'
+                        }
+                    >
+                        {type === 'in' ? '+' : '-'}
+                        {quantity}
+                    </span>
+                )
+            },
+        },
+        {
+            header: 'Referencia',
+            accessorKey: 'referenceType',
+            cell: (props) => {
+                const { referenceType, referenceId } = props.row.original
+                if (!referenceType)
+                    return <span className="text-gray-400">-</span>
+                return (
+                    <span className="text-sm">
+                        {referenceTypeLabels[referenceType] ?? referenceType}
+                        {referenceId ? ` #${referenceId}` : ''}
+                    </span>
+                )
+            },
+        },
+        {
+            header: 'Razón',
+            accessorKey: 'reason',
+            cell: (props) => (
+                <span className="text-sm text-gray-600 dark:text-gray-400">
+                    {props.row.original.reason ?? '-'}
+                </span>
+            ),
+        },
+        {
+            header: 'Fecha',
+            accessorKey: 'date',
+            cell: (props) => (
+                <span className="text-sm text-gray-600 dark:text-gray-400">
+                    {formatDateTime(props.row.original.date)}
+                </span>
+            ),
+        },
+    ]
+
+    const summaryColumns: ColumnDef<WarehouseSummary>[] = [
+        {
+            header: 'Almacén',
+            accessorKey: 'warehouseName',
+            cell: (props) => (
+                <span className="font-medium">
+                    {props.row.original.warehouseName}
+                </span>
+            ),
+        },
+        {
+            header: 'Código',
+            accessorKey: 'warehouseCode',
+            cell: (props) => (
+                <span className="text-sm font-mono text-gray-600 dark:text-gray-400">
+                    {props.row.original.warehouseCode}
+                </span>
+            ),
+        },
+        {
+            header: 'Productos',
+            accessorKey: 'totalProducts',
+            cell: (props) => (
+                <span className="font-medium">
+                    {props.row.original.totalProducts}
+                </span>
+            ),
+        },
+        {
+            header: 'Cantidad Total',
+            accessorKey: 'totalQuantity',
+            cell: (props) => (
+                <span className="font-medium">
+                    {props.row.original.totalQuantity}
+                </span>
+            ),
+        },
+        {
+            header: 'Reservado',
+            accessorKey: 'reservedQuantity',
+            cell: (props) => (
+                <span className="text-amber-600 dark:text-amber-400">
+                    {props.row.original.reservedQuantity}
+                </span>
+            ),
+        },
+        {
+            header: 'Disponible',
+            accessorKey: 'availableQuantity',
+            cell: (props) => (
+                <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+                    {props.row.original.availableQuantity}
+                </span>
+            ),
+        },
+        {
+            header: 'Valor Total',
+            accessorKey: 'totalValue',
+            cell: (props) => (
+                <span className="font-semibold">
+                    {formatCurrency(props.row.original.totalValue)}
+                </span>
+            ),
+        },
+    ]
+
+    return (
+        <div className="flex flex-col gap-4">
+            <Card>
+                <Tabs value={activeTab} onChange={setActiveTab}>
+                    <TabList>
+                        <TabNav value="valuation">Valorización</TabNav>
+                        <TabNav value="rotation">Rotación</TabNav>
+                        <TabNav value="movements">Movimientos</TabNav>
+                        <TabNav value="summary">Resumen por Almacén</TabNav>
+                    </TabList>
+
+                    <div className="mt-4">
+                        {/* Valuation Tab */}
+                        <TabContent value="valuation">
+                            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+                                <div>
+                                    <label className="block text-sm font-medium mb-2">
+                                        Almacén
+                                    </label>
+                                    <Select
+                                        placeholder="Todos los almacenes"
+                                        options={warehouseOptions}
+                                        value={warehouseOptions.find(
+                                            (o) =>
+                                                o.value === valuationWarehouse
+                                        )}
+                                        onChange={(option) =>
+                                            setValuationWarehouse(
+                                                option?.value || ''
+                                            )
+                                        }
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-2">
+                                        Fecha histórica
+                                    </label>
+                                    <input
+                                        type="date"
+                                        className="w-full border rounded-lg px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+                                        value={valuationDate}
+                                        onChange={(e) =>
+                                            setValuationDate(e.target.value)
+                                        }
+                                    />
+                                </div>
+                            </div>
+
+                            {valuation && (
+                                <div className="flex items-center justify-between mb-4 p-4 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-200 dark:border-emerald-500/20 rounded-lg">
+                                    <div>
+                                        <p className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
+                                            Valor Total del Inventario
+                                        </p>
+                                        <p className="text-sm text-emerald-600 dark:text-emerald-400 mt-0.5">
+                                            Al {formatDate(valuation.asOfDate)}
+                                        </p>
+                                    </div>
+                                    <p className="text-3xl font-bold text-emerald-600 dark:text-emerald-400">
+                                        {formatCurrency(valuation.totalValue)}
+                                    </p>
+                                </div>
+                            )}
+
+                            <DataTable
+                                columns={valuationColumns}
+                                data={valuation?.items ?? []}
+                                loading={loadingValuation}
+                                pagingData={{
+                                    total: valuation?.items?.length ?? 0,
+                                    pageIndex: 1,
+                                    pageSize: valuation?.items?.length || 10,
+                                }}
+                            />
+                        </TabContent>
+
+                        {/* Rotation Tab */}
+                        <TabContent value="rotation">
+                            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+                                <div>
+                                    <label className="block text-sm font-medium mb-2">
+                                        Almacén
+                                    </label>
+                                    <Select
+                                        placeholder="Todos los almacenes"
+                                        options={warehouseOptions}
+                                        value={warehouseOptions.find(
+                                            (o) => o.value === rotationWarehouse
+                                        )}
+                                        onChange={(option) =>
+                                            setRotationWarehouse(
+                                                option?.value || ''
+                                            )
+                                        }
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-2">
+                                        Desde
+                                    </label>
+                                    <input
+                                        type="date"
+                                        className="w-full border rounded-lg px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+                                        value={rotationFromDate}
+                                        onChange={(e) =>
+                                            setRotationFromDate(e.target.value)
+                                        }
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-2">
+                                        Hasta
+                                    </label>
+                                    <input
+                                        type="date"
+                                        className="w-full border rounded-lg px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+                                        value={rotationToDate}
+                                        onChange={(e) =>
+                                            setRotationToDate(e.target.value)
+                                        }
+                                    />
+                                </div>
+                            </div>
+
+                            <DataTable
+                                columns={rotationColumns}
+                                data={rotation}
+                                loading={loadingRotation}
+                                pagingData={{
+                                    total: rotation.length,
+                                    pageIndex: 1,
+                                    pageSize: rotation.length || 10,
+                                }}
+                            />
+                        </TabContent>
+
+                        {/* Movements Tab */}
+                        <TabContent value="movements">
+                            <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
+                                <div>
+                                    <label className="block text-sm font-medium mb-2">
+                                        Almacén
+                                    </label>
+                                    <Select
+                                        placeholder="Todos"
+                                        options={warehouseOptions}
+                                        value={warehouseOptions.find(
+                                            (o) => o.value === movWarehouse
+                                        )}
+                                        onChange={(option) => {
+                                            setMovWarehouse(option?.value || '')
+                                            setMovPageIndex(1)
+                                        }}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-2">
+                                        Producto
+                                    </label>
+                                    <Select
+                                        placeholder="Todos"
+                                        options={productOptions}
+                                        value={productOptions.find(
+                                            (o) => o.value === movProduct
+                                        )}
+                                        onChange={(option) => {
+                                            setMovProduct(option?.value || '')
+                                            setMovPageIndex(1)
+                                        }}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-2">
+                                        Tipo
+                                    </label>
+                                    <Select
+                                        placeholder="Todos"
+                                        options={movementTypeOptions}
+                                        value={movementTypeOptions.find(
+                                            (o) => o.value === movType
+                                        )}
+                                        onChange={(option) => {
+                                            setMovType(option?.value || '')
+                                            setMovPageIndex(1)
+                                        }}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-2">
+                                        Desde
+                                    </label>
+                                    <input
+                                        type="date"
+                                        className="w-full border rounded-lg px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+                                        value={movFromDate}
+                                        onChange={(e) => {
+                                            setMovFromDate(e.target.value)
+                                            setMovPageIndex(1)
+                                        }}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-2">
+                                        Hasta
+                                    </label>
+                                    <input
+                                        type="date"
+                                        className="w-full border rounded-lg px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+                                        value={movToDate}
+                                        onChange={(e) => {
+                                            setMovToDate(e.target.value)
+                                            setMovPageIndex(1)
+                                        }}
+                                    />
+                                </div>
+                            </div>
+
+                            <DataTable
+                                columns={movementColumns}
+                                data={movements}
+                                loading={loadingMovements}
+                                pagingData={{
+                                    total: movTotal,
+                                    pageIndex: movPageIndex,
+                                    pageSize: movPageSize,
+                                }}
+                                onPaginationChange={setMovPageIndex}
+                                onSelectChange={(size) => {
+                                    setMovPageSize(size)
+                                    setMovPageIndex(1)
+                                }}
+                            />
+                        </TabContent>
+
+                        {/* Summary Tab */}
+                        <TabContent value="summary">
+                            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+                                <div>
+                                    <label className="block text-sm font-medium mb-2">
+                                        Almacén
+                                    </label>
+                                    <Select
+                                        placeholder="Todos los almacenes"
+                                        options={warehouseOptions}
+                                        value={warehouseOptions.find(
+                                            (o) => o.value === summaryWarehouse
+                                        )}
+                                        onChange={(option) =>
+                                            setSummaryWarehouse(
+                                                option?.value || ''
+                                            )
+                                        }
+                                    />
+                                </div>
+                            </div>
+
+                            <DataTable
+                                columns={summaryColumns}
+                                data={summary}
+                                loading={loadingSummary}
+                                pagingData={{
+                                    total: summary.length,
+                                    pageIndex: 1,
+                                    pageSize: summary.length || 10,
+                                }}
+                            />
+                        </TabContent>
+                    </div>
+                </Tabs>
+            </Card>
+        </div>
+    )
+}
+
+export default ReportsView


### PR DESCRIPTION
## Descripción

  - Add ReportService with valuation, rotation, movement history and warehouse summary endpoints
  - Add useReports hooks (useValuation, useRotation, useMovementHistory with pagination, useWarehouseSummary)
  - Add ReportsView with tab-based UI: valuation (total card + filters), rotation (turnover badges), movements (paginated with multi-filter), warehouse summary
  - Register route reports.inventory → /reports/inventory
  - Add Reports item to navigation under Inventory section

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
