### PR TITLE
feat: add invoicing settings module with company config and certificates

### DIFF
--- a/api-1.json
+++ b/api-1.json
@@ -1,0 +1,1318 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "faclab-invoicing",
+    "version": "1.0.0",
+    "description": "Faclab Invoicing API"
+  },
+  "components": {
+    "schemas": {}
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificates": {
+      "post": {
+        "summary": "Upload a .p12 digital signature certificate",
+        "tags": [
+          "Certificates"
+        ],
+        "description": "Accepts a PKCS#12 (.p12) file and its password. The service parses the certificate metadata, stores the file in S3, and persists the metadata in DynamoDB. The returned `id` should be saved as the `signingCertId` field in the company configuration (PUT /api/company-config) so the service uses this certificate to sign invoices.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file",
+                  "password"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "PKCS#12 (.p12) certificate file issued by a trusted CA (e.g. BCE, Security Data, ANF)."
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "Password that protects the .p12 file. Required to extract the private key."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Certificate uploaded and parsed successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Unique certificate identifier. Set this value as the `signingCertId` in the company configuration (PUT /api/company-config)."
+                        },
+                        "serialNumber": {
+                          "type": "string",
+                          "description": "Serial number extracted from the X.509 certificate inside the .p12 file."
+                        },
+                        "subject": {
+                          "type": "string",
+                          "description": "Distinguished Name (DN) of the certificate subject in RFC 4514 format.",
+                          "example": "CN=JUAN PEREZ, O=BCE, C=EC"
+                        },
+                        "issuer": {
+                          "type": "string",
+                          "description": "Distinguished Name (DN) of the Certificate Authority that issued this certificate.",
+                          "example": "CN=BCE ENTIDAD CERTIFICADORA, O=BCE, C=EC"
+                        },
+                        "validFrom": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Certificate validity start date (ISO 8601)."
+                        },
+                        "validTo": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Certificate expiry date (ISO 8601). Invoices cannot be signed after this date."
+                        },
+                        "fileName": {
+                          "type": "string",
+                          "description": "Original filename of the uploaded .p12 file.",
+                          "example": "firma_electronica.p12"
+                        },
+                        "s3Url": {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "S3 URL where the certificate file is stored."
+                        },
+                        "uploadedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp when the certificate was uploaded (ISO 8601)."
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "description": "Certificate uploaded and parsed successfully."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing file, wrong file extension, or invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "errors",
+                    "meta"
+                  ],
+                  "description": "Missing file, wrong file extension, or invalid request."
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "File could not be parsed — wrong password or corrupted .p12.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "errors",
+                    "meta"
+                  ],
+                  "description": "File could not be parsed — wrong password or corrupted .p12."
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "List all certificates",
+        "tags": [
+          "Certificates"
+        ],
+        "description": "Returns all certificates stored in the system.",
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique certificate identifier. Set this value as the `signingCertId` in the company configuration (PUT /api/company-config)."
+                          },
+                          "serialNumber": {
+                            "type": "string",
+                            "description": "Serial number extracted from the X.509 certificate inside the .p12 file."
+                          },
+                          "subject": {
+                            "type": "string",
+                            "description": "Distinguished Name (DN) of the certificate subject in RFC 4514 format.",
+                            "example": "CN=JUAN PEREZ, O=BCE, C=EC"
+                          },
+                          "issuer": {
+                            "type": "string",
+                            "description": "Distinguished Name (DN) of the Certificate Authority that issued this certificate.",
+                            "example": "CN=BCE ENTIDAD CERTIFICADORA, O=BCE, C=EC"
+                          },
+                          "validFrom": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Certificate validity start date (ISO 8601)."
+                          },
+                          "validTo": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Certificate expiry date (ISO 8601). Invoices cannot be signed after this date."
+                          },
+                          "fileName": {
+                            "type": "string",
+                            "description": "Original filename of the uploaded .p12 file.",
+                            "example": "firma_electronica.p12"
+                          },
+                          "s3Url": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "S3 URL where the certificate file is stored."
+                          },
+                          "uploadedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Timestamp when the certificate was uploaded (ISO 8601)."
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificates/{id}": {
+      "get": {
+        "summary": "Get a certificate by ID",
+        "tags": [
+          "Certificates"
+        ],
+        "description": "Returns the metadata for a single certificate.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "description": "Certificate UUID."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Unique certificate identifier. Set this value as the `signingCertId` in the company configuration (PUT /api/company-config)."
+                        },
+                        "serialNumber": {
+                          "type": "string",
+                          "description": "Serial number extracted from the X.509 certificate inside the .p12 file."
+                        },
+                        "subject": {
+                          "type": "string",
+                          "description": "Distinguished Name (DN) of the certificate subject in RFC 4514 format.",
+                          "example": "CN=JUAN PEREZ, O=BCE, C=EC"
+                        },
+                        "issuer": {
+                          "type": "string",
+                          "description": "Distinguished Name (DN) of the Certificate Authority that issued this certificate.",
+                          "example": "CN=BCE ENTIDAD CERTIFICADORA, O=BCE, C=EC"
+                        },
+                        "validFrom": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Certificate validity start date (ISO 8601)."
+                        },
+                        "validTo": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Certificate expiry date (ISO 8601). Invoices cannot be signed after this date."
+                        },
+                        "fileName": {
+                          "type": "string",
+                          "description": "Original filename of the uploaded .p12 file.",
+                          "example": "firma_electronica.p12"
+                        },
+                        "s3Url": {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "S3 URL where the certificate file is stored."
+                        },
+                        "uploadedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp when the certificate was uploaded (ISO 8601)."
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No certificate found with the given ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "errors",
+                    "meta"
+                  ],
+                  "description": "No certificate found with the given ID."
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a certificate",
+        "tags": [
+          "Certificates"
+        ],
+        "description": "Deletes the certificate from both DynamoDB and S3. If this certificate is currently set as the `signingCertId` in company configuration, invoice signing will fail until a new certificate is configured.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "description": "Certificate UUID."
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Certificate deleted successfully."
+          },
+          "404": {
+            "description": "No certificate found with the given ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "errors",
+                    "meta"
+                  ],
+                  "description": "No certificate found with the given ID."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/company-config": {
+      "put": {
+        "summary": "Create or update the company fiscal configuration",
+        "tags": [
+          "Company Config"
+        ],
+        "description": "Upserts the singleton company configuration used when generating invoices. This must be configured before the service can process any `sales.confirmed` Kafka events. The `invoiceSequence` field is optional — if omitted, the current counter is preserved.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "taxId",
+                  "name",
+                  "tradeName",
+                  "mainAddress",
+                  "branchAddress",
+                  "branchCode",
+                  "salePointCode",
+                  "environment",
+                  "emissionType"
+                ],
+                "properties": {
+                  "taxId": {
+                    "type": "string",
+                    "minLength": 13,
+                    "maxLength": 13,
+                    "description": "Company RUC — exactly 13 digits."
+                  },
+                  "name": {
+                    "type": "string",
+                    "maxLength": 64,
+                    "description": "Legal company name (max 64 chars)."
+                  },
+                  "tradeName": {
+                    "type": "string",
+                    "maxLength": 64,
+                    "description": "Trade name (max 64 chars)."
+                  },
+                  "mainAddress": {
+                    "type": "string",
+                    "description": "Main establishment address."
+                  },
+                  "branchAddress": {
+                    "type": "string",
+                    "description": "Branch address printed on invoices."
+                  },
+                  "branchCode": {
+                    "type": "string",
+                    "maxLength": 4,
+                    "description": "Branch code (max 4 chars)."
+                  },
+                  "salePointCode": {
+                    "type": "string",
+                    "maxLength": 4,
+                    "description": "Point-of-sale code (max 4 chars)."
+                  },
+                  "specialTaxpayerResolution": {
+                    "type": "string",
+                    "maxLength": 32,
+                    "description": "SRI special taxpayer resolution number (optional)."
+                  },
+                  "withholdingAgentResolution": {
+                    "type": "string",
+                    "maxLength": 32,
+                    "description": "SRI withholding agent resolution number (optional)."
+                  },
+                  "accountingRequired": {
+                    "type": "boolean",
+                    "description": "Whether the company is obligated to keep accounting records."
+                  },
+                  "environment": {
+                    "type": "number",
+                    "enum": [
+                      1,
+                      2
+                    ],
+                    "description": "`1` = Testing, `2` = Production."
+                  },
+                  "emissionType": {
+                    "type": "number",
+                    "enum": [
+                      1
+                    ],
+                    "description": "`1` = Normal. Only supported value."
+                  },
+                  "invoiceSequence": {
+                    "type": "number",
+                    "minimum": 1,
+                    "description": "Seed value for the invoice sequence counter. Optional — preserves the existing counter if omitted."
+                  },
+                  "signingCertId": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "UUID of the signing certificate. Use the `id` returned by POST /api/certificates/upload."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Configuration saved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "taxId": {
+                          "type": "string",
+                          "description": "Company RUC (13-digit Ecuadorian tax ID).",
+                          "example": "1792141001001"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Legal company name as registered with the SRI.",
+                          "example": "ACME SOLUTIONS S.A."
+                        },
+                        "tradeName": {
+                          "type": "string",
+                          "description": "Commercial or trade name shown on invoices.",
+                          "example": "ACME"
+                        },
+                        "mainAddress": {
+                          "type": "string",
+                          "description": "Main establishment address registered with the SRI."
+                        },
+                        "branchAddress": {
+                          "type": "string",
+                          "description": "Branch address printed on invoices."
+                        },
+                        "branchCode": {
+                          "type": "string",
+                          "description": "Branch code used in invoice numbering (001–999).",
+                          "example": "001"
+                        },
+                        "salePointCode": {
+                          "type": "string",
+                          "description": "Point-of-sale code used in invoice numbering (001–999).",
+                          "example": "001"
+                        },
+                        "specialTaxpayerResolution": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "description": "SRI resolution number if the company is a special taxpayer. Null otherwise."
+                        },
+                        "withholdingAgentResolution": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "description": "SRI resolution number if the company is a withholding agent. Null otherwise."
+                        },
+                        "accountingRequired": {
+                          "type": "boolean",
+                          "description": "Whether the company is required to keep accounting records (obligado a llevar contabilidad)."
+                        },
+                        "environment": {
+                          "type": "number",
+                          "enum": [
+                            1,
+                            2
+                          ],
+                          "description": "SRI environment. `1` = Testing (pruebas), `2` = Production (producción).",
+                          "example": 1
+                        },
+                        "emissionType": {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ],
+                          "description": "Emission type. `1` = Normal (currently the only supported value).",
+                          "example": 1
+                        },
+                        "invoiceSequence": {
+                          "type": "number",
+                          "description": "Current sequential invoice counter. Auto-incremented on each invoice creation. Can be seeded on first setup.",
+                          "example": 42
+                        },
+                        "signingCertId": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "uuid",
+                          "description": "UUID of the PKCS#12 certificate used to sign invoices. Set this to the `id` returned by the certificate upload endpoint. Null if no certificate has been configured."
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp of the last configuration update (ISO 8601)."
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "description": "Configuration saved successfully."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error or missing required fields.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "errors",
+                    "meta"
+                  ],
+                  "description": "Validation error or missing required fields."
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "Get the company fiscal configuration",
+        "tags": [
+          "Company Config"
+        ],
+        "description": "Returns the current singleton company configuration.",
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "taxId": {
+                          "type": "string",
+                          "description": "Company RUC (13-digit Ecuadorian tax ID).",
+                          "example": "1792141001001"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Legal company name as registered with the SRI.",
+                          "example": "ACME SOLUTIONS S.A."
+                        },
+                        "tradeName": {
+                          "type": "string",
+                          "description": "Commercial or trade name shown on invoices.",
+                          "example": "ACME"
+                        },
+                        "mainAddress": {
+                          "type": "string",
+                          "description": "Main establishment address registered with the SRI."
+                        },
+                        "branchAddress": {
+                          "type": "string",
+                          "description": "Branch address printed on invoices."
+                        },
+                        "branchCode": {
+                          "type": "string",
+                          "description": "Branch code used in invoice numbering (001–999).",
+                          "example": "001"
+                        },
+                        "salePointCode": {
+                          "type": "string",
+                          "description": "Point-of-sale code used in invoice numbering (001–999).",
+                          "example": "001"
+                        },
+                        "specialTaxpayerResolution": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "description": "SRI resolution number if the company is a special taxpayer. Null otherwise."
+                        },
+                        "withholdingAgentResolution": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "description": "SRI resolution number if the company is a withholding agent. Null otherwise."
+                        },
+                        "accountingRequired": {
+                          "type": "boolean",
+                          "description": "Whether the company is required to keep accounting records (obligado a llevar contabilidad)."
+                        },
+                        "environment": {
+                          "type": "number",
+                          "enum": [
+                            1,
+                            2
+                          ],
+                          "description": "SRI environment. `1` = Testing (pruebas), `2` = Production (producción).",
+                          "example": 1
+                        },
+                        "emissionType": {
+                          "type": "number",
+                          "enum": [
+                            1
+                          ],
+                          "description": "Emission type. `1` = Normal (currently the only supported value).",
+                          "example": 1
+                        },
+                        "invoiceSequence": {
+                          "type": "number",
+                          "description": "Current sequential invoice counter. Auto-incremented on each invoice creation. Can be seeded on first setup.",
+                          "example": 42
+                        },
+                        "signingCertId": {
+                          "type": [
+                            "null",
+                            "string"
+                          ],
+                          "format": "uuid",
+                          "description": "UUID of the PKCS#12 certificate used to sign invoices. Set this to the `id` returned by the certificate upload endpoint. Null if no certificate has been configured."
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp of the last configuration update (ISO 8601)."
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No company configuration has been saved yet.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "errors",
+                    "meta"
+                  ],
+                  "description": "No company configuration has been saved yet."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/invoices": {
+      "get": {
+        "summary": "List all invoices",
+        "tags": [
+          "Invoices"
+        ],
+        "description": "Returns a summary list of all invoices stored in the system, ordered by creation time. The XML body is omitted from list responses for performance.",
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique invoice identifier."
+                          },
+                          "orderId": {
+                            "type": "string",
+                            "description": "Identifier of the originating sale order."
+                          },
+                          "accessCode": {
+                            "type": "string",
+                            "description": "49-digit SRI access code that uniquely identifies the voucher. Includes emission date, voucher type, RUC, environment, sequence, and a mod-11 check digit.",
+                            "example": "2412202401179214100100120010010000000011234567811"
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Current lifecycle status of the invoice.",
+                            "enum": [
+                              "CREATED",
+                              "SIGNED",
+                              "SENT",
+                              "AUTHORIZED",
+                              "REJECTED"
+                            ],
+                            "example": "AUTHORIZED"
+                          },
+                          "signatureId": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "ID of the digital certificate used to sign the invoice XML."
+                          },
+                          "statusHistory": {
+                            "type": "array",
+                            "description": "Ordered list of all status transitions the invoice has gone through.",
+                            "items": {
+                              "type": "object",
+                              "description": "A single status transition recorded on the invoice audit trail.",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Status name at the time of the transition.",
+                                  "example": "SIGNED"
+                                },
+                                "statusDate": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "description": "ISO 8601 timestamp when the transition occurred."
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "description": "Optional message from SRI or internal notes attached to the transition."
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/invoices/{id}": {
+      "get": {
+        "summary": "Get an invoice by ID",
+        "tags": [
+          "Invoices"
+        ],
+        "description": "Returns full invoice detail including the signed XML and complete status history.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "description": "Invoice UUID."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Unique invoice identifier."
+                        },
+                        "orderId": {
+                          "type": "string",
+                          "description": "Identifier of the originating sale order."
+                        },
+                        "accessCode": {
+                          "type": "string",
+                          "description": "49-digit SRI access code that uniquely identifies the voucher. Includes emission date, voucher type, RUC, environment, sequence, and a mod-11 check digit.",
+                          "example": "2412202401179214100100120010010000000011234567811"
+                        },
+                        "status": {
+                          "type": "string",
+                          "description": "Current lifecycle status of the invoice.",
+                          "enum": [
+                            "CREATED",
+                            "SIGNED",
+                            "SENT",
+                            "AUTHORIZED",
+                            "REJECTED"
+                          ],
+                          "example": "AUTHORIZED"
+                        },
+                        "signatureId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "ID of the digital certificate used to sign the invoice XML."
+                        },
+                        "statusHistory": {
+                          "type": "array",
+                          "description": "Ordered list of all status transitions the invoice has gone through.",
+                          "items": {
+                            "type": "object",
+                            "description": "A single status transition recorded on the invoice audit trail.",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Status name at the time of the transition.",
+                                "example": "SIGNED"
+                              },
+                              "statusDate": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "ISO 8601 timestamp when the transition occurred."
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "Optional message from SRI or internal notes attached to the transition."
+                              }
+                            }
+                          }
+                        },
+                        "xml": {
+                          "type": "string",
+                          "description": "Full signed invoice XML in SRI format. Present only in the detail endpoint."
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No invoice found with the given ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message"
+                        ]
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "timestamp"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "errors",
+                    "meta"
+                  ],
+                  "description": "No invoice found with the given ID."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/configs/app.config.ts
+++ b/src/configs/app.config.ts
@@ -7,6 +7,7 @@ export type AppConfig = {
     enableMock: boolean
     inventoryApiHost?: string
     posApiHost?: string
+    invoicingApiHost?: string
 }
 
 const appConfig: AppConfig = {
@@ -18,6 +19,7 @@ const appConfig: AppConfig = {
     enableMock: false,
     inventoryApiHost: 'http://localhost:3000/api/admin',
     posApiHost: 'http://localhost:3000/api/pos',
+    invoicingApiHost: 'http://localhost:3173',
 }
 
 export default appConfig

--- a/src/configs/navigation-icon.config.tsx
+++ b/src/configs/navigation-icon.config.tsx
@@ -7,6 +7,7 @@ import {
     HiOutlineDocumentText,
     HiOutlineFolder,
     HiOutlineLocationMarker,
+    HiOutlineLockClosed,
     HiOutlineOfficeBuilding,
     HiOutlineQrcode,
     HiOutlineScale,
@@ -38,6 +39,8 @@ const navigationIcon: NavigationIcons = {
     inventoryReports: <HiOutlineDocumentText />,
     salesSales: <HiOutlineShoppingCart />,
     inventoryAlerts: <HiOutlineBell />,
+    settingsCompanyConfig: <HiOutlineOfficeBuilding />,
+    settingsCertificates: <HiOutlineLockClosed />,
 }
 
 export default navigationIcon

--- a/src/configs/navigation.config/index.ts
+++ b/src/configs/navigation.config/index.ts
@@ -230,6 +230,37 @@ const navigationConfig: NavigationTree[] = [
             },
         ],
     },
