### PR TITLE
feat(auth): add session store with /me bootstrap

### DIFF
--- a/docs/auth-implementation-plan.md
+++ b/docs/auth-implementation-plan.md
@@ -9,15 +9,17 @@ Contrato backend: ver `auth-api-spec.md` (raíz del repo). Este documento traduc
 ## Estado actual
 
 - Branch: `feat/auth-real-api`
-- Última etapa completada: **Etapa 2 — HTTP client auth aislado** ✅
-- Próximo paso: **Etapa 3 — Store de sesión + bootstrap `/me`**. Refactor `useAuthStore` (`accessToken`/`refreshToken`/`accessExpiresAt`/`session`, v2 de persist) consumiendo el `tokenStorage` ya existente; reescribir `AuthService` con `apiLogin`/`apiRefresh`/`apiMe`/`apiChangePassword` sobre `AuthApiClient`; crear hooks RQ `useLogin`/`useMe`/`useChangePassword`/`useLogout`; montar `AuthBootstrap` que llama `/me` al arrancar.
+- Última etapa completada: **Etapa 3 — Store de sesión + bootstrap `/me`** ✅
+- Próximo paso: **Etapa 4 — Login real + pantalla obligatoria `mustChangePassword`**. Migrar `SignInForm` a `username` (1..64 / password 1..128), mapear errores por `code` (`INVALID_CREDENTIALS`, `PASSWORD_CHANGE_REQUIRED`, etc.), navegar CASHIER → `/pos`, resto → `/home`, si `session.mustChangePassword` → `/change-password`. Montar `MustChangePasswordGuard` en `Layouts.tsx`. Borrar SignUp/ForgotPassword (views + rutas en `authRoute.tsx`); eliminar los shims `@deprecated` en `AuthService.ts`.
 
 Notas de sesión anterior:
 - Los tipos legacy (`SignInCredential`, `SignUpCredential`, `ForgotPassword`, `ResetPassword`, `SignInResponse`, `SignUpResponse`) se dejaron marcados `@deprecated` en `src/@types/auth.ts`; se eliminan en Etapa 4 al borrar SignUp/ForgotPassword.
 - Los errores preexistentes de `tsc` en Customer/POS/Purchase/Adjustment services NO son de auth; no tocar en este plan.
 - Etapa 2 se implementó con **cliente auth aislado** (no se reescribió `BaseService`) para no romper los 23 hooks existentes que leen `response.data.data`. Envelope/ApiError/refresh se aplican solo al nuevo `AuthApiClient`. La migración cross-module del envelope queda diferida.
-- Tokens persisten por ahora en `src/services/tokenStorage.ts` (`fc.access`, `fc.refresh`, `fc.accessExpiresAt`). Etapa 3 debe hacer que `useAuthStore` consuma este módulo en vez de duplicar persistencia.
+- Tokens persisten en `src/services/tokenStorage.ts` (`fc.access`, `fc.refresh`, `fc.accessExpiresAt`). Etapa 3 hizo que `useAuthStore` consuma este módulo como única fuente de verdad (sin `persist` middleware) — `session` es runtime-only y se rehidrata vía `/me` en `AuthBootstrap`.
 - Navegación desde interceptor vía `src/services/navigationRef.ts` + `<NavigationBinder/>` montado en `App.tsx`.
+- Etapa 3 conservó un **adaptador legacy** en `src/utils/hooks/useAuth.ts` (firma `{ authenticated, signIn, signUp, signOut }`) para no romper `SignInForm`/`ProtectedRoute`/`Layouts`/`UserDropdown`/`AuthorityGuard`/`PublicRoute`/`AuthorityCheck`/`SignUpForm` en esta etapa. `signUp` es stub (`Sign up deshabilitado`). `BaseService` legacy sigue sirviendo a los 23 hooks no-auth, ahora apuntando a `accessToken`/`clear()` del store nuevo. Etapa 4 eliminará el adaptador al borrar SignUp/ForgotPassword y migrar `SignInForm` al hook RQ `useLogin` directo.
+- `tsc --noEmit` deja exactamente los mismos errores preexistentes que master (no introduce nuevos). `npm run lint` pasa con 0 errores.
 
 Actualiza estas líneas al final de cada sesión.
 
@@ -140,14 +142,24 @@ Archivos entregados:
 
 ---
 
