### PR TITLE
feat(auth): role-based POS gating and admin users CRUD

### DIFF
--- a/docs/auth-implementation-plan.md
+++ b/docs/auth-implementation-plan.md
@@ -9,8 +9,8 @@ Contrato backend: ver `auth-api-spec.md` (raíz del repo). Este documento traduc
 ## Estado actual
 
 - Branch: `feat/auth-real-api`
-- Última etapa completada: **Etapa 6 — Gating de rutas y navegación por permiso** ✅
-- Próximo paso: **Etapa 7 — Ruteo por rol + enlaces cruzados POS↔Admin**.
+- Última etapa completada: **Etapa 8 — Admin Users CRUD** ✅
+- Próximo paso: **Etapa 9 — Actualizar Mock (MirageJS)**.
 
 Notas de sesión anterior (S5):
 - Etapa 6 completada.
@@ -18,6 +18,26 @@ Notas de sesión anterior (S5):
 - `navigation.config/index.ts`: `authority[]` rellenados en ítems y section titles (OR-match en section titles para ocultar sección si usuario no tiene ningún ítem accesible).
 - `src/views/auth/AccessDenied.tsx` creado (minimal: "Sin acceso" + botón volver al inicio). `AuthorityGuard` ya redirigía allí pero la ruta no existía.
 - Sin cambios a `AuthorityGuard`, `AuthorityCheck`, `useAuthority`, `Views.tsx` — infraestructura ya estaba cableada.
+- `npm run lint` 0 errores. `tsc --noEmit` mismos errores preexistentes que master.
+
+Notas de sesión S7:
+- Etapa 8 completada.
+- `src/services/AuthApiClient.ts`: interceptor de respuesta ahora preserva `meta.pagination` en `response._pagination` antes de unwrap; nuevo helper `authRequestPaginated<T>()` exportado.
+- `src/services/AdminUsersService.ts`: nuevo, cubre list/get/create/updateRole/activate/deactivate/resetPassword usando `authRequest` / `authRequestPaginated`.
+- `src/hooks/useAdminUsers.ts`: nuevo, hooks RQ con invalidación por `['admin-users']`: `useAdminUsers`, `useCreateAdminUser`, `useUpdateUserRole`, `useActivateUser`, `useDeactivateUser`, `useResetUserPassword`.
+- `src/views/settings/UsersView/index.tsx`: tabla paginada con filtros (rol, estado); inline role Select; toggle activar/desactivar con confirm dialog; botón "Resetear" por fila.
+- `src/views/settings/UsersView/CreateUserModal.tsx`: modal Formik+Yup; maneja `USERNAME_ALREADY_EXISTS` y `EMAIL_ALREADY_EXISTS` como field errors.
+- `src/views/settings/UsersView/ResetPasswordModal.tsx`: genera 12-char password, 2 fases (antes/después de reset); copia al portapapeles + banner de aviso.
+- `routes.config.ts`: ruta `/settings/users` gateada con `['user:manage']`.
+- `navigation.config/index.ts`: ítem "Usuarios" bajo Settings, authority `['user:manage']`.
+- `navigation-icon.config.tsx`: `settingsUsers: <HiOutlineUsers />`.
+- `npm run lint` 0 errores. `tsc --noEmit` sin errores nuevos.
+
+Notas de sesión S6:
+- Post-login/post-change-password routing ya estaba implementado en sesiones anteriores (CASHIER→/pos, resto→/home).
+- `ModernLayout.tsx`: botón "POS" gateado con `useCan('pos:operate')` — solo visible para ADMIN y CASHIER.
+- `POSHeader.tsx`: botón "Devolución" gateado con `useCan('refund:approve')`; botón "Dashboard" renombrado a "Administración" y visible solo si `!useHasRole(ROLE.CASHIER)`.
+- `ParkedSalesDrawer.tsx`: botón "Cancelar" gateado con `useCan('sale:cancel')` — oculto para CASHIER.
 - `npm run lint` 0 errores. `tsc --noEmit` mismos errores preexistentes que master.
 
 Actualiza estas líneas al final de cada sesión.
@@ -188,7 +208,7 @@ Archivos entregados:
 
 ---
 
-### ☐ Etapa 7 — Ruteo por rol + enlaces cruzados POS↔Admin
+### ✅ Etapa 7 — Ruteo por rol + enlaces cruzados POS↔Admin
 
 - Post-login/post-`/me`: CASHIER → `/pos`; else → `/home`.
 - Gating interno POS: `sale:cancel`, `refund:approve`.
@@ -197,7 +217,7 @@ Archivos entregados:
 
 ---
 
-### ☐ Etapa 8 — Admin Users CRUD
+### ✅ Etapa 8 — Admin Users CRUD
 
 - `src/services/UserService.ts`: list/get/create/updateRole/activate/deactivate/resetPassword.
 - `src/hooks/useUsers.ts` RQ con invalidations.

--- a/src/components/layouts/ModernLayout.tsx
+++ b/src/components/layouts/ModernLayout.tsx
@@ -8,6 +8,7 @@ import SideNav from '@/components/template/SideNav'
 import Button from '@/components/ui/Button'
 import View from '@/views'
 import { HiOutlineShoppingCart } from 'react-icons/hi'