+    {
+        key: 'settings',
+        path: '',
+        title: 'Settings',
+        translateKey: 'nav.settings.title',
+        icon: '',
+        type: NAV_ITEM_TYPE_TITLE,
+        authority: [],
+        subMenu: [
+            {
+                key: 'settings.companyConfig',
+                path: '/settings/company-config',
+                title: 'Company Configuration',
+                translateKey: 'nav.settings.companyConfig',
+                icon: 'settingsCompanyConfig',
+                type: NAV_ITEM_TYPE_ITEM,
+                authority: [],
+                subMenu: [],
+            },
+            {
+                key: 'settings.certificates',
+                path: '/settings/certificates',
+                title: 'Digital Certificates',
+                translateKey: 'nav.settings.certificates',
+                icon: 'settingsCertificates',
+                type: NAV_ITEM_TYPE_ITEM,
+                authority: [],
+                subMenu: [],
+            },
+        ],
+    },
 ]
 
 export default navigationConfig

--- a/src/configs/routes.config/routes.config.ts
+++ b/src/configs/routes.config/routes.config.ts
@@ -163,4 +163,16 @@ export const protectedRoutes = [
         component: lazy(() => import('@/views/pos/POSView')),
         authority: [],
     },
+    {
+        key: 'settings.companyConfig',
+        path: '/settings/company-config',
+        component: lazy(() => import('@/views/settings/CompanyConfigView')),
+        authority: [],
+    },
+    {
+        key: 'settings.certificates',
+        path: '/settings/certificates',
+        component: lazy(() => import('@/views/settings/CertificatesView')),
+        authority: [],
+    },
 ]