-### ☐ Etapa 3 — Store de sesión + bootstrap `/me`
+### ✅ Etapa 3 — Store de sesión + bootstrap `/me`
 
-- Refactor `useAuthStore`: `{ accessToken, refreshToken, accessExpiresAt, session }`.
-- Acciones: `setTokens`, `setSession`, `clear`. Zustand `version: 2` para invalidar storage v1.
-- Selectors: `useSession()`, `useCan(perm)`, `useHasRole(...roles)`.
-- `AuthService` reescrito: `apiLogin`, `apiRefresh`, `apiMe`, `apiChangePassword`.
-- Hooks RQ: `useLogin`, `useMe` (enabled si hay token), `useChangePassword`, `useLogout`.
-- Componente `AuthBootstrap` en `App.tsx` → llama `/me` al montar.
+**Alcance ajustado**: store SIN `persist` middleware (consume `tokenStorage` como única fuente); adaptador legacy en `src/utils/hooks/useAuth.ts`; migración quirúrgica de 7 consumidores directos del store; `BaseService` legacy actualizado a `accessToken`/`clear()`.
+
+Archivos entregados:
+- `src/stores/useAuthStore.ts` reescrito: `{ accessToken, refreshToken, accessExpiresAt, session }` + `setTokens`/`setSession`/`clear`. Tokens hidratados al crear desde `tokenStorage`; `clear` también llama `resetRefreshManager()`.
+- Selectores: `useAccessToken`, `useSession`, `useIsAuthenticated`, `useCan(permission)`, `useHasRole(...roles)`. Re-exportados desde `src/stores/index.ts`.
+- `src/services/AuthService.ts` reescrito: `apiLogin`/`apiRefresh`/`apiMe`/`apiChangePassword` sobre `authRequest<T>` de `AuthApiClient`. Shims `@deprecated` (`apiSignUp`/`apiForgotPassword`/`apiResetPassword`) que rechazan con error claro — solo para que los forms legacy compilen hasta Etapa 4. `apiSignIn`/`apiSignOut` legacy removidos.
+- `src/hooks/useAuth.ts` reescrito: `useLogin` (setTokens + `qc.fetchQuery(['auth','me'])` + setSession), `useMe` (enabled si hay accessToken; en catch llama `clear()`), `useChangePassword`, `useLogout` (no hace request; `clear()` + `qc.clear()` + navega a `unAuthenticatedEntryPath`). Exporta `ME_QUERY_KEY`.
+- `src/utils/hooks/useAuth.ts` reescrito como **adaptador legacy** sobre los hooks RQ — firma preservada para no tocar `SignInForm`/`ProtectedRoute`/`Layouts`/`UserDropdown`/`PublicRoute`/`AuthorityGuard`/`AuthorityCheck`/`SignUpForm`.
+- `src/components/AuthBootstrap.tsx` nuevo: llama `useMe()` al montar; si `accessToken && !session && isLoading` muestra `<Loading>`. Migra una vez la clave localStorage legacy `auth-storage` (flag `fc.migratedV2`).
+- `src/App.tsx`: monta `<AuthBootstrap>` dentro de `<Theme>` envolviendo `<Layout />`.
+- Consumidores migrados a `useSession()?.permissions ?? []` (authority) o `useSession()?.username`: `src/views/Views.tsx`, `src/views/pos/components/ShiftOpenDialog.tsx`, `src/components/template/{SideNav,HorizontalNav,MobileNav,SecondaryHeader}.tsx`, `src/components/template/StackedSideNav/StackedSideNav.tsx`.
+- `src/services/BaseService.ts` (legacy) actualizado al nuevo shape: `state.token` → `state.accessToken`; `signOutSuccess()` → `clear()`.
+
+**NO tocado** (explícito, reservado para Etapas 4–6): `SignInForm` (sigue usando el adaptador; migra a username/códigos en Etapa 4), `ProtectedRoute`/`PublicRoute`/`Layouts`/`UserDropdown`, `AuthorityGuard`, navegación por rol post-login, pantalla `/change-password`, Admin Users, mocks.
+
+**Verificación**: `npm run lint` 0 errores. `tsc --noEmit` deja exactamente los mismos errores preexistentes que master en Customer/POS/Purchase/Adjustment services (no se introducen nuevos).
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { queryClient } from '@/lib/react-query'
 import Theme from '@/components/template/Theme'
 import Layout from '@/components/layouts'
 import NavigationBinder from '@/components/route/NavigationBinder'