+import { useCan } from '@/stores'
 
 const HeaderActionsStart = () => {
     return (
@@ -20,17 +21,20 @@ const HeaderActionsStart = () => {
 
 const HeaderActionsEnd = () => {
     const navigate = useNavigate()
+    const canOperatePOS = useCan('pos:operate')
 
     return (
         <>
-            <Button
-                size="sm"
-                variant="solid"
-                icon={<HiOutlineShoppingCart />}
-                onClick={() => navigate('/pos')}
-            >
-                POS
-            </Button>
+            {canOperatePOS && (
+                <Button
+                    size="sm"
+                    variant="solid"
+                    icon={<HiOutlineShoppingCart />}
+                    onClick={() => navigate('/pos')}
+                >
+                    POS
+                </Button>
+            )}
             <SidePanel />
             <UserDropdown hoverable={false} />
         </>

--- a/src/configs/navigation-icon.config.tsx
+++ b/src/configs/navigation-icon.config.tsx
@@ -16,6 +16,7 @@ import {
     HiOutlineSwitchVertical,
     HiOutlineTruck,
     HiOutlineUserGroup,
+    HiOutlineUsers,
 } from 'react-icons/hi'
 
 export type NavigationIcons = Record<string, JSX.Element>
@@ -39,6 +40,7 @@ const navigationIcon: NavigationIcons = {
     inventoryReports: <HiOutlineDocumentText />,
     salesSales: <HiOutlineShoppingCart />,
     inventoryAlerts: <HiOutlineBell />,
+    settingsUsers: <HiOutlineUsers />,
     settingsCompanyConfig: <HiOutlineOfficeBuilding />,
     settingsCertificates: <HiOutlineLockClosed />,
 }

--- a/src/configs/navigation.config/index.ts
+++ b/src/configs/navigation.config/index.ts
@@ -251,6 +251,16 @@ const navigationConfig: NavigationTree[] = [
         authority: [],
         subMenu: [
             {
+                key: 'settings.users',
+                path: '/settings/users',
+                title: 'Usuarios',
+                translateKey: 'nav.settings.users',
+                icon: 'settingsUsers',
+                type: NAV_ITEM_TYPE_ITEM,
+                authority: ['user:manage'],
+                subMenu: [],
+            },
+            {
                 key: 'settings.companyConfig',
                 path: '/settings/company-config',
                 title: 'Company Configuration',

--- a/src/configs/routes.config/routes.config.ts
+++ b/src/configs/routes.config/routes.config.ts
@@ -164,6 +164,12 @@ export const protectedRoutes = [
         authority: ['pos:operate'],
     },
     {
+        key: 'settings.users',
+        path: '/settings/users',
+        component: lazy(() => import('@/views/settings/UsersView')),
+        authority: ['user:manage'],
+    },
+    {
         key: 'settings.companyConfig',
         path: '/settings/company-config',
         component: lazy(() => import('@/views/settings/CompanyConfigView')),

--- a/src/hooks/useAdminUsers.ts
+++ b/src/hooks/useAdminUsers.ts
@@ -1,0 +1,68 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import AdminUsersService from '@/services/AdminUsersService'
+import type {
+    AdminUserListParams,
+    CreateUserRequest,
+    UpdateUserRoleRequest,
+    ResetUserPasswordRequest,
+} from '@/@types/auth'
+import type { RoleCode } from '@/constants/roles.constant'
+
+const USERS_KEY = ['admin-users'] as const
+
+export const useAdminUsers = (params?: AdminUserListParams) =>
+    useQuery({
+        queryKey: [...USERS_KEY, params],
+        queryFn: () => AdminUsersService.listUsers(params),
+    })
+
+export const useCreateAdminUser = () => {
+    const qc = useQueryClient()
+    return useMutation({
+        mutationFn: (data: CreateUserRequest) =>
+            AdminUsersService.createUser(data),
+        onSuccess: () => qc.invalidateQueries({ queryKey: USERS_KEY }),
+    })
+}
+
+export const useUpdateUserRole = () => {
+    const qc = useQueryClient()
+    return useMutation({
+        mutationFn: ({ id, role }: { id: number; role: RoleCode }) =>
+            AdminUsersService.updateRole(id, { role } as UpdateUserRoleRequest),
+        onSuccess: () => qc.invalidateQueries({ queryKey: USERS_KEY }),
+    })
+}
+
+export const useActivateUser = () => {
+    const qc = useQueryClient()
+    return useMutation({
+        mutationFn: (id: number) => AdminUsersService.activate(id),
+        onSuccess: () => qc.invalidateQueries({ queryKey: USERS_KEY }),
+    })
+}
+
+export const useDeactivateUser = () => {
+    const qc = useQueryClient()
+    return useMutation({
+        mutationFn: (id: number) => AdminUsersService.deactivate(id),
+        onSuccess: () => qc.invalidateQueries({ queryKey: USERS_KEY }),
+    })
+}
+
+export const useResetUserPassword = () => {
+    const qc = useQueryClient()
+    return useMutation({
+        mutationFn: ({
+            id,
+            newPassword,
+        }: {
+            id: number
+            newPassword: string
+        }) =>
+            AdminUsersService.resetPassword(id, {
+                newPassword,
+            } as ResetUserPasswordRequest),
+        onSuccess: () => qc.invalidateQueries({ queryKey: USERS_KEY }),
+    })
+}

--- a/src/services/AdminUsersService.ts
+++ b/src/services/AdminUsersService.ts
@@ -1,0 +1,54 @@
+import appConfig from '@/configs/app.config'
+import { authRequest, authRequestPaginated } from './AuthApiClient'
+import type {
+    AdminUserResponse,
+    AdminUserListParams,
+    CreateUserRequest,
+    UpdateUserRoleRequest,
+    ResetUserPasswordRequest,
+} from '@/@types/auth'
+
+const BASE = appConfig.adminUsersApiHost
+
+const AdminUsersService = {
+    listUsers: (params?: AdminUserListParams) =>
+        authRequestPaginated<AdminUserResponse>({
+            url: BASE,
+            method: 'GET',
+            params,
+        }),
+
+    getUser: (id: number) =>
+        authRequest<AdminUserResponse>({ url: `${BASE}/${id}`, method: 'GET' }),
+
+    createUser: (data: CreateUserRequest) =>
+        authRequest<AdminUserResponse>({ url: BASE, method: 'POST', data }),
+
+    updateRole: (id: number, data: UpdateUserRoleRequest) =>
+        authRequest<AdminUserResponse>({
+            url: `${BASE}/${id}/role`,
+            method: 'PUT',
+            data,
+        }),
+
+    activate: (id: number) =>
+        authRequest<AdminUserResponse>({
+            url: `${BASE}/${id}/activate`,
+            method: 'POST',
+        }),
+
+    deactivate: (id: number) =>
+        authRequest<AdminUserResponse>({
+            url: `${BASE}/${id}/deactivate`,
+            method: 'POST',
+        }),
+
+    resetPassword: (id: number, data: ResetUserPasswordRequest) =>
+        authRequest<AdminUserResponse>({
+            url: `${BASE}/${id}/reset-password`,
+            method: 'POST',
+            data,
+        }),
+}
+
+export default AdminUsersService

--- a/src/services/AuthApiClient.ts
+++ b/src/services/AuthApiClient.ts
@@ -46,6 +46,12 @@ AuthApiClient.interceptors.response.use(
 
         const body = response.data
         if (body && typeof body === 'object' && 'data' in body) {
+            const meta = (body as { meta?: { pagination?: unknown } }).meta
+            if (meta?.pagination) {
+                ;(
+                    response as AxiosResponse & { _pagination?: unknown }
+                )._pagination = meta.pagination
+            }
             response.data = (body as { data: unknown }).data
         }
         return response
@@ -102,6 +108,19 @@ export const authRequest = async <T>(
 ): Promise<T> => {
     const response = await AuthApiClient.request<T>(config)
     return response.data as T
+}
+
+export const authRequestPaginated = async <T>(
+    config: AxiosRequestConfig
+): Promise<{ data: T[]; total: number }> => {
+    type WithPagination = AxiosResponse & { _pagination?: { total: number } }
+    const response = (await AuthApiClient.request<T[]>(
+        config
+    )) as WithPagination
+    return {
+        data: response.data as T[],
+        total: response._pagination?.total ?? 0,
+    }
 }
 
 export { ApiError, isApiError }

--- a/src/views/pos/components/POSHeader.tsx
+++ b/src/views/pos/components/POSHeader.tsx
@@ -8,6 +8,8 @@ import {
     HiOutlineHome,
     HiOutlineReceiptRefund,
 } from 'react-icons/hi'
+import { useCan, useHasRole } from '@/stores'
+import { ROLE } from '@/constants/roles.constant'
 
 interface POSHeaderProps {
     onOpenCloseShift?: () => void
@@ -23,6 +25,8 @@ const POSHeader = ({
     const navigate = useNavigate()
     const shift = useShift()
     const [currentTime, setCurrentTime] = useState(new Date())
+    const canRefund = useCan('refund:approve')
+    const isCashier = useHasRole(ROLE.CASHIER)
 
     useEffect(() => {
         const timer = setInterval(() => setCurrentTime(new Date()), 60000)
@@ -62,14 +66,16 @@ const POSHeader = ({
             </span>
 
             <div className="flex items-center gap-2">
-                <Button
-                    size="sm"
-                    variant="plain"
-                    icon={<HiOutlineReceiptRefund />}
-                    onClick={onOpenRefund}
-                >
-                    Devolución
-                </Button>
+                {canRefund && (
+                    <Button
+                        size="sm"
+                        variant="plain"
+                        icon={<HiOutlineReceiptRefund />}
+                        onClick={onOpenRefund}
+                    >
+                        Devolución
+                    </Button>
+                )}
                 <Button
                     size="sm"
                     variant="plain"
@@ -86,14 +92,16 @@ const POSHeader = ({
                 >
                     Cerrar Turno
                 </Button>
-                <Button
-                    size="sm"
-                    variant="solid"
-                    icon={<HiOutlineHome />}
-                    onClick={() => navigate('/home')}
-                >
-                    Dashboard
-                </Button>
+                {!isCashier && (
+                    <Button
+                        size="sm"
+                        variant="solid"
+                        icon={<HiOutlineHome />}
+                        onClick={() => navigate('/home')}
+                    >
+                        Administración
+                    </Button>
+                )}
             </div>
         </div>
     )

--- a/src/views/pos/components/ParkedSalesDrawer.tsx
+++ b/src/views/pos/components/ParkedSalesDrawer.tsx
@@ -6,6 +6,7 @@ import toast from '@/components/ui/toast'
 import { useParkedSales, useResumeSale, useCancelSale } from '@/hooks/usePOS'
 import { usePOSStore } from '@/stores/usePOSStore'
 import POSService from '@/services/POSService'
+import { useCan } from '@/stores'
 
 interface ParkedSalesDrawerProps {
     isOpen: boolean
@@ -17,6 +18,7 @@ const ParkedSalesDrawer = ({ isOpen, onClose }: ParkedSalesDrawerProps) => {
     const resumeSale = useResumeSale()
     const cancelSale = useCancelSale()
     const { clearCart, addItem, setCustomer, applyDiscount } = usePOSStore()
+    const canCancelSale = useCan('sale:cancel')
 
     const handleResume = async (saleId: number) => {
         try {
@@ -162,16 +164,20 @@ const ParkedSalesDrawer = ({ isOpen, onClose }: ParkedSalesDrawerProps) => {
                                             ${sale.total.toFixed(2)}
                                         </p>
                                         <div className="flex gap-1 mt-1">
-                                            <Button
-                                                size="xs"
-                                                variant="default"
-                                                loading={cancelSale.isPending}
-                                                onClick={() =>
-                                                    handleCancel(sale.id)
-                                                }
-                                            >
-                                                Cancelar
-                                            </Button>
+                                            {canCancelSale && (
+                                                <Button
+                                                    size="xs"
+                                                    variant="default"
+                                                    loading={
+                                                        cancelSale.isPending
+                                                    }
+                                                    onClick={() =>
+                                                        handleCancel(sale.id)
+                                                    }
+                                                >
+                                                    Cancelar
+                                                </Button>
+                                            )}
                                             <Button
                                                 size="xs"
                                                 variant="solid"

--- a/src/views/settings/UsersView/CreateUserModal.tsx
+++ b/src/views/settings/UsersView/CreateUserModal.tsx
@@ -1,0 +1,218 @@
+import Dialog from '@/components/ui/Dialog'
+import Button from '@/components/ui/Button'
+import { FormItem, FormContainer } from '@/components/ui/Form'
+import Input from '@/components/ui/Input'
+import Select from '@/components/ui/Select'
+import Notification from '@/components/ui/Notification'
+import toast from '@/components/ui/toast'
+import { useCreateAdminUser } from '@/hooks/useAdminUsers'
+import { isApiError } from '@/utils/errors/ApiError'
+import { ROLE, ROLE_LABELS, ALL_ROLES } from '@/constants/roles.constant'
+import type { RoleCode } from '@/constants/roles.constant'
+import type { CreateUserRequest } from '@/@types/auth'
+import { Field, Form, Formik } from 'formik'
+import * as Yup from 'yup'
+
+interface CreateUserModalProps {
+    open: boolean
+    onClose: () => void
+}
+
+const roleOptions = ALL_ROLES.map((role) => ({
+    value: role,
+    label: ROLE_LABELS[role],
+}))
+
+const validationSchema = Yup.object().shape({
+    username: Yup.string()
+        .min(1, 'Requerido')
+        .max(64, 'Máximo 64 caracteres')
+        .required('Ingresa el nombre de usuario'),
+    email: Yup.string()
+        .email('Email inválido')
+        .max(128, 'Máximo 128 caracteres')
+        .required('Ingresa el email'),
+    password: Yup.string()
+        .min(8, 'Mínimo 8 caracteres')
+        .max(128, 'Máximo 128 caracteres')
+        .required('Ingresa una contraseña'),
+    role: Yup.number()
+        .oneOf(ALL_ROLES as unknown as number[])
+        .required('Selecciona un rol'),
+})
+
+const initialValues: CreateUserRequest = {
+    username: '',
+    email: '',
+    password: '',
+    role: ROLE.VIEWER,
+}
+
+const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
+    const createUser = useCreateAdminUser()
+
+    const handleClose = () => {
+        if (!createUser.isPending) onClose()
+    }
+
+    return (
+        <Dialog
+            isOpen={open}
+            width={480}
+            shouldCloseOnEsc={!createUser.isPending}
+            shouldCloseOnOverlayClick={!createUser.isPending}
+            onClose={handleClose}
+            onRequestClose={handleClose}
+        >
+            <h5 className="mb-4">Nuevo usuario</h5>
+            <Formik
+                initialValues={initialValues}
+                validationSchema={validationSchema}
+                onSubmit={async (
+                    values,
+                    { setSubmitting, setFieldError, resetForm }
+                ) => {
+                    try {
+                        await createUser.mutateAsync(values)
+                        toast.push(
+                            <Notification
+                                type="success"
+                                title="Usuario creado"
+                            />,
+                            { placement: 'top-center' }
+                        )
+                        resetForm()
+                        onClose()
+                    } catch (err) {
+                        if (isApiError(err)) {
+                            if (err.code === 'USERNAME_ALREADY_EXISTS') {
+                                setFieldError(
+                                    'username',
+                                    'Este nombre de usuario ya existe'
+                                )
+                            } else if (err.code === 'EMAIL_ALREADY_EXISTS') {
+                                setFieldError(
+                                    'email',
+                                    'Este email ya está registrado'
+                                )
+                            } else {
+                                toast.push(
+                                    <Notification
+                                        type="danger"
+                                        title={err.message}
+                                    />,
+                                    { placement: 'top-center' }
+                                )
+                            }
+                        } else {
+                            toast.push(
+                                <Notification
+                                    type="danger"
+                                    title="Error al crear el usuario"
+                                />,
+                                { placement: 'top-center' }
+                            )
+                        }
+                    } finally {
+                        setSubmitting(false)
+                    }
+                }}
+            >
+                {({ touched, errors, isSubmitting, values, setFieldValue }) => (
+                    <Form>
+                        <FormContainer>
+                            <FormItem
+                                label="Usuario"
+                                invalid={
+                                    (errors.username &&
+                                        touched.username) as boolean
+                                }
+                                errorMessage={errors.username}
+                            >
+                                <Field
+                                    name="username"
+                                    autoComplete="off"
+                                    placeholder="nombre.usuario"
+                                    component={Input}
+                                />
+                            </FormItem>
+                            <FormItem
+                                label="Email"
+                                invalid={
+                                    (errors.email && touched.email) as boolean
+                                }
+                                errorMessage={errors.email}
+                            >
+                                <Field
+                                    name="email"
+                                    type="email"
+                                    autoComplete="off"
+                                    placeholder="usuario@empresa.com"
+                                    component={Input}
+                                />
+                            </FormItem>
+                            <FormItem
+                                label="Contraseña"
+                                invalid={
+                                    (errors.password &&
+                                        touched.password) as boolean
+                                }
+                                errorMessage={errors.password}
+                            >
+                                <Field
+                                    name="password"
+                                    type="password"
+                                    autoComplete="new-password"
+                                    placeholder="Mínimo 8 caracteres"
+                                    component={Input}
+                                />
+                            </FormItem>
+                            <FormItem
+                                label="Rol"
+                                invalid={
+                                    (errors.role && touched.role) as boolean
+                                }
+                                errorMessage={errors.role as string}
+                            >
+                                <Select
+                                    options={roleOptions}
+                                    value={
+                                        roleOptions.find(
+                                            (o) => o.value === values.role
+                                        ) ?? null
+                                    }
+                                    onChange={(opt) =>
+                                        setFieldValue(
+                                            'role',
+                                            (opt?.value ??
+                                                ROLE.VIEWER) as RoleCode
+                                        )
+                                    }
+                                />
+                            </FormItem>
+                            <div className="flex justify-end gap-2 mt-2">
+                                <Button
+                                    variant="plain"
+                                    disabled={isSubmitting}
+                                    type="button"
+                                    onClick={handleClose}
+                                >
+                                    Cancelar
+                                </Button>
+                                <Button
+                                    variant="solid"
+                                    loading={isSubmitting}
+                                    type="submit"
+                                >
+                                    Crear
+                                </Button>
+                            </div>
+                        </FormContainer>
+                    </Form>
+                )}
+            </Formik>
+        </Dialog>
+    )
+}
+
+export default CreateUserModal

--- a/src/views/settings/UsersView/ResetPasswordModal.tsx
+++ b/src/views/settings/UsersView/ResetPasswordModal.tsx
@@ -1,0 +1,168 @@
+import { useState, useEffect } from 'react'
+import Dialog from '@/components/ui/Dialog'
+import Button from '@/components/ui/Button'
+import Input from '@/components/ui/Input'
+import Notification from '@/components/ui/Notification'
+import toast from '@/components/ui/toast'
+import { useResetUserPassword } from '@/hooks/useAdminUsers'
+import { getErrorMessage } from '@/utils/getErrorMessage'
+import type { AdminUserResponse } from '@/@types/auth'
+
+interface ResetPasswordModalProps {
+    open: boolean
+    onClose: () => void
+    user: AdminUserResponse | null
+}
+
+const CHARS = 'ABCDEFGHJKMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#%'
+
+const generatePassword = () =>
+    Array.from(crypto.getRandomValues(new Uint8Array(12)))
+        .map((b) => CHARS[b % CHARS.length])
+        .join('')
+
+const ResetPasswordModal = ({
+    open,
+    user,
+    onClose,
+}: ResetPasswordModalProps) => {
+    const [password, setPassword] = useState('')
+    const [done, setDone] = useState(false)
+    const resetPassword = useResetUserPassword()
+
+    useEffect(() => {
+        if (open) {
+            setPassword(generatePassword())
+            setDone(false)
+        }
+    }, [open])
+
+    const handleClose = () => {
+        if (!resetPassword.isPending) {
+            setDone(false)
+            onClose()
+        }
+    }
+
+    const handleCopy = () => {
+        navigator.clipboard.writeText(password)
+        toast.push(<Notification type="success" title="Contraseña copiada" />, {
+            placement: 'top-center',
+        })
+    }
+
+    const handleSubmit = async () => {
+        if (!user) return
+        try {
+            await resetPassword.mutateAsync({
+                id: user.id,
+                newPassword: password,
+            })
+            setDone(true)
+        } catch (err) {
+            toast.push(
+                <Notification
+                    type="danger"
+                    title={getErrorMessage(
+                        err,
+                        'Error al resetear la contraseña'
+                    )}
+                />,
+                { placement: 'top-center' }
+            )
+        }
+    }
+
+    return (
+        <Dialog
+            isOpen={open}
+            width={480}
+            shouldCloseOnEsc={!resetPassword.isPending}
+            shouldCloseOnOverlayClick={!resetPassword.isPending}
+            onClose={handleClose}
+            onRequestClose={handleClose}
+        >
+            <h5 className="mb-1">Resetear contraseña</h5>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                Usuario:{' '}
+                <span className="font-semibold text-gray-700 dark:text-gray-200">
+                    {user?.username}
+                </span>
+            </p>
+
+            {!done ? (
+                <>
+                    <p className="text-sm mb-3">
+                        Se generó una contraseña temporal. Puedes editarla antes
+                        de confirmar.
+                    </p>
+                    <div className="flex gap-2 mb-6">
+                        <Input
+                            className="font-mono"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                        />
+                        <Button
+                            variant="default"
+                            type="button"
+                            onClick={() => setPassword(generatePassword())}
+                        >
+                            Regenerar
+                        </Button>
+                    </div>
+                    <div className="flex justify-end gap-2">
+                        <Button
+                            variant="plain"
+                            disabled={resetPassword.isPending}
+                            type="button"
+                            onClick={handleClose}
+                        >
+                            Cancelar
+                        </Button>
+                        <Button
+                            variant="solid"
+                            loading={resetPassword.isPending}
+                            disabled={password.length < 8}
+                            type="button"
+                            onClick={handleSubmit}
+                        >
+                            Resetear
+                        </Button>
+                    </div>
+                </>
+            ) : (
+                <>
+                    <div className="p-3 mb-4 rounded-lg bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/20 text-amber-800 dark:text-amber-300 text-sm">
+                        Comparte esta contraseña con el usuario por un canal
+                        seguro. No la podrás ver de nuevo.
+                    </div>
+                    <div className="flex gap-2 mb-6">
+                        <Input
+                            readOnly
+                            className="font-mono"
+                            value={password}
+                        />
+                        <Button
+                            variant="solid"
+                            type="button"
+                            onClick={handleCopy}
+                        >
+                            Copiar
+                        </Button>
+                    </div>
+                    <div className="flex justify-end">
+                        <Button
+                            variant="default"
+                            type="button"
+                            onClick={handleClose}
+                        >
+                            Cerrar
+                        </Button>
+                    </div>
+                </>
+            )}
+        </Dialog>
+    )
+}
+
+export default ResetPasswordModal

--- a/src/views/settings/UsersView/index.tsx
+++ b/src/views/settings/UsersView/index.tsx
@@ -1,0 +1,395 @@
+import { useState } from 'react'
+import DataTable, { ColumnDef } from '@/components/shared/DataTable'
+import Card from '@/components/ui/Card'
+import Button from '@/components/ui/Button'
+import Dialog from '@/components/ui/Dialog'
+import Select from '@/components/ui/Select'
+import Notification from '@/components/ui/Notification'
+import toast from '@/components/ui/toast'
+import {
+    useAdminUsers,
+    useUpdateUserRole,
+    useActivateUser,
+    useDeactivateUser,
+} from '@/hooks/useAdminUsers'
+import { getErrorMessage } from '@/utils/getErrorMessage'
+import { ROLE_LABELS, ALL_ROLES } from '@/constants/roles.constant'
+import type { RoleCode } from '@/constants/roles.constant'
+import type { AdminUserResponse } from '@/@types/auth'
+import { HiPlus } from 'react-icons/hi'
+import CreateUserModal from './CreateUserModal'
+import ResetPasswordModal from './ResetPasswordModal'
+
+const roleOptions = ALL_ROLES.map((role) => ({
+    value: role,
+    label: ROLE_LABELS[role],
+}))
+
+const isActiveOptions = [
+    { value: undefined as boolean | undefined, label: 'Todos' },
+    { value: true as boolean | undefined, label: 'Activos' },
+    { value: false as boolean | undefined, label: 'Inactivos' },
+]
+
+const roleFilterOptions = [
+    { value: undefined as RoleCode | undefined, label: 'Todos los roles' },
+    ...roleOptions.map((o) => ({
+        ...o,
+        value: o.value as RoleCode | undefined,
+    })),
+]
+
+const UsersView = () => {
+    const [pageIndex, setPageIndex] = useState(1)
+    const [pageSize, setPageSize] = useState(10)
+    const [filterRole, setFilterRole] = useState<RoleCode | undefined>(
+        undefined
+    )
+    const [filterIsActive, setFilterIsActive] = useState<boolean | undefined>(
+        undefined
+    )
+
+    const [createOpen, setCreateOpen] = useState(false)
+    const [resetDialog, setResetDialog] = useState<{
+        open: boolean
+        user: AdminUserResponse | null
+    }>({
+        open: false,
+        user: null,
+    })
+    const [deactivateDialog, setDeactivateDialog] = useState<{
+        open: boolean
+        userId: number | null
+        username: string
+    }>({ open: false, userId: null, username: '' })
+
+    const [updatingRoleId, setUpdatingRoleId] = useState<number | null>(null)
+    const [togglingId, setTogglingId] = useState<number | null>(null)
+
+    const offset = (pageIndex - 1) * pageSize
+    const { data: usersData, isLoading } = useAdminUsers({
+        limit: pageSize,
+        offset,
+        role: filterRole,
+        isActive: filterIsActive,
+    })
+    const items = usersData?.data ?? []
+    const total = usersData?.total ?? 0
+
+    const updateRole = useUpdateUserRole()
+    const activateUser = useActivateUser()
+    const deactivateUser = useDeactivateUser()
+
+    const handleRoleChange = async (userId: number, role: RoleCode) => {
+        setUpdatingRoleId(userId)
+        try {
+            await updateRole.mutateAsync({ id: userId, role })
+            toast.push(
+                <Notification type="success" title="Rol actualizado" />,
+                { placement: 'top-center' }
+            )
+        } catch (err) {
+            toast.push(
+                <Notification
+                    type="danger"
+                    title={getErrorMessage(err, 'Error al actualizar el rol')}
+                />,
+                { placement: 'top-center' }
+            )
+        } finally {
+            setUpdatingRoleId(null)
+        }
+    }
+
+    const handleActivate = async (userId: number) => {
+        setTogglingId(userId)
+        try {
+            await activateUser.mutateAsync(userId)
+            toast.push(
+                <Notification type="success" title="Usuario activado" />,
+                { placement: 'top-center' }
+            )
+        } catch (err) {
+            toast.push(
+                <Notification
+                    type="danger"
+                    title={getErrorMessage(err, 'Error al activar el usuario')}
+                />,
+                { placement: 'top-center' }
+            )
+        } finally {
+            setTogglingId(null)
+        }
+    }
+
+    const handleDeactivateConfirm = async () => {
+        if (!deactivateDialog.userId) return
+        const userId = deactivateDialog.userId
+        setDeactivateDialog({ open: false, userId: null, username: '' })
+        setTogglingId(userId)
+        try {
+            await deactivateUser.mutateAsync(userId)
+            toast.push(
+                <Notification type="success" title="Usuario desactivado" />,
+                { placement: 'top-center' }
+            )
+        } catch (err) {
+            toast.push(
+                <Notification
+                    type="danger"
+                    title={getErrorMessage(
+                        err,
+                        'Error al desactivar el usuario'
+                    )}
+                />,
+                { placement: 'top-center' }
+            )
+        } finally {
+            setTogglingId(null)
+        }
+    }
+
+    const formatDate = (dateStr: string | null) => {
+        if (!dateStr) return '—'
+        return new Date(dateStr).toLocaleString('es-EC', {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        })
+    }
+
+    const columns: ColumnDef<AdminUserResponse>[] = [
+        {
+            header: 'Usuario',
+            accessorKey: 'username',
+            cell: (props) => (
+                <div>
+                    <p className="font-semibold">
+                        {props.row.original.username}
+                    </p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                        {props.row.original.email}
+                    </p>
+                </div>
+            ),
+        },
+        {
+            header: 'Rol',
+            accessorKey: 'role',
+            cell: (props) => {
+                const user = props.row.original
+                const isUpdating = updatingRoleId === user.id
+                return (
+                    <Select
+                        size="sm"
+                        className="min-w-[150px]"
+                        isDisabled={isUpdating}
+                        options={roleOptions}
+                        value={
+                            roleOptions.find((o) => o.value === user.role) ??
+                            null
+                        }
+                        onChange={(opt) => {
+                            if (opt && opt.value !== user.role) {
+                                handleRoleChange(user.id, opt.value as RoleCode)
+                            }
+                        }}
+                    />
+                )
+            },
+        },
+        {
+            header: 'Estado',
+            accessorKey: 'isActive',
+            cell: (props) =>
+                props.row.original.isActive ? (
+                    <span className="px-2 py-1 bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 rounded text-xs font-medium">
+                        Activo
+                    </span>
+                ) : (
+                    <span className="px-2 py-1 bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200 rounded text-xs font-medium">
+                        Inactivo
+                    </span>
+                ),
+        },
+        {
+            header: 'Último acceso',
+            accessorKey: 'lastLoginAt',
+            cell: (props) => (
+                <span className="text-sm text-gray-500 dark:text-gray-400">
+                    {formatDate(props.row.original.lastLoginAt)}
+                </span>
+            ),
+        },
+        {
+            header: 'Acciones',
+            id: 'actions',
+            cell: (props) => {
+                const user = props.row.original
+                const isToggling = togglingId === user.id
+                return (
+                    <div className="flex gap-1 flex-wrap">
+                        <Button
+                            size="xs"
+                            variant="plain"
+                            onClick={() => setResetDialog({ open: true, user })}
+                        >
+                            Resetear
+                        </Button>
+                        {user.isActive ? (
+                            <Button
+                                size="xs"
+                                variant="plain"
+                                loading={isToggling}
+                                onClick={() =>
+                                    setDeactivateDialog({
+                                        open: true,
+                                        userId: user.id,
+                                        username: user.username,
+                                    })
+                                }
+                            >
+                                Desactivar
+                            </Button>
+                        ) : (
+                            <Button
+                                size="xs"
+                                variant="solid"
+                                loading={isToggling}
+                                onClick={() => handleActivate(user.id)}
+                            >
+                                Activar
+                            </Button>
+                        )}
+                    </div>
+                )
+            },
+        },
+    ]
+
+    return (
+        <>
+            <Card>
+                <div className="p-4">
+                    <div className="flex justify-between items-center mb-4 flex-wrap gap-3">
+                        <div>
+                            <h4 className="text-lg font-semibold">Usuarios</h4>
+                            <p className="text-sm text-gray-500 mt-1">
+                                Gestiona los usuarios del sistema
+                            </p>
+                        </div>
+                        <div className="flex items-center gap-2 flex-wrap">
+                            <Select
+                                isClearable
+                                size="sm"
+                                className="min-w-[160px]"
+                                placeholder="Todos los roles"
+                                options={roleFilterOptions.slice(1)}
+                                value={
+                                    roleFilterOptions.find(
+                                        (o) => o.value === filterRole
+                                    ) ?? null
+                                }
+                                onChange={(opt) => {
+                                    setFilterRole(opt?.value)
+                                    setPageIndex(1)
+                                }}
+                            />
+                            <Select
+                                size="sm"
+                                className="min-w-[130px]"
+                                options={isActiveOptions}
+                                value={
+                                    isActiveOptions.find(
+                                        (o) => o.value === filterIsActive
+                                    ) ?? isActiveOptions[0]
+                                }
+                                onChange={(opt) => {
+                                    setFilterIsActive(opt?.value)
+                                    setPageIndex(1)
+                                }}
+                            />
+                            <Button
+                                variant="solid"
+                                size="sm"
+                                icon={<HiPlus />}
+                                onClick={() => setCreateOpen(true)}
+                            >
+                                Nuevo usuario
+                            </Button>
+                        </div>
+                    </div>
+
+                    <DataTable
+                        columns={columns}
+                        data={items}
+                        loading={isLoading}
+                        pagingData={{ total, pageIndex, pageSize }}
+                        onPaginationChange={setPageIndex}
+                        onSelectChange={(size) => {
+                            setPageSize(size)
+                            setPageIndex(1)
+                        }}
+                    />
+                </div>
+            </Card>
+
+            <CreateUserModal
+                open={createOpen}
+                onClose={() => setCreateOpen(false)}
+            />
+
+            <ResetPasswordModal
+                open={resetDialog.open}
+                user={resetDialog.user}
+                onClose={() => setResetDialog({ open: false, user: null })}
+            />
+
+            <Dialog
+                isOpen={deactivateDialog.open}
+                onClose={() =>
+                    setDeactivateDialog({
+                        open: false,
+                        userId: null,
+                        username: '',
+                    })
+                }
+                onRequestClose={() =>
+                    setDeactivateDialog({
+                        open: false,
+                        userId: null,
+                        username: '',
+                    })
+                }
+            >
+                <h5 className="mb-4">Confirmar desactivación</h5>
+                <p className="mb-6 text-sm">
+                    ¿Desactivar a <strong>{deactivateDialog.username}</strong>?
+                    Su sesión activa seguirá funcionando hasta que expire el
+                    token.
+                </p>
+                <div className="flex justify-end gap-2">
+                    <Button
+                        variant="plain"
+                        onClick={() =>
+                            setDeactivateDialog({
+                                open: false,
+                                userId: null,
+                                username: '',
+                            })
+                        }
+                    >
+                        Cancelar
+                    </Button>
+                    <Button variant="solid" onClick={handleDeactivateConfirm}>
+                        Desactivar
+                    </Button>
+                </div>
+            </Dialog>
+        </>
+    )
+}
+
+export default UsersView


### PR DESCRIPTION
## Descripción

  - ModernLayout: hide POS button for users without pos:operate
  - POSHeader: hide Devolución without refund:approve; rename Dashboard → Administración and hide for CASHIER role
  - ParkedSalesDrawer: hide Cancelar button without sale:cancel
  - AuthApiClient: preserve meta.pagination before envelope strip; add authRequestPaginated<T> helper
  - AdminUsersService: list/get/create/updateRole/activate/deactivate/ resetPassword against /api/admin/users
  - useAdminUsers: React Query hooks with cache invalidation
  - UsersView: paginated table with role/status filters, inline role Select, activate/deactivate toggle with confirm dialog
  - CreateUserModal: Formik+Yup; maps USERNAME_ALREADY_EXISTS and EMAIL_ALREADY_EXISTS to field-level errors
  - ResetPasswordModal: generates 12-char temp password, two-phase (before/after submit), copy button + security banner
  - Route /settings/users gated with user:manage; nav item + icon

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