--- a/src/hooks/useInvoicing.ts
+++ b/src/hooks/useInvoicing.ts
@@ -1,0 +1,80 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import InvoicingService, {
+    CompanyConfigInput,
+} from '@/services/InvoicingService'
+
+export function useCertificates() {
+    return useQuery({
+        queryKey: ['invoicing', 'certificates'],
+        queryFn: async () => {
+            const response = await InvoicingService.getCertificates()
+            return response.data.data
+        },
+    })
+}
+
+export function useUploadCertificate() {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: async ({
+            file,
+            password,
+        }: {
+            file: File
+            password: string
+        }) => {
+            const response = await InvoicingService.uploadCertificate(
+                file,
+                password
+            )
+            return response.data.data
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: ['invoicing', 'certificates'],
+            })
+        },
+    })
+}
+
+export function useDeleteCertificate() {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: (id: string) => InvoicingService.deleteCertificate(id),
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: ['invoicing', 'certificates'],
+            })
+        },
+    })
+}
+
+export function useCompanyConfig() {
+    return useQuery({
+        queryKey: ['invoicing', 'company-config'],
+        queryFn: async () => {
+            const response = await InvoicingService.getCompanyConfig()
+            return response.data.data
+        },
+        retry: (failureCount, error: unknown) => {
+            const axiosError = error as { response?: { status?: number } }
+            if (axiosError?.response?.status === 404) return false
+            return failureCount < 2
+        },
+    })
+}
+
+export function useUpdateCompanyConfig() {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: async (data: CompanyConfigInput) => {
+            const response = await InvoicingService.updateCompanyConfig(data)
+            return response.data.data
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: ['invoicing', 'company-config'],
+            })
+        },
+    })
+}