+import AuthBootstrap from '@/components/AuthBootstrap'
 import mockServer from './mock'
 import appConfig from '@/configs/app.config'
 import './locales'
@@ -24,7 +25,9 @@ function App() {
             <BrowserRouter>
                 <NavigationBinder />
                 <Theme>
-                    <Layout />
+                    <AuthBootstrap>
+                        <Layout />
+                    </AuthBootstrap>
                 </Theme>
             </BrowserRouter>
         </QueryClientProvider>

--- a/src/components/AuthBootstrap.tsx
+++ b/src/components/AuthBootstrap.tsx
@@ -1,0 +1,40 @@
+import { useEffect, type ReactNode } from 'react'
+import { useMe } from '@/hooks/useAuth'
+import { useAccessToken, useSession } from '@/stores/useAuthStore'
+import Loading from '@/components/shared/Loading'
+
+const LEGACY_STORAGE_KEY = 'auth-storage'
+const MIGRATION_FLAG = 'fc.migratedV2'
+
+const migrateLegacyStorage = (): void => {
+    if (typeof window === 'undefined') return
+    try {
+        if (window.localStorage.getItem(MIGRATION_FLAG)) return
+        window.localStorage.removeItem(LEGACY_STORAGE_KEY)
+        window.localStorage.setItem(MIGRATION_FLAG, '1')
+    } catch {
+        /* ignore */
+    }
+}
+
+interface AuthBootstrapProps {
+    children: ReactNode
+}
+
+const AuthBootstrap = ({ children }: AuthBootstrapProps) => {
+    useEffect(() => {
+        migrateLegacyStorage()
+    }, [])
+
+    const accessToken = useAccessToken()
+    const session = useSession()
+    const { isLoading } = useMe()
+
+    if (accessToken && !session && isLoading) {
+        return <Loading loading={true} />
+    }
+
+    return <>{children}</>
+}
+
+export default AuthBootstrap

--- a/src/components/template/HorizontalNav.tsx
+++ b/src/components/template/HorizontalNav.tsx
@@ -1,10 +1,10 @@
 import HorizontalMenuContent from './HorizontalMenuContent'
 import useResponsive from '@/utils/hooks/useResponsive'
-import { useThemeStore, useAuthStore } from '@/stores'
+import { useThemeStore, useSession } from '@/stores'
 
 const HorizontalNav = () => {
     const mode = useThemeStore((state) => state.mode)
-    const userAuthority = useAuthStore((state) => state.user?.authority)
+    const userAuthority = useSession()?.permissions ?? []
 
     const { larger } = useResponsive()
 

--- a/src/components/template/MobileNav.tsx
+++ b/src/components/template/MobileNav.tsx
@@ -10,7 +10,7 @@ import withHeaderItem, { WithHeaderItemProps } from '@/utils/hoc/withHeaderItem'
 import NavToggle from '@/components/shared/NavToggle'
 import navigationConfig from '@/configs/navigation.config'
 import useResponsive from '@/utils/hooks/useResponsive'
-import { useThemeStore, useAuthStore, useBaseStore } from '@/stores'
+import { useThemeStore, useSession, useBaseStore } from '@/stores'
 
 const VerticalMenuContent = lazy(
     () => import('@/components/template/VerticalMenuContent')
@@ -44,7 +44,7 @@ const MobileNav = () => {
     const sideNavCollapse = useThemeStore(
         (state) => state.layout.sideNavCollapse
     )
-    const userAuthority = useAuthStore((state) => state.user?.authority)
+    const userAuthority = useSession()?.permissions ?? []
 
     const { smaller } = useResponsive()
 

--- a/src/components/template/SecondaryHeader.tsx
+++ b/src/components/template/SecondaryHeader.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames'
 import HorizontalMenuContent from '@/components/template/HorizontalMenuContent'
 import { NAV_MODE_THEMED } from '@/constants/theme.constant'
 import useResponsive from '@/utils/hooks/useResponsive'
-import { useThemeStore, useAuthStore } from '@/stores'
+import { useThemeStore, useSession } from '@/stores'
 import type { CommonProps } from '@/@types/common'
 
 interface SecondaryHeaderProps extends CommonProps {
@@ -15,7 +15,7 @@ const SecondaryHeader = (props: SecondaryHeaderProps) => {
     const navMode = useThemeStore((state) => state.navMode)
     const themeColor = useThemeStore((state) => state.themeColor)
     const primaryColorLevel = useThemeStore((state) => state.primaryColorLevel)
-    const userAuthority = useAuthStore((state) => state.user?.authority)
+    const userAuthority = useSession()?.permissions ?? []
 
     const { larger } = useResponsive()
 

--- a/src/components/template/SideNav.tsx
+++ b/src/components/template/SideNav.tsx
@@ -13,7 +13,7 @@ import Logo from '@/components/template/Logo'
 import navigationConfig from '@/configs/navigation.config'
 import VerticalMenuContent from '@/components/template/VerticalMenuContent'
 import useResponsive from '@/utils/hooks/useResponsive'
-import { useThemeStore, useAuthStore, useBaseStore } from '@/stores'
+import { useThemeStore, useSession, useBaseStore } from '@/stores'
 
 const sideNavStyle = {
     width: SIDE_NAV_WIDTH,
@@ -35,7 +35,7 @@ const SideNav = () => {
     const sideNavCollapse = useThemeStore(
         (state) => state.layout.sideNavCollapse
     )
-    const userAuthority = useAuthStore((state) => state.user?.authority)
+    const userAuthority = useSession()?.permissions ?? []
 
     const { larger } = useResponsive()
 

--- a/src/components/template/StackedSideNav/StackedSideNav.tsx
+++ b/src/components/template/StackedSideNav/StackedSideNav.tsx
@@ -11,7 +11,7 @@ import StackedSideNavMini, { SelectedMenuItem } from './StackedSideNavMini'
 import StackedSideNavSecondary from './StackedSideNavSecondary'
 import useResponsive from '@/utils/hooks/useResponsive'
 import isEmpty from 'lodash/isEmpty'
-import { useThemeStore, useAuthStore, useBaseStore } from '@/stores'
+import { useThemeStore, useSession, useBaseStore } from '@/stores'
 import { useTranslation } from 'react-i18next'
 
 const stackedSideNavDefaultStyle = {
@@ -30,7 +30,7 @@ const StackedSideNav = () => {
     const mode = useThemeStore((state) => state.mode)
     const direction = useThemeStore((state) => state.direction)
     const currentRouteKey = useBaseStore((state) => state.currentRouteKey)
-    const userAuthority = useAuthStore((state) => state.user?.authority)
+    const userAuthority = useSession()?.permissions ?? []
 
     const { larger } = useResponsive()
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,69 +1,76 @@
-import { useMutation } from '@tanstack/react-query'
-import { useAuthStore } from '@/stores'
-import {
-    apiSignIn,
-    apiSignUp,
-    apiSignOut,
-    apiForgotPassword,
-    apiResetPassword,
-} from '@/services/AuthService'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '@/stores/useAuthStore'
+import { apiChangePassword, apiLogin, apiMe } from '@/services/AuthService'
+import { navigateTo } from '@/services/navigationRef'
+import appConfig from '@/configs/app.config'
 import type {
-    SignInCredential,
-    SignUpCredential,
-    ForgotPassword,
-    ResetPassword,
+    ChangePasswordRequest,
+    LoginRequest,
+    LoginResponse,
+    MeResponse,
 } from '@/@types/auth'
 
-// Hook para Sign In
-export function useSignIn() {
-    const { signInSuccess } = useAuthStore()
+export const ME_QUERY_KEY = ['auth', 'me'] as const
 
-    return useMutation({
-        mutationFn: (credentials: SignInCredential) => apiSignIn(credentials),
-        onSuccess: (response) => {
-            if (response.data.token && response.data.user) {
-                signInSuccess(response.data.token, response.data.user)
+export function useMe() {
+    const accessToken = useAuthStore((s) => s.accessToken)
+    const setSession = useAuthStore((s) => s.setSession)
+    const clear = useAuthStore((s) => s.clear)
+
+    return useQuery<MeResponse>({
+        queryKey: ME_QUERY_KEY,
+        queryFn: async () => {
+            try {
+                const session = await apiMe()
+                setSession(session)
+                return session
+            } catch (err) {
+                clear()
+                throw err
             }
+        },
+        enabled: !!accessToken,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    })
+}
+
+export function useLogin() {
+    const qc = useQueryClient()
+    const setTokens = useAuthStore((s) => s.setTokens)
+    const setSession = useAuthStore((s) => s.setSession)
+
+    return useMutation<LoginResponse, unknown, LoginRequest>({
+        mutationFn: (body) => apiLogin(body),
+        onSuccess: async (tokens) => {
+            setTokens(tokens)
+            const session = await qc.fetchQuery({
+                queryKey: ME_QUERY_KEY,
+                queryFn: apiMe,
+            })
+            setSession(session)
         },
     })
 }
 
-// Hook para Sign Up
-export function useSignUp() {
-    const { signInSuccess } = useAuthStore()
-
-    return useMutation({
-        mutationFn: (credentials: SignUpCredential) => apiSignUp(credentials),
-        onSuccess: (response) => {
-            if (response.data.token && response.data.user) {
-                signInSuccess(response.data.token, response.data.user)
-            }
-        },
+export function useChangePassword() {
+    return useMutation<void, unknown, ChangePasswordRequest>({
+        mutationFn: (body) => apiChangePassword(body),
     })
 }
 
-// Hook para Sign Out
-export function useSignOut() {
-    const { signOutSuccess } = useAuthStore()
+export function useLogout() {
+    const qc = useQueryClient()
+    const clear = useAuthStore((s) => s.clear)
 
-    return useMutation({
-        mutationFn: () => apiSignOut(),
+    return useMutation<void, unknown, void>({
+        mutationFn: async () => {
+            /* El backend real no define logout server-side. */
+        },
         onSuccess: () => {
-            signOutSuccess()
+            clear()
+            qc.clear()
+            navigateTo(appConfig.unAuthenticatedEntryPath, { replace: true })
         },
-    })
-}
-
-// Hook para Forgot Password
-export function useForgotPassword() {
-    return useMutation({
-        mutationFn: (data: ForgotPassword) => apiForgotPassword(data),
-    })
-}
-
-// Hook para Reset Password
-export function useResetPassword() {
-    return useMutation({
-        mutationFn: (data: ResetPassword) => apiResetPassword(data),
     })
 }

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,48 +1,62 @@
-import ApiService from './ApiService'
+import { authRequest } from './AuthApiClient'
+import appConfig from '@/configs/app.config'
 import type {
-    SignInCredential,
-    SignUpCredential,
-    ForgotPassword,
-    ResetPassword,
-    SignInResponse,
-    SignUpResponse,
+    ChangePasswordRequest,
+    LoginRequest,
+    LoginResponse,
+    MeResponse,
+    RefreshRequest,
+    RefreshResponse,
 } from '@/@types/auth'
 
-export async function apiSignIn(data: SignInCredential) {
-    return ApiService.fetchData<SignInResponse>({
-        url: '/sign-in',
-        method: 'post',
-        data,
+const AUTH = appConfig.authApiHost
+
+export const apiLogin = (body: LoginRequest): Promise<LoginResponse> =>
+    authRequest<LoginResponse>({
+        url: `${AUTH}/login`,
+        method: 'POST',
+        data: body,
     })
+
+export const apiRefresh = (body: RefreshRequest): Promise<RefreshResponse> =>
+    authRequest<RefreshResponse>({
+        url: `${AUTH}/refresh`,
+        method: 'POST',
+        data: body,
+    })
+
+export const apiMe = (): Promise<MeResponse> =>
+    authRequest<MeResponse>({
+        url: `${AUTH}/me`,
+        method: 'GET',
+    })
+
+export const apiChangePassword = (body: ChangePasswordRequest): Promise<void> =>
+    authRequest<void>({
+        url: `${AUTH}/change-password`,
+        method: 'POST',
+        data: body,
+    })
+
+type DeprecatedAuthResponse = { data: { token: string; user: unknown } | null }
+
+/** @deprecated Removed in Etapa 4. Only kept so legacy forms still compile. */
+export const apiSignUp = async (
+    _payload?: unknown
+): Promise<DeprecatedAuthResponse> => {
+    throw new Error('Sign up deshabilitado')
 }
 
-export async function apiSignUp(data: SignUpCredential) {
-    return ApiService.fetchData<SignUpResponse>({
-        url: '/sign-up',
-        method: 'post',
-        data,
-    })
+/** @deprecated Removed in Etapa 4. */
+export const apiForgotPassword = async (
+    _payload?: unknown
+): Promise<DeprecatedAuthResponse> => {
+    throw new Error('Recuperación de contraseña deshabilitada')
 }
 
-export async function apiSignOut() {
-    return ApiService.fetchData({
-        url: '/sign-out',
-        method: 'post',
-    })
-}
-
-export async function apiForgotPassword(data: ForgotPassword) {
-    return ApiService.fetchData({
-        url: '/forgot-password',
-        method: 'post',
-        data,
-    })
-}
-
-export async function apiResetPassword(data: ResetPassword) {
-    return ApiService.fetchData({
-        url: '/reset-password',
-        method: 'post',
-        data,
-    })
+/** @deprecated Removed in Etapa 4. */
+export const apiResetPassword = async (
+    _payload?: unknown
+): Promise<DeprecatedAuthResponse> => {
+    throw new Error('Reset de contraseña deshabilitado')
 }

--- a/src/services/BaseService.ts
+++ b/src/services/BaseService.ts
@@ -12,7 +12,7 @@ const BaseService = axios.create({
 
 BaseService.interceptors.request.use(
     (config) => {
-        const token = useAuthStore.getState().token
+        const token = useAuthStore.getState().accessToken
 
         if (token) {
             config.headers[REQUEST_HEADER_AUTH_KEY] = `${TOKEN_TYPE}${token}`
@@ -31,7 +31,7 @@ BaseService.interceptors.response.use(
         const { response } = error
 
         if (response && unauthorizedCode.includes(response.status)) {
-            useAuthStore.getState().signOutSuccess()
+            useAuthStore.getState().clear()
         }
 
         return Promise.reject(error)

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,4 +1,11 @@
-export { useAuthStore } from './useAuthStore'
+export {
+    useAuthStore,
+    useAccessToken,
+    useSession,
+    useIsAuthenticated,
+    useCan,
+    useHasRole,
+} from './useAuthStore'
 export { useThemeStore } from './useThemeStore'
 export { useLocaleStore } from './useLocaleStore'
 export { useBaseStore } from './useBaseStore'

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,52 +1,66 @@
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import type { Session } from '@/@types/auth'
+import type { Permission } from '@/constants/permissions.constant'
+import type { RoleCode } from '@/constants/roles.constant'
+import tokenStorage from '@/services/tokenStorage'
+import { resetRefreshManager } from '@/services/refreshManager'
 
-export interface User {
-    avatar?: string
-    userName?: string
-    email?: string
-    authority?: string[]
+type SetTokensPayload = {
+    accessToken: string
+    refreshToken: string
+    expiresIn: number
 }
 
 interface AuthState {
-    // State
-    user: User | null
-    token: string | null
-    signedIn: boolean
+    accessToken: string | null
+    refreshToken: string | null
+    accessExpiresAt: number | null
+    session: Session | null
 
-    // Actions
-    signInSuccess: (token: string, user: User) => void
-    signOutSuccess: () => void
-    setUser: (user: User) => void
+    setTokens: (payload: SetTokensPayload) => void
+    setSession: (session: Session | null) => void
+    clear: () => void
 }
 
-export const useAuthStore = create<AuthState>()(
-    persist(
-        (set) => ({
-            // Initial state
-            user: null,
-            token: null,
-            signedIn: false,
+export const useAuthStore = create<AuthState>((set) => ({
+    accessToken: tokenStorage.getAccessToken(),
+    refreshToken: tokenStorage.getRefreshToken(),
+    accessExpiresAt: tokenStorage.getAccessExpiresAt(),
+    session: null,
 
-            // Actions
-            signInSuccess: (token, user) =>
-                set({
-                    token,
-                    user,
-                    signedIn: true,
-                }),
+    setTokens: (payload) => {
+        tokenStorage.setTokens(payload)
+        set({
+            accessToken: payload.accessToken,
+            refreshToken: payload.refreshToken,
+            accessExpiresAt: Date.now() + payload.expiresIn * 1000,
+        })
+    },
 
-            signOutSuccess: () =>
-                set({
-                    user: null,
-                    token: null,
-                    signedIn: false,
-                }),
+    setSession: (session) => set({ session }),
 
-            setUser: (user) => set({ user }),
-        }),
-        {
-            name: 'auth-storage',
-        }
-    )
-)
+    clear: () => {
+        tokenStorage.clearTokens()
+        resetRefreshManager()
+        set({
+            accessToken: null,
+            refreshToken: null,
+            accessExpiresAt: null,
+            session: null,
+        })
+    },
+}))
+
+export const useAccessToken = (): string | null =>
+    useAuthStore((s) => s.accessToken)
+
+export const useSession = (): Session | null => useAuthStore((s) => s.session)
+
+export const useIsAuthenticated = (): boolean =>
+    useAuthStore((s) => !!s.accessToken && !!s.session)
+
+export const useCan = (permission: Permission): boolean =>
+    useAuthStore((s) => s.session?.permissions.includes(permission) ?? false)
+
+export const useHasRole = (...roles: RoleCode[]): boolean =>
+    useAuthStore((s) => (s.session ? roles.includes(s.session.role) : false))

--- a/src/utils/hooks/useAuth.ts
+++ b/src/utils/hooks/useAuth.ts
@@ -1,102 +1,54 @@
-import { apiSignIn, apiSignOut, apiSignUp } from '@/services/AuthService'
-import { useAuthStore } from '@/stores'
+import { useNavigate } from 'react-router-dom'
 import appConfig from '@/configs/app.config'
 import { REDIRECT_URL_KEY } from '@/constants/app.constant'
-import { useNavigate } from 'react-router-dom'
+import { useIsAuthenticated } from '@/stores/useAuthStore'
+import { useLogin, useLogout } from '@/hooks/useAuth'
+import { isApiError } from '@/utils/errors/ApiError'
 import useQuery from './useQuery'
-import type { SignInCredential, SignUpCredential } from '@/@types/auth'
+import type { SignInCredential } from '@/@types/auth'
 
 type Status = 'success' | 'failed'
+type SignInResult = { status: Status; message: string }
 
 function useAuth() {
     const navigate = useNavigate()
     const query = useQuery()
+    const authenticated = useIsAuthenticated()
+    const loginMutation = useLogin()
+    const logoutMutation = useLogout()
 
-    const token = useAuthStore((state) => state.token)
-    const signedIn = useAuthStore((state) => state.signedIn)
-    const signInSuccess = useAuthStore((state) => state.signInSuccess)
-    const signOutSuccess = useAuthStore((state) => state.signOutSuccess)
-
-    const signIn = async (
-        values: SignInCredential
-    ): Promise<
-        | {
-              status: Status
-              message: string
-          }
-        | undefined
-    > => {
+    const signIn = async ({
+        userName,
+        password,
+    }: SignInCredential): Promise<SignInResult> => {
         try {
-            const resp = await apiSignIn(values)
-            if (resp.data) {
-                const { token } = resp.data
-                const user = resp.data.user || {
-                    avatar: '',
-                    userName: 'Anonymous',
-                    authority: ['USER'],
-                    email: '',
-                }
-                signInSuccess(token, user)
-                const redirectUrl = query.get(REDIRECT_URL_KEY)
-                navigate(
-                    redirectUrl ? redirectUrl : appConfig.authenticatedEntryPath
-                )
-                return {
-                    status: 'success',
-                    message: '',
-                }
-            }
-            // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-        } catch (errors: any) {
+            await loginMutation.mutateAsync({ username: userName, password })
+            const redirect = query.get(REDIRECT_URL_KEY)
+            navigate(redirect ?? appConfig.authenticatedEntryPath)
+            return { status: 'success', message: '' }
+        } catch (err) {
             return {
                 status: 'failed',
-                message: errors?.response?.data?.message || errors.toString(),
+                message: isApiError(err)
+                    ? err.message
+                    : err instanceof Error
+                    ? err.message
+                    : String(err),
             }
         }
     }
 
-    const signUp = async (values: SignUpCredential) => {
-        try {
-            const resp = await apiSignUp(values)
-            if (resp.data) {
-                const { token } = resp.data
-                const user = resp.data.user || {
-                    avatar: '',
-                    userName: 'Anonymous',
-                    authority: ['USER'],
-                    email: '',
-                }
-                signInSuccess(token, user)
-                const redirectUrl = query.get(REDIRECT_URL_KEY)
-                navigate(
-                    redirectUrl ? redirectUrl : appConfig.authenticatedEntryPath
-                )
-                return {
-                    status: 'success',
-                    message: '',
-                }
-            }
-            // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-        } catch (errors: any) {
-            return {
-                status: 'failed',
-                message: errors?.response?.data?.message || errors.toString(),
-            }
-        }
-    }
+    const signUp = async (_credentials?: unknown): Promise<SignInResult> => ({
+        status: 'failed',
+        message: 'Sign up deshabilitado',
+    })
 
-    const handleSignOut = () => {
-        signOutSuccess()
-        navigate(appConfig.unAuthenticatedEntryPath)
-    }
-
-    const signOut = async () => {
-        await apiSignOut()
-        handleSignOut()
+    const signOut = async (): Promise<void> => {
+        await logoutMutation.mutateAsync()
     }
 
     return {
-        authenticated: token && signedIn,
+        authenticated,
         signIn,
         signUp,
         signOut,

--- a/src/views/Views.tsx
+++ b/src/views/Views.tsx
@@ -4,7 +4,7 @@ import { protectedRoutes, publicRoutes } from '@/configs/routes.config'
 import appConfig from '@/configs/app.config'
 import PageContainer from '@/components/template/PageContainer'
 import { Routes, Route, Navigate } from 'react-router-dom'
-import { useAuthStore } from '@/stores'
+import { useSession } from '@/stores'
 import ProtectedRoute from '@/components/route/ProtectedRoute'
 import PublicRoute from '@/components/route/PublicRoute'
 import AuthorityGuard from '@/components/route/AuthorityGuard'
@@ -21,7 +21,7 @@ type AllRoutesProps = ViewsProps
 const { authenticatedEntryPath } = appConfig
 
 const AllRoutes = (props: AllRoutesProps) => {
-    const userAuthority = useAuthStore((state) => state.user?.authority)
+    const userAuthority = useSession()?.permissions ?? []
 
     return (
         <Routes>

--- a/src/views/pos/components/ShiftOpenDialog.tsx
+++ b/src/views/pos/components/ShiftOpenDialog.tsx
@@ -3,14 +3,14 @@ import { useNavigate } from 'react-router-dom'
 import Input from '@/components/ui/Input'
 import Button from '@/components/ui/Button'
 import { useOpenShift } from '@/hooks/usePOS'
-import { useAuthStore } from '@/stores/useAuthStore'
+import { useSession } from '@/stores/useAuthStore'
 
 const ShiftOpenDialog = () => {
     const navigate = useNavigate()
-    const { user } = useAuthStore()
+    const session = useSession()
     const openShift = useOpenShift()
 
-    const [cashierName, setCashierName] = useState(user?.userName || '')
+    const [cashierName, setCashierName] = useState(session?.username || '')
     const [openingBalance, setOpeningBalance] = useState<string>('0')
     const [notes, setNotes] = useState('')
 


### PR DESCRIPTION
  ## Descripción

Rewrite useAuthStore to { accessToken, refreshToken, accessExpiresAt,
  session } without persist middleware, using tokenStorage as the single
  source of truth. Session is runtime-only and rehydrates via /me in a
  new AuthBootstrap mounted inside <Theme>, which shows Loading while a
  token exists without a session and migrates the legacy auth-storage
  key once.

  Add selectors useAccessToken / useSession / useIsAuthenticated /
  useCan / useHasRole. Rewrite AuthService on top of authRequest<T> from
  the isolated AuthApiClient: apiLogin, apiRefresh, apiMe,
  apiChangePassword. Keep @deprecated shims for apiSignUp / apiForgot /
  apiReset so legacy forms compile until Stage 4. Rewrite hooks/useAuth
  with useLogin (setTokens + fetchQuery /me), useMe (clear on error),
  useChangePassword, and useLogout (no server call: clear +
  queryClient.clear + navigate).

  Keep a thin legacy adapter in utils/hooks/useAuth so SignInForm,
  ProtectedRoute, Layouts, UserDropdown, PublicRoute, AuthorityGuard,
  AuthorityCheck, and SignUpForm stay untouched this stage. Migrate the
  7 direct store consumers (Views, ShiftOpenDialog, SideNav,
  HorizontalNav, MobileNav, SecondaryHeader, StackedSideNav) from
  user?.authority/userName to the new selectors. Point legacy
  BaseService at the new shape (accessToken + clear).

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
