### PR TITLE
feat: require customer selection before completing POS sale

### DIFF
--- a/src/components/ui/Switcher/Switcher.tsx
+++ b/src/components/ui/Switcher/Switcher.tsx
@@ -87,7 +87,7 @@ const Switcher = forwardRef<HTMLInputElement, SwitcherProps>((props, ref) => {
             setSwitcherChecked(nextChecked)
             onChange?.(nextChecked, e)
         } else {
-            onChange?.(switcherChecked as boolean, e)
+            onChange?.(nextChecked, e)
         }
     }
 

--- a/src/locales/lang/es.json
+++ b/src/locales/lang/es.json
@@ -17,16 +17,13 @@
             "serials": "Números de Serie",
             "adjustments": "Ajustes",
             "transfers": "Transferencias",
-            "reports": "Reportes",
-            "collapse": {
-                "collapse": "Group collapse menu",
-                "item1": "Group collapse menu item 1",
-                "item2": "Group collapse menu item 2"
-            }
+            "alerts": "Alertas",
+            "reports": "Reportes"
         },
         "sales": {
             "title": "Ventas",
-            "customers": "Clientes"
+            "customers": "Clientes",
+            "sales": "Ventas"
         },
         "purchases": {
             "title": "Compras",

--- a/src/stores/usePOSStore.ts
+++ b/src/stores/usePOSStore.ts
@@ -46,7 +46,7 @@ export const usePOSStore = create<POSState>()((set) => ({
     cartItems: [],
     customerId: null,
     customerName: null,
-    isFinalConsumer: true,
+    isFinalConsumer: false,
 
     discountType: null,
     discountValue: 0,
@@ -119,7 +119,7 @@ export const usePOSStore = create<POSState>()((set) => ({
         set({
             customerId: id,
             customerName: name,
-            isFinalConsumer: id === null,
+            isFinalConsumer: false,
         }),
 
     setFinalConsumer: (value) => set({ isFinalConsumer: value }),
@@ -134,7 +134,7 @@ export const usePOSStore = create<POSState>()((set) => ({
             cartItems: [],
             customerId: null,
             customerName: null,
-            isFinalConsumer: true,
+            isFinalConsumer: false,
             discountType: null,
             discountValue: 0,
         }),

--- a/src/views/pos/components/ActionButtons.tsx
+++ b/src/views/pos/components/ActionButtons.tsx
@@ -1,5 +1,5 @@
 import Button from '@/components/ui/Button'
-import { usePOSStore } from '@/stores/usePOSStore'
+import { usePOSStore, getCartTotal } from '@/stores/usePOSStore'
 
 interface ActionButtonsProps {
     onPayment: () => void
@@ -14,8 +14,19 @@ const ActionButtons = ({
     onHold,
     onViewOrders,
 }: ActionButtonsProps) => {
-    const { cartItems } = usePOSStore()
+    const {
+        cartItems,
+        customerId,
+        isFinalConsumer,
+        discountType,
+        discountValue,
+    } = usePOSStore()
     const cartEmpty = cartItems.length === 0
+    const total = getCartTotal(cartItems, discountType, discountValue)
+    const requiresCustomer = total > 50
+    const canPay =
+        !cartEmpty &&
+        (customerId !== null || (isFinalConsumer && !requiresCustomer))
 
     return (
         <div className="p-4 border-t border-gray-200 dark:border-gray-700 grid grid-cols-2 gap-2">
@@ -38,7 +49,7 @@ const ActionButtons = ({
             <Button
                 block
                 variant="solid"
-                disabled={cartEmpty}
+                disabled={!canPay}
                 onClick={onPayment}
             >
                 Cobrar

--- a/src/views/pos/components/CustomerSelector.tsx
+++ b/src/views/pos/components/CustomerSelector.tsx
@@ -3,13 +3,27 @@ import Button from '@/components/ui/Button'
 import Dialog from '@/components/ui/Dialog'
 import Input from '@/components/ui/Input'
 import Notification from '@/components/ui/Notification'
+import Switcher from '@/components/ui/Switcher'
 import toast from '@/components/ui/toast'
-import { usePOSStore } from '@/stores/usePOSStore'
+import { usePOSStore, getCartTotal } from '@/stores/usePOSStore'
 import { usePOSCustomerSearch, useQuickCreateCustomer } from '@/hooks/usePOS'
 import { HiOutlineUser } from 'react-icons/hi'
 
+const FINAL_CONSUMER_MAX = 50
+
 const CustomerSelector = () => {
-    const { customerId, customerName, setCustomer } = usePOSStore()
+    const {
+        customerId,
+        customerName,
+        isFinalConsumer,
+        setCustomer,
+        setFinalConsumer,
+        cartItems,
+        discountType,
+        discountValue,
+    } = usePOSStore()
+    const total = getCartTotal(cartItems, discountType, discountValue)
+    const finalConsumerBlocked = total > FINAL_CONSUMER_MAX
     const [dialogOpen, setDialogOpen] = useState(false)
     const [taxId, setTaxId] = useState('')
     const [showCreateForm, setShowCreateForm] = useState(false)
@@ -21,14 +35,19 @@ const CustomerSelector = () => {
         usePOSCustomerSearch(taxId)
     const quickCreate = useQuickCreateCustomer()
 
+    const handleToggleFinalConsumer = (checked: boolean) => {
+        if (checked) {
+            setCustomer(null, null)
+            setFinalConsumer(true)
+        } else {
+            setFinalConsumer(false)
+        }
+    }
+
     const handleSelectCustomer = (id: number, name: string) => {
         setCustomer(id, name)
         setDialogOpen(false)
         resetForm()
-    }
-
-    const handleClearCustomer = () => {
-        setCustomer(null, null)
     }
 
     const handleCreateCustomer = async () => {
@@ -65,34 +84,79 @@ const CustomerSelector = () => {
 
     return (
         <>
-            <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-                <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                        <div className="w-8 h-8 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
-                            <HiOutlineUser className="text-gray-500" />
-                        </div>
-                        <div>
-                            <p className="text-sm font-medium">
-                                {customerName || 'Consumidor Final'}
+            <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 space-y-3">
+                {/* Toggle consumidor final */}
+                <div className="flex items-center justify-between gap-2">
+                    <div className="min-w-0">
+                        <label
+                            className={`text-sm select-none ${
+                                finalConsumerBlocked
+                                    ? 'text-gray-400 dark:text-gray-600'
+                                    : 'text-gray-600 dark:text-gray-400 cursor-pointer'
+                            }`}
+                        >
+                            Consumidor Final
+                        </label>
+                        {finalConsumerBlocked && (
+                            <p className="text-xs text-amber-500">
+                                Requerido para montos {'>'} $
+                                {FINAL_CONSUMER_MAX}
                             </p>
-                            {customerId && (
-                                <button
-                                    className="text-xs text-red-500 hover:underline"
-                                    onClick={handleClearCustomer}
-                                >
-                                    Quitar
-                                </button>
+                        )}
+                    </div>
+                    <Switcher
+                        checked={isFinalConsumer && !finalConsumerBlocked}
+                        disabled={finalConsumerBlocked}
+                        onChange={handleToggleFinalConsumer}
+                    />
+                </div>
+
+                {/* Cliente seleccionado o botón de búsqueda */}
+                {(!isFinalConsumer || finalConsumerBlocked) && (
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2 min-w-0">
+                            <div
+                                className={`w-7 h-7 rounded-full flex-shrink-0 flex items-center justify-center ${
+                                    customerId
+                                        ? 'bg-primary-100 dark:bg-primary-500/20'
+                                        : 'bg-gray-100 dark:bg-gray-700'
+                                }`}
+                            >
+                                <HiOutlineUser
+                                    className={`text-sm ${
+                                        customerId
+                                            ? 'text-primary-600'
+                                            : 'text-gray-400'
+                                    }`}
+                                />
+                            </div>
+                            {customerId ? (
+                                <div className="min-w-0">
+                                    <p className="text-sm font-medium truncate">
+                                        {customerName}
+                                    </p>
+                                    <button
+                                        className="text-xs text-red-500 hover:underline"
+                                        onClick={() => setCustomer(null, null)}
+                                    >
+                                        Quitar
+                                    </button>
+                                </div>
+                            ) : (
+                                <p className="text-sm text-gray-400 italic">
+                                    Sin cliente
+                                </p>
                             )}
                         </div>
+                        <Button
+                            size="xs"
+                            variant={customerId ? 'default' : 'solid'}
+                            onClick={() => setDialogOpen(true)}
+                        >
+                            {customerId ? 'Cambiar' : 'Buscar'}
+                        </Button>
                     </div>
-                    <Button
-                        size="xs"
-                        variant="twoTone"
-                        onClick={() => setDialogOpen(true)}
-                    >
-                        {customerId ? 'Cambiar' : 'Buscar'}
-                    </Button>
-                </div>
+                )}
             </div>
 
             <Dialog


### PR DESCRIPTION
## Descripción

  - Block checkout if no customer selected and not marked as final consumer
  - Add Switcher toggle for 'Consumidor Final' as explicit action (isFinalConsumer defaults to false)
  - Disable final consumer option and show warning when cart total exceeds
  - Show customer search row when final consumer is blocked by amount limit
  - Fix Switcher controlled mode bug: onChange now receives next value instead of current

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