--- a/src/locales/lang/es.json
+++ b/src/locales/lang/es.json
@@ -30,7 +30,13 @@
         },
         "purchases": {
             "title": "Compras",
-            "suppliers": "Proveedores"
+            "suppliers": "Proveedores",
+            "purchaseOrders": "Órdenes de Compra"
+        },
+        "settings": {
+            "title": "Configuración",
+            "companyConfig": "Configuración Fiscal",
+            "certificates": "Certificados Digitales"
         }
     }
 }

--- a/src/services/InvoicingService.ts
+++ b/src/services/InvoicingService.ts
@@ -1,0 +1,106 @@
+import ApiService from './ApiService'
+import appConfig from '@/configs/app.config'
+import type { DataResponse } from '@/@types/api'
+
+export interface Certificate {
+    id: string
+    serialNumber: string
+    subject: string
+    issuer: string
+    validFrom: string
+    validTo: string
+    fileName: string
+    s3Url: string
+    uploadedAt: string
+}
+
+export interface CompanyConfig {
+    taxId: string
+    name: string
+    tradeName: string
+    mainAddress: string
+    branchAddress: string
+    branchCode: string
+    salePointCode: string
+    specialTaxpayerResolution: string | null
+    withholdingAgentResolution: string | null
+    accountingRequired: boolean
+    environment: 1 | 2
+    emissionType: 1
+    invoiceSequence: number
+    signingCertId: string | null
+    updatedAt: string
+}
+
+export interface CompanyConfigInput {
+    taxId: string
+    name: string
+    tradeName: string
+    mainAddress: string
+    branchAddress: string
+    branchCode: string
+    salePointCode: string
+    specialTaxpayerResolution?: string
+    withholdingAgentResolution?: string
+    accountingRequired?: boolean
+    environment: 1 | 2
+    emissionType: 1
+    invoiceSequence?: number
+    signingCertId?: string
+}
+
+interface CertificatesResponse {
+    data: Certificate[]
+    meta: { requestId: string; timestamp: string }
+}
+
+class InvoicingService {
+    private host: string
+
+    constructor() {
+        this.host = appConfig.invoicingApiHost || 'http://localhost:3173'
+    }
+
+    async getCertificates() {
+        return ApiService.fetchData<CertificatesResponse>({
+            url: `${this.host}/api/certificates`,
+            method: 'get',
+        })
+    }
+
+    async uploadCertificate(file: File, password: string) {
+        const formData = new FormData()
+        formData.append('file', file)
+        formData.append('password', password)
+        return ApiService.fetchData<DataResponse<Certificate>, unknown>({
+            url: `${this.host}/api/certificates`,
+            method: 'post',
+            data: formData,
+            headers: { 'Content-Type': 'multipart/form-data' },
+        })
+    }
+
+    async deleteCertificate(id: string) {
+        return ApiService.fetchData({
+            url: `${this.host}/api/certificates/${id}`,
+            method: 'delete',
+        })
+    }
+
+    async getCompanyConfig() {
+        return ApiService.fetchData<DataResponse<CompanyConfig>>({
+            url: `${this.host}/api/company-config`,
+            method: 'get',
+        })
+    }
+
+    async updateCompanyConfig(data: CompanyConfigInput) {
+        return ApiService.fetchData<DataResponse<CompanyConfig>, unknown>({
+            url: `${this.host}/api/company-config`,
+            method: 'put',
+            data,
+        })
+    }
+}
+
+export default new InvoicingService()

--- a/src/views/settings/CertificatesView/index.tsx
+++ b/src/views/settings/CertificatesView/index.tsx
@@ -1,0 +1,321 @@
+import { useState, useRef } from 'react'
+import DataTable, { ColumnDef } from '@/components/shared/DataTable'
+import Card from '@/components/ui/Card'
+import Button from '@/components/ui/Button'
+import Dialog from '@/components/ui/Dialog'
+import Input from '@/components/ui/Input'
+import Notification from '@/components/ui/Notification'
+import toast from '@/components/ui/toast'
+import {
+    useCertificates,
+    useUploadCertificate,
+    useDeleteCertificate,
+} from '@/hooks/useInvoicing'
+import { getErrorMessage } from '@/utils/getErrorMessage'
+import type { Certificate } from '@/services/InvoicingService'
+import { HiOutlineTrash, HiOutlineUpload } from 'react-icons/hi'
+
+const CertificatesView = () => {
+    const [uploadDialog, setUploadDialog] = useState(false)
+    const [deleteDialog, setDeleteDialog] = useState<{
+        open: boolean
+        cert: Certificate | null
+    }>({ open: false, cert: null })
+    const [password, setPassword] = useState('')
+    const [selectedFile, setSelectedFile] = useState<File | null>(null)
+    const fileInputRef = useRef<HTMLInputElement>(null)
+
+    const { data: certificates = [], isLoading } = useCertificates()
+    const uploadCertificate = useUploadCertificate()
+    const deleteCertificate = useDeleteCertificate()
+
+    const handleUploadOpen = () => {
+        setSelectedFile(null)
+        setPassword('')
+        setUploadDialog(true)
+    }
+
+    const handleUploadClose = () => {
+        if (uploadCertificate.isPending) return
+        setUploadDialog(false)
+        setSelectedFile(null)
+        setPassword('')
+        if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+
+    const handleUploadSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        if (!selectedFile) return
+
+        try {
+            await uploadCertificate.mutateAsync({
+                file: selectedFile,
+                password,
+            })
+            toast.push(
+                <Notification title="Certificado subido" type="success">
+                    El certificado se subió correctamente
+                </Notification>,
+                { placement: 'top-center' }
+            )
+            handleUploadClose()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al subir el certificado')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
+    }
+
+    const handleDeleteConfirm = async () => {
+        if (!deleteDialog.cert) return
+        try {
+            await deleteCertificate.mutateAsync(deleteDialog.cert.id)
+            toast.push(
+                <Notification title="Certificado eliminado" type="success">
+                    El certificado se eliminó correctamente
+                </Notification>,
+                { placement: 'top-center' }
+            )
+            setDeleteDialog({ open: false, cert: null })
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al eliminar el certificado')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
+    }
+
+    const formatDate = (iso: string) =>
+        new Date(iso).toLocaleDateString('es-EC', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+        })
+
+    const isExpired = (validTo: string) => new Date(validTo) < new Date()
+
+    const columns: ColumnDef<Certificate>[] = [
+        {
+            header: 'Archivo',
+            accessorKey: 'fileName',
+            cell: (props) => (
+                <span className="font-medium">
+                    {props.row.original.fileName}
+                </span>
+            ),
+        },
+        {
+            header: 'Sujeto',
+            accessorKey: 'subject',
+            cell: (props) => (
+                <span className="text-sm">{props.row.original.subject}</span>
+            ),
+        },
+        {
+            header: 'Emisor',
+            accessorKey: 'issuer',
+            cell: (props) => (
+                <span className="text-sm text-gray-500">
+                    {props.row.original.issuer}
+                </span>
+            ),
+        },
+        {
+            header: 'Válido desde',
+            accessorKey: 'validFrom',
+            cell: (props) => (
+                <span className="text-sm">
+                    {formatDate(props.row.original.validFrom)}
+                </span>
+            ),
+        },
+        {
+            header: 'Válido hasta',
+            accessorKey: 'validTo',
+            cell: (props) => {
+                const expired = isExpired(props.row.original.validTo)
+                return (
+                    <span
+                        className={`inline-flex items-center gap-1 text-sm font-medium ${
+                            expired ? 'text-red-500' : 'text-green-600'
+                        }`}
+                    >
+                        <span
+                            className={`w-2 h-2 rounded-full ${
+                                expired ? 'bg-red-500' : 'bg-green-500'
+                            }`}
+                        />
+                        {formatDate(props.row.original.validTo)}
+                    </span>
+                )
+            },
+        },
+        {
+            header: 'Acciones',
+            id: 'actions',
+            cell: (props) => (
+                <Button
+                    size="sm"
+                    variant="plain"
+                    icon={<HiOutlineTrash />}
+                    onClick={() =>
+                        setDeleteDialog({
+                            open: true,
+                            cert: props.row.original,
+                        })
+                    }
+                />
+            ),
+        },
+    ]
+
+    return (
+        <>
+            <Card>
+                <div className="p-4">
+                    <div className="flex justify-between items-center mb-4">
+                        <div>
+                            <h4 className="text-lg font-semibold">
+                                Certificados Digitales
+                            </h4>
+                            <p className="text-sm text-gray-500 mt-1">
+                                Gestiona los certificados .p12 para firma de
+                                facturas electrónicas
+                            </p>
+                        </div>
+                        <Button
+                            variant="solid"
+                            size="sm"
+                            icon={<HiOutlineUpload />}
+                            onClick={handleUploadOpen}
+                        >
+                            Subir Certificado
+                        </Button>
+                    </div>
+
+                    <DataTable
+                        columns={columns}
+                        data={certificates}
+                        loading={isLoading}
+                        pagingData={{
+                            total: certificates.length,
+                            pageIndex: 1,
+                            pageSize: certificates.length || 10,
+                        }}
+                    />
+                </div>
+            </Card>
+
+            {/* Upload Dialog */}
+            <Dialog
+                isOpen={uploadDialog}
+                shouldCloseOnEsc={!uploadCertificate.isPending}
+                shouldCloseOnOverlayClick={!uploadCertificate.isPending}
+                onClose={handleUploadClose}
+                onRequestClose={handleUploadClose}
+            >
+                <div className="flex flex-col h-full justify-between">
+                    <h5 className="mb-4">Subir Certificado Digital</h5>
+                    <form className="flex-1" onSubmit={handleUploadSubmit}>
+                        <div className="space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium mb-2">
+                                    Archivo .p12{' '}
+                                    <span className="text-red-500">*</span>
+                                </label>
+                                <input
+                                    ref={fileInputRef}
+                                    required
+                                    type="file"
+                                    accept=".p12"
+                                    disabled={uploadCertificate.isPending}
+                                    className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"
+                                    onChange={(e) =>
+                                        setSelectedFile(
+                                            e.target.files?.[0] ?? null
+                                        )
+                                    }
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium mb-2">
+                                    Contraseña{' '}
+                                    <span className="text-red-500">*</span>
+                                </label>
+                                <Input
+                                    required
+                                    type="password"
+                                    placeholder="Contraseña del certificado"
+                                    value={password}
+                                    disabled={uploadCertificate.isPending}
+                                    onChange={(e) =>
+                                        setPassword(e.target.value)
+                                    }
+                                />
+                            </div>
+                        </div>
+                        <div className="flex justify-end gap-2 mt-6">
+                            <Button
+                                type="button"
+                                variant="plain"
+                                disabled={uploadCertificate.isPending}
+                                onClick={handleUploadClose}
+                            >
+                                Cancelar
+                            </Button>
+                            <Button
+                                type="submit"
+                                variant="solid"
+                                loading={uploadCertificate.isPending}
+                                disabled={!selectedFile || !password}
+                            >
+                                Subir
+                            </Button>
+                        </div>
+                    </form>
+                </div>
+            </Dialog>
+
+            {/* Delete Confirmation Dialog */}
+            <Dialog
+                isOpen={deleteDialog.open}
+                onClose={() => setDeleteDialog({ open: false, cert: null })}
+                onRequestClose={() =>
+                    setDeleteDialog({ open: false, cert: null })
+                }
+            >
+                <h5 className="mb-4">Confirmar Eliminación</h5>
+                <p className="mb-6">
+                    ¿Estás seguro de que deseas eliminar el certificado{' '}
+                    <strong>{deleteDialog.cert?.fileName}</strong>? Esta acción
+                    no se puede deshacer.
+                </p>
+                <div className="flex justify-end gap-2">
+                    <Button
+                        variant="plain"
+                        disabled={deleteCertificate.isPending}
+                        onClick={() =>
+                            setDeleteDialog({ open: false, cert: null })
+                        }
+                    >
+                        Cancelar
+                    </Button>
+                    <Button
+                        variant="solid"
+                        loading={deleteCertificate.isPending}
+                        onClick={handleDeleteConfirm}
+                    >
+                        Eliminar
+                    </Button>
+                </div>
+            </Dialog>
+        </>
+    )
+}
+
+export default CertificatesView

--- a/src/views/settings/CompanyConfigView/index.tsx
+++ b/src/views/settings/CompanyConfigView/index.tsx
@@ -1,0 +1,386 @@
+import { useState, useEffect } from 'react'
+import Card from '@/components/ui/Card'
+import Button from '@/components/ui/Button'
+import Input from '@/components/ui/Input'
+import Notification from '@/components/ui/Notification'
+import toast from '@/components/ui/toast'
+import {
+    useCompanyConfig,
+    useUpdateCompanyConfig,
+    useCertificates,
+} from '@/hooks/useInvoicing'
+import { getErrorMessage } from '@/utils/getErrorMessage'
+import type { CompanyConfigInput } from '@/services/InvoicingService'
+
+const emptyForm: CompanyConfigInput = {
+    taxId: '',
+    name: '',
+    tradeName: '',
+    mainAddress: '',
+    branchAddress: '',
+    branchCode: '',
+    salePointCode: '',
+    specialTaxpayerResolution: '',
+    withholdingAgentResolution: '',
+    accountingRequired: false,
+    environment: 1,
+    emissionType: 1,
+    invoiceSequence: undefined,
+    signingCertId: '',
+}
+
+const CompanyConfigView = () => {
+    const [formData, setFormData] = useState<CompanyConfigInput>(emptyForm)
+
+    const { data: config, isLoading } = useCompanyConfig()
+    const { data: certificates = [] } = useCertificates()
+    const updateConfig = useUpdateCompanyConfig()
+
+    useEffect(() => {
+        if (config) {
+            setFormData({
+                taxId: config.taxId,
+                name: config.name,
+                tradeName: config.tradeName,
+                mainAddress: config.mainAddress,
+                branchAddress: config.branchAddress,
+                branchCode: config.branchCode,
+                salePointCode: config.salePointCode,
+                specialTaxpayerResolution:
+                    config.specialTaxpayerResolution ?? '',
+                withholdingAgentResolution:
+                    config.withholdingAgentResolution ?? '',
+                accountingRequired: config.accountingRequired,
+                environment: config.environment,
+                emissionType: config.emissionType,
+                invoiceSequence: config.invoiceSequence,
+                signingCertId: config.signingCertId ?? '',
+            })
+        }
+    }, [config])
+
+    const set =
+        (field: keyof CompanyConfigInput) =>
+        (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+            const value =
+                e.target.type === 'checkbox'
+                    ? (e.target as HTMLInputElement).checked
+                    : e.target.value
+            setFormData((prev) => ({ ...prev, [field]: value }))
+        }
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        try {
+            const payload: CompanyConfigInput = {
+                ...formData,
+                environment: Number(formData.environment) as 1 | 2,
+                emissionType: 1,
+                invoiceSequence: formData.invoiceSequence
+                    ? Number(formData.invoiceSequence)
+                    : undefined,
+                specialTaxpayerResolution:
+                    formData.specialTaxpayerResolution || undefined,
+                withholdingAgentResolution:
+                    formData.withholdingAgentResolution || undefined,
+                signingCertId: formData.signingCertId || undefined,
+            }
+            await updateConfig.mutateAsync(payload)
+            toast.push(
+                <Notification title="Configuración guardada" type="success">
+                    La configuración fiscal se guardó correctamente
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(
+                        error,
+                        'Error al guardar la configuración'
+                    )}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
+    }
+
+    if (isLoading) {
+        return (
+            <Card>
+                <div className="p-4 text-center text-gray-500">
+                    Cargando configuración...
+                </div>
+            </Card>
+        )
+    }
+
+    return (
+        <Card>
+            <div className="p-4">
+                <div className="mb-6">
+                    <h4 className="text-lg font-semibold">
+                        Configuración Fiscal
+                    </h4>
+                    <p className="text-sm text-gray-500 mt-1">
+                        Datos fiscales de la empresa para la generación de
+                        facturas electrónicas
+                    </p>
+                </div>
+
+                <form onSubmit={handleSubmit}>
+                    <div className="space-y-6">
+                        {/* Datos de la empresa */}
+                        <section>
+                            <h5 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 uppercase tracking-wide">
+                                Datos de la Empresa
+                            </h5>
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        RUC{' '}
+                                        <span className="text-red-500">*</span>
+                                    </label>
+                                    <Input
+                                        required
+                                        placeholder="1792141001001"
+                                        maxLength={13}
+                                        value={formData.taxId}
+                                        disabled={updateConfig.isPending}
+                                        onChange={set('taxId')}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        Razón Social{' '}
+                                        <span className="text-red-500">*</span>
+                                    </label>
+                                    <Input
+                                        required
+                                        placeholder="ACME SOLUTIONS S.A."
+                                        value={formData.name}
+                                        disabled={updateConfig.isPending}
+                                        onChange={set('name')}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        Nombre Comercial{' '}
+                                        <span className="text-red-500">*</span>
+                                    </label>
+                                    <Input
+                                        required
+                                        placeholder="ACME"
+                                        value={formData.tradeName}
+                                        disabled={updateConfig.isPending}
+                                        onChange={set('tradeName')}
+                                    />
+                                </div>
+                            </div>
+                        </section>
+
+                        {/* Dirección */}
+                        <section>
+                            <h5 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 uppercase tracking-wide">
+                                Dirección
+                            </h5>
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        Dirección Matriz{' '}
+                                        <span className="text-red-500">*</span>
+                                    </label>
+                                    <Input
+                                        required
+                                        placeholder="Av. Principal 123, Quito"
+                                        value={formData.mainAddress}
+                                        disabled={updateConfig.isPending}
+                                        onChange={set('mainAddress')}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        Dirección Sucursal{' '}
+                                        <span className="text-red-500">*</span>
+                                    </label>
+                                    <Input
+                                        required
+                                        placeholder="Av. Secundaria 456, Quito"
+                                        value={formData.branchAddress}
+                                        disabled={updateConfig.isPending}
+                                        onChange={set('branchAddress')}
+                                    />
+                                </div>
+                            </div>
+                        </section>
+
+                        {/* Configuración SRI */}
+                        <section>
+                            <h5 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 uppercase tracking-wide">
+                                Configuración SRI
+                            </h5>
+                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        Código Establecimiento{' '}
+                                        <span className="text-red-500">*</span>
+                                    </label>
+                                    <Input
+                                        required
+                                        placeholder="001"
+                                        maxLength={4}
+                                        value={formData.branchCode}
+                                        disabled={updateConfig.isPending}
+                                        onChange={set('branchCode')}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        Punto de Emisión{' '}
+                                        <span className="text-red-500">*</span>
+                                    </label>
+                                    <Input
+                                        required
+                                        placeholder="001"
+                                        maxLength={4}
+                                        value={formData.salePointCode}
+                                        disabled={updateConfig.isPending}
+                                        onChange={set('salePointCode')}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        Ambiente{' '}
+                                        <span className="text-red-500">*</span>
+                                    </label>
+                                    <select
+                                        required
+                                        className="w-full h-10 px-3 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                        value={formData.environment}
+                                        disabled={updateConfig.isPending}
+                                        onChange={set('environment')}
+                                    >
+                                        <option value={1}>
+                                            1 - Pruebas (Testing)
+                                        </option>
+                                        <option value={2}>
+                                            2 - Producción
+                                        </option>
+                                    </select>
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        Secuencia de Factura
+                                    </label>
+                                    <Input
+                                        type="number"
+                                        placeholder="1"
+                                        value={formData.invoiceSequence ?? ''}
+                                        disabled={updateConfig.isPending}
+                                        onChange={set('invoiceSequence')}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        Resolución Contrib. Especial
+                                    </label>
+                                    <Input
+                                        placeholder="Opcional"
+                                        value={
+                                            formData.specialTaxpayerResolution
+                                        }
+                                        disabled={updateConfig.isPending}
+                                        onChange={set(
+                                            'specialTaxpayerResolution'
+                                        )}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">
+                                        Resolución Agente Retención
+                                    </label>
+                                    <Input
+                                        placeholder="Opcional"
+                                        value={
+                                            formData.withholdingAgentResolution
+                                        }
+                                        disabled={updateConfig.isPending}
+                                        onChange={set(
+                                            'withholdingAgentResolution'
+                                        )}
+                                    />
+                                </div>
+                                <div className="flex items-center gap-2 pt-6">
+                                    <input
+                                        id="accountingRequired"
+                                        type="checkbox"
+                                        className="w-4 h-4 rounded text-indigo-600"
+                                        checked={formData.accountingRequired}
+                                        disabled={updateConfig.isPending}
+                                        onChange={set('accountingRequired')}
+                                    />
+                                    <label
+                                        htmlFor="accountingRequired"
+                                        className="text-sm font-medium cursor-pointer"
+                                    >
+                                        Obligado a llevar contabilidad
+                                    </label>
+                                </div>
+                            </div>
+                        </section>
+
+                        {/* Certificado de firma */}
+                        <section>
+                            <h5 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 uppercase tracking-wide">
+                                Certificado de Firma
+                            </h5>
+                            <div className="max-w-md">
+                                <label className="block text-sm font-medium mb-1">
+                                    Certificado Digital (.p12)
+                                </label>
+                                <select
+                                    className="w-full h-10 px-3 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                    value={formData.signingCertId ?? ''}
+                                    disabled={updateConfig.isPending}
+                                    onChange={set('signingCertId')}
+                                >
+                                    <option value="">
+                                        — Sin certificado —
+                                    </option>
+                                    {certificates.map((cert) => (
+                                        <option key={cert.id} value={cert.id}>
+                                            {cert.fileName} (
+                                            {new Date(
+                                                cert.validTo
+                                            ).toLocaleDateString('es-EC')}
+                                            )
+                                        </option>
+                                    ))}
+                                </select>
+                                {certificates.length === 0 && (
+                                    <p className="text-xs text-gray-400 mt-1">
+                                        No hay certificados disponibles. Sube
+                                        uno en la sección de Certificados
+                                        Digitales.
+                                    </p>
+                                )}
+                            </div>
+                        </section>
+                    </div>
+
+                    <div className="flex justify-end mt-8">
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            loading={updateConfig.isPending}
+                        >
+                            Guardar Configuración
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </Card>
+    )
+}
+
+export default CompanyConfigView


### PR DESCRIPTION
 ## Descripción

 - Add InvoicingService connecting to faclab-invoicing (localhost:3173)
  - Add React Query hooks for certificates and company config CRUD
  - Add CompanyConfigView with fiscal data form (RUC, addresses, SRI config)
  - Add CertificatesView with .p12 upload, expiry badge, and delete
  - Register settings routes and navigation section

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
