### PR TITLE
feat(inventory): apply CRUD abstractions to 4 views

### DIFF
--- a/src/components/shared/FormModal.tsx
+++ b/src/components/shared/FormModal.tsx
@@ -5,7 +5,8 @@ import Button from '@/components/ui/Button'
 interface FormModalProps {
     isOpen: boolean
     onClose: () => void
-    onSubmit: () => void
+    onSubmit?: () => void
+    formId?: string
     title: string
     isSubmitting?: boolean
     children: ReactNode
@@ -15,6 +16,7 @@ const FormModal = ({
     isOpen,
     onClose,
     onSubmit,
+    formId,
     title,
     isSubmitting = false,
     children,
@@ -40,14 +42,25 @@ const FormModal = ({
                 >
                     Cancelar
                 </Button>
-                <Button
-                    type="button"
-                    variant="solid"
-                    loading={isSubmitting}
-                    onClick={onSubmit}
-                >
-                    Guardar
-                </Button>
+                {formId ? (
+                    <Button
+                        type="submit"
+                        form={formId}
+                        variant="solid"
+                        loading={isSubmitting}
+                    >
+                        Guardar
+                    </Button>
+                ) : (
+                    <Button
+                        type="button"
+                        variant="solid"
+                        loading={isSubmitting}
+                        onClick={onSubmit}
+                    >
+                        Guardar
+                    </Button>
+                )}
             </div>
         </div>
     </Dialog>

--- a/src/views/inventory/CategoriesView/CategoryForm.tsx
+++ b/src/views/inventory/CategoriesView/CategoryForm.tsx
@@ -1,166 +1,85 @@
 import { useState, useEffect } from 'react'
-import Dialog from '@/components/ui/Dialog'
 import Input from '@/components/ui/Input'
-import Button from '@/components/ui/Button'
-import Notification from '@/components/ui/Notification'
-import toast from '@/components/ui/toast'
-import { useCreateCategory, useUpdateCategory } from '@/hooks/useCategories'
-import { getErrorMessage } from '@/utils/getErrorMessage'
 import type { Category } from '@/services/CategoryService'
 
-interface CategoryFormProps {
-    open: boolean
-    onClose: () => void
-    category: Category | null
+interface CategoryFormData {
+    name: string
+    description: string
 }
 
-const CategoryForm = ({ open, onClose, category }: CategoryFormProps) => {
-    const [formData, setFormData] = useState({
+interface CategoryFormProps {
+    formId: string
+    category: Category | null
+    isSubmitting?: boolean
+    onSubmit: (data: CategoryFormData) => void
+}
+
+const CategoryForm = ({
+    formId,
+    category,
+    isSubmitting = false,
+    onSubmit,
+}: CategoryFormProps) => {
+    const [formData, setFormData] = useState<CategoryFormData>({
         name: '',
         description: '',
     })
 
-    const createCategory = useCreateCategory()
-    const updateCategory = useUpdateCategory()
-
-    const isEditMode = !!category
-
     useEffect(() => {
-        if (category) {
-            setFormData({
-                name: category.name,
-                description: category.description || '',
-            })
-        } else {
-            setFormData({
-                name: '',
-                description: '',
-            })
-        }
-    }, [category, open])
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-
-        try {
-            if (isEditMode && category) {
-                await updateCategory.mutateAsync({
-                    id: category.id,
-                    data: formData,
-                })
-            } else {
-                await createCategory.mutateAsync(formData)
-            }
-
-            toast.push(
-                <Notification
-                    title={
-                        isEditMode
-                            ? 'Categoría actualizada'
-                            : 'Categoría creada'
-                    }
-                    type="success"
-                >
-                    {isEditMode
-                        ? 'La categoría se actualizó correctamente'
-                        : 'La categoría se creó correctamente'}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-
-            onClose()
-        } catch (error: unknown) {
-            const errorMessage = getErrorMessage(
-                error,
-                'Error al guardar la categoría'
-            )
-
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {errorMessage}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-        }
-    }
-
-    const isPending = createCategory.isPending || updateCategory.isPending
+        setFormData(
+            category
+                ? {
+                      name: category.name,
+                      description: category.description || '',
+                  }
+                : { name: '', description: '' }
+        )
+    }, [category])
 
     return (
-        <Dialog
-            isOpen={open}
-            shouldCloseOnEsc={!isPending}
-            shouldCloseOnOverlayClick={!isPending}
-            onClose={onClose}
-            onRequestClose={onClose}
+        <form
+            id={formId}
+            onSubmit={(e) => {
+                e.preventDefault()
+                onSubmit(formData)
+            }}
         >
-            <div className="flex flex-col h-full justify-between">
-                <h5 className="mb-4">
-                    {isEditMode ? 'Editar Categoría' : 'Nueva Categoría'}
-                </h5>
+            <div className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Nombre <span className="text-red-500">*</span>
+                    </label>
+                    <Input
+                        required
+                        placeholder="Nombre de la categoría"
+                        value={formData.name}
+                        disabled={isSubmitting}
+                        onChange={(e) =>
+                            setFormData({ ...formData, name: e.target.value })
+                        }
+                    />
+                </div>
 
-                <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        {/* Name */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Nombre <span className="text-red-500">*</span>
-                            </label>
-                            <Input
-                                required
-                                placeholder="Nombre de la categoría"
-                                value={formData.name}
-                                disabled={isPending}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        name: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
-
-                        {/* Description */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Descripción
-                            </label>
-                            <Input
-                                textArea
-                                placeholder="Descripción de la categoría"
-                                value={formData.description}
-                                style={{ minHeight: '80px' }}
-                                disabled={isPending}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        description: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
-                    </div>
-
-                    <div className="flex justify-end gap-2 mt-6">
-                        <Button
-                            type="button"
-                            variant="plain"
-                            disabled={isPending}
-                            onClick={onClose}
-                        >
-                            Cancelar
-                        </Button>
-                        <Button
-                            type="submit"
-                            variant="solid"
-                            loading={isPending}
-                        >
-                            {isEditMode ? 'Actualizar' : 'Crear'}
-                        </Button>
-                    </div>
-                </form>
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Descripción
+                    </label>
+                    <Input
+                        textArea
+                        placeholder="Descripción de la categoría"
+                        value={formData.description}
+                        style={{ minHeight: '80px' }}
+                        disabled={isSubmitting}
+                        onChange={(e) =>
+                            setFormData({
+                                ...formData,
+                                description: e.target.value,
+                            })
+                        }
+                    />
+                </div>
             </div>
-        </Dialog>
+        </form>
     )
 }
 

--- a/src/views/inventory/CategoriesView/index.tsx
+++ b/src/views/inventory/CategoriesView/index.tsx
@@ -1,79 +1,89 @@
-import { useState } from 'react'
 import DataTable, { ColumnDef } from '@/components/shared/DataTable'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
-import Dialog from '@/components/ui/Dialog'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
-import { useCategories, useDeleteCategory } from '@/hooks/useCategories'
+import {
+    useCategories,
+    useDeleteCategory,
+    useCreateCategory,
+    useUpdateCategory,
+} from '@/hooks/useCategories'
 import { getErrorMessage } from '@/utils/getErrorMessage'
+import { useCrudOperations } from '@/hooks'
+import { FormModal, DeleteConfirmDialog } from '@/components/shared'
 import type { Category } from '@/services/CategoryService'
 import CategoryForm from './CategoryForm'
 import { HiOutlinePencil, HiOutlineTrash, HiPlus } from 'react-icons/hi'
 
 const CategoriesView = () => {
-    const [isFormOpen, setIsFormOpen] = useState(false)
-    const [selectedCategory, setSelectedCategory] = useState<Category | null>(
-        null
-    )
-    const [deleteDialog, setDeleteDialog] = useState<{
-        open: boolean
-        category: Category | null
-    }>({ open: false, category: null })
+    const crud = useCrudOperations<Category>()
+    const offset = (crud.pageIndex - 1) * crud.pageSize
 
-    const [pageIndex, setPageIndex] = useState(1)
-    const [pageSize, setPageSize] = useState(10)
-    const offset = (pageIndex - 1) * pageSize
-
-    const { data, isLoading } = useCategories({ limit: pageSize, offset })
+    const { data, isLoading } = useCategories({ limit: crud.pageSize, offset })
     const categories = data?.items ?? []
     const total = data?.pagination?.total ?? 0
+
     const deleteCategory = useDeleteCategory()
+    const createCategory = useCreateCategory()
+    const updateCategory = useUpdateCategory()
+    const isPending = createCategory.isPending || updateCategory.isPending
 
-    const handleCreate = () => {
-        setSelectedCategory(null)
-        setIsFormOpen(true)
-    }
-
-    const handleEdit = (category: Category) => {
-        setSelectedCategory(category)
-        setIsFormOpen(true)
-    }
-
-    const handleDeleteClick = (category: Category) => {
-        setDeleteDialog({ open: true, category })
-    }
-
-    const handleDeleteConfirm = async () => {
-        if (deleteDialog.category) {
-            try {
-                await deleteCategory.mutateAsync(deleteDialog.category.id)
+    const handleFormSubmit = async (formData: {
+        name: string
+        description: string
+    }) => {
+        try {
+            if (crud.isEditOpen && crud.selectedItem) {
+                await updateCategory.mutateAsync({
+                    id: crud.selectedItem.id,
+                    data: formData,
+                })
                 toast.push(
-                    <Notification title="Categoría eliminada" type="success">
-                        La categoría se eliminó correctamente
+                    <Notification title="Categoría actualizada" type="success">
+                        La categoría se actualizó correctamente
                     </Notification>,
                     { placement: 'top-center' }
                 )
-                setDeleteDialog({ open: false, category: null })
-            } catch (error: unknown) {
-                const errorMessage = getErrorMessage(
-                    error,
-                    'Error al eliminar la categoría'
-                )
-
+            } else {
+                await createCategory.mutateAsync(formData)
                 toast.push(
-                    <Notification title="Error" type="danger">
-                        {errorMessage}
+                    <Notification title="Categoría creada" type="success">
+                        La categoría se creó correctamente
                     </Notification>,
                     { placement: 'top-center' }
                 )
             }
+            crud.closeAll()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al guardar la categoría')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
         }
     }
 
-    const handleFormClose = () => {
-        setIsFormOpen(false)
-        setSelectedCategory(null)
+    const handleDeleteConfirm = async () => {
+        if (!crud.selectedItem) return
+        try {
+            await deleteCategory.mutateAsync(crud.selectedItem.id)
+            toast.push(
+                <Notification title="Categoría eliminada" type="success">
+                    La categoría se eliminó correctamente
+                </Notification>,
+                { placement: 'top-center' }
+            )
+            crud.closeAll()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al eliminar la categoría')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
     }
 
     const columns: ColumnDef<Category>[] = [
@@ -118,13 +128,13 @@ const CategoriesView = () => {
                             size="sm"
                             variant="plain"
                             icon={<HiOutlinePencil />}
-                            onClick={() => handleEdit(row.original)}
+                            onClick={() => crud.openEdit(row.original)}
                         />
                         <Button
                             size="sm"
                             variant="plain"
                             icon={<HiOutlineTrash />}
-                            onClick={() => handleDeleteClick(row.original)}
+                            onClick={() => crud.openDelete(row.original)}
                         />
                     </div>
                 )
@@ -149,7 +159,7 @@ const CategoriesView = () => {
                             variant="solid"
                             size="sm"
                             icon={<HiPlus />}
-                            onClick={handleCreate}
+                            onClick={crud.openCreate}
                         >
                             Nueva Categoría
                         </Button>
@@ -159,56 +169,43 @@ const CategoriesView = () => {
                         columns={columns}
                         data={categories}
                         loading={isLoading}
-                        pagingData={{ total, pageIndex, pageSize }}
-                        onPaginationChange={setPageIndex}
-                        onSelectChange={(size) => {
-                            setPageSize(size)
-                            setPageIndex(1)
+                        pagingData={{
+                            total,
+                            pageIndex: crud.pageIndex,
+                            pageSize: crud.pageSize,
                         }}
+                        onPaginationChange={(idx) =>
+                            crud.onPaginationChange(idx, crud.pageSize)
+                        }
+                        onSelectChange={(size) =>
+                            crud.onPaginationChange(1, size)
+                        }
                     />
                 </div>
             </Card>
 
-            {/* Form Modal */}
-            <CategoryForm
-                open={isFormOpen}
-                category={selectedCategory}
-                onClose={handleFormClose}
-            />
-
-            {/* Delete Confirmation Dialog */}
-            <Dialog
-                isOpen={deleteDialog.open}
-                onClose={() => setDeleteDialog({ open: false, category: null })}
-                onRequestClose={() =>
-                    setDeleteDialog({ open: false, category: null })
-                }
+            <FormModal
+                formId="category-form"
+                isOpen={crud.isCreateOpen || crud.isEditOpen}
+                title={crud.isEditOpen ? 'Editar Categoría' : 'Nueva Categoría'}
+                isSubmitting={isPending}
+                onClose={crud.closeAll}
             >
-                <h5 className="mb-4">Confirmar Eliminación</h5>
-                <p className="mb-6">
-                    ¿Estás seguro de que deseas eliminar la categoría{' '}
-                    <strong>{deleteDialog.category?.name}</strong>? Esta acción
-                    no se puede deshacer.
-                </p>
-                <div className="flex justify-end gap-2">
-                    <Button
-                        variant="plain"
-                        disabled={deleteCategory.isPending}
-                        onClick={() =>
-                            setDeleteDialog({ open: false, category: null })
-                        }
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        variant="solid"
-                        loading={deleteCategory.isPending}
-                        onClick={handleDeleteConfirm}
-                    >
-                        Eliminar
-                    </Button>
-                </div>
-            </Dialog>
+                <CategoryForm
+                    formId="category-form"
+                    category={crud.selectedItem}
+                    isSubmitting={isPending}
+                    onSubmit={handleFormSubmit}
+                />
+            </FormModal>
+
+            <DeleteConfirmDialog
+                isOpen={crud.isDeleteOpen}
+                itemName={crud.selectedItem?.name}
+                isDeleting={deleteCategory.isPending}
+                onClose={crud.closeAll}
+                onConfirm={handleDeleteConfirm}
+            />
         </>
     )
 }

--- a/src/views/inventory/LocationsView/LocationForm.tsx
+++ b/src/views/inventory/LocationsView/LocationForm.tsx
@@ -1,13 +1,9 @@
 import { useState, useEffect } from 'react'
-import Dialog from '@/components/ui/Dialog'
 import Input from '@/components/ui/Input'
-import Button from '@/components/ui/Button'
 import Select from '@/components/ui/Select'
 import Switcher from '@/components/ui/Switcher'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
-import { useCreateLocation, useUpdateLocation } from '@/hooks/useLocations'
-import { getErrorMessage } from '@/utils/getErrorMessage'
 import { useWarehouses } from '@/hooks/useWarehouses'
 import type {
     Location,
@@ -16,9 +12,10 @@ import type {
 } from '@/services/LocationService'
 
 interface LocationFormProps {
-    open: boolean
-    onClose: () => void
+    formId: string
     location: Location | null
+    isSubmitting?: boolean
+    onSubmit: (data: LocationInput) => void
 }
 
 const LOCATION_TYPES: { value: LocationType; label: string }[] = [
@@ -28,7 +25,12 @@ const LOCATION_TYPES: { value: LocationType; label: string }[] = [
     { value: 'RETURN', label: 'Devolución' },
 ]
 
-const LocationForm = ({ open, onClose, location }: LocationFormProps) => {
+const LocationForm = ({
+    formId,
+    location,
+    isSubmitting = false,
+    onSubmit,
+}: LocationFormProps) => {
     const [formData, setFormData] = useState<LocationInput>({
         warehouseId: 0,
         name: '',
@@ -38,43 +40,37 @@ const LocationForm = ({ open, onClose, location }: LocationFormProps) => {
         capacity: null,
     })
 
-    const createLocation = useCreateLocation()
-    const updateLocation = useUpdateLocation()
     const { data: warehousesData } = useWarehouses({ isActive: true })
     const warehouses = warehousesData?.items ?? []
-
-    const isEdit = !!location
-
     const warehouseOptions = warehouses.map((w) => ({
         value: w.id,
         label: w.name,
     }))
 
     useEffect(() => {
-        if (location) {
-            setFormData({
-                warehouseId: location.warehouseId,
-                name: location.name,
-                code: location.code,
-                type: location.type,
-                isActive: location.isActive,
-                capacity: location.capacity ?? null,
-            })
-        } else {
-            setFormData({
-                warehouseId: 0,
-                name: '',
-                code: '',
-                type: 'STORAGE',
-                isActive: true,
-                capacity: null,
-            })
-        }
-    }, [location, open])
+        setFormData(
+            location
+                ? {
+                      warehouseId: location.warehouseId,
+                      name: location.name,
+                      code: location.code,
+                      type: location.type,
+                      isActive: location.isActive,
+                      capacity: location.capacity ?? null,
+                  }
+                : {
+                      warehouseId: 0,
+                      name: '',
+                      code: '',
+                      type: 'STORAGE',
+                      isActive: true,
+                      capacity: null,
+                  }
+        )
+    }, [location])
 
-    const handleSubmit = async (e: React.FormEvent) => {
+    const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault()
-
         if (!formData.warehouseId) {
             toast.push(
                 <Notification title="Error" type="danger">
@@ -84,215 +80,130 @@ const LocationForm = ({ open, onClose, location }: LocationFormProps) => {
             )
             return
         }
-
-        try {
-            const dataToSend = {
-                ...formData,
-                capacity: formData.capacity || null,
-            }
-
-            if (isEdit && location) {
-                await updateLocation.mutateAsync({
-                    id: location.id,
-                    data: dataToSend,
-                })
-            } else {
-                await createLocation.mutateAsync(dataToSend)
-            }
-
-            toast.push(
-                <Notification
-                    title={
-                        isEdit ? 'Ubicación actualizada' : 'Ubicación creada'
-                    }
-                    type="success"
-                >
-                    {isEdit
-                        ? 'La ubicación se actualizó correctamente'
-                        : 'La ubicación se creó correctamente'}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-
-            onClose()
-        } catch (error: unknown) {
-            const errorMessage = getErrorMessage(
-                error,
-                'Error al guardar la ubicación'
-            )
-
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {errorMessage}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-        }
-    }
-
-    const isPending = createLocation.isPending || updateLocation.isPending
-
-    const handleClose = () => {
-        if (!isPending) {
-            onClose()
-        }
+        onSubmit({ ...formData, capacity: formData.capacity || null })
     }
 
     return (
-        <Dialog
-            isOpen={open}
-            onClose={handleClose}
-            onRequestClose={handleClose}
-        >
-            <div className="flex flex-col h-full justify-between">
-                <h5 className="mb-4">
-                    {isEdit ? 'Editar Ubicación' : 'Nueva Ubicación'}
-                </h5>
+        <form id={formId} onSubmit={handleSubmit}>
+            <div className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Bodega <span className="text-red-500">*</span>
+                    </label>
+                    <Select
+                        placeholder="Seleccione una bodega"
+                        value={
+                            warehouseOptions.find(
+                                (opt) => opt.value === formData.warehouseId
+                            ) || null
+                        }
+                        options={warehouseOptions}
+                        onChange={(option) =>
+                            setFormData({
+                                ...formData,
+                                warehouseId: option?.value || 0,
+                            })
+                        }
+                    />
+                </div>
 
-                <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Bodega <span className="text-red-500">*</span>
-                            </label>
-                            <Select
-                                placeholder="Seleccione una bodega"
-                                value={
-                                    warehouseOptions.find(
-                                        (opt) =>
-                                            opt.value === formData.warehouseId
-                                    ) || null
-                                }
-                                options={warehouseOptions}
-                                onChange={(option) =>
-                                    setFormData({
-                                        ...formData,
-                                        warehouseId: option?.value || 0,
-                                    })
-                                }
-                            />
-                        </div>
-
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Nombre{' '}
-                                    <span className="text-red-500">*</span>
-                                </label>
-                                <Input
-                                    required
-                                    type="text"
-                                    placeholder="Ej: Estante A1"
-                                    value={formData.name}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            name: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Código{' '}
-                                    <span className="text-red-500">*</span>
-                                </label>
-                                <Input
-                                    required
-                                    type="text"
-                                    placeholder="Ej: EST-A1"
-                                    value={formData.code}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            code: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-                        </div>
-
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Tipo <span className="text-red-500">*</span>
-                                </label>
-                                <Select
-                                    placeholder="Seleccione un tipo"
-                                    value={
-                                        LOCATION_TYPES.find(
-                                            (opt) => opt.value === formData.type
-                                        ) || null
-                                    }
-                                    options={LOCATION_TYPES}
-                                    onChange={(option) =>
-                                        setFormData({
-                                            ...formData,
-                                            type:
-                                                (option?.value as LocationType) ||
-                                                'STORAGE',
-                                        })
-                                    }
-                                />
-                            </div>
-
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Capacidad
-                                </label>
-                                <Input
-                                    type="number"
-                                    placeholder="Ej: 100"
-                                    value={formData.capacity ?? ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            capacity: e.target.value
-                                                ? Number(e.target.value)
-                                                : null,
-                                        })
-                                    }
-                                />
-                            </div>
-                        </div>
-
-                        <div className="flex items-center gap-3">
-                            <Switcher
-                                checked={formData.isActive}
-                                onChange={(checked) =>
-                                    setFormData({
-                                        ...formData,
-                                        isActive: !checked,
-                                    })
-                                }
-                            />
-                            <label className="text-sm font-medium">
-                                Activo
-                            </label>
-                        </div>
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Nombre <span className="text-red-500">*</span>
+                        </label>
+                        <Input
+                            required
+                            type="text"
+                            placeholder="Ej: Estante A1"
+                            value={formData.name}
+                            disabled={isSubmitting}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    name: e.target.value,
+                                })
+                            }
+                        />
                     </div>
 
-                    <div className="flex justify-end gap-2 mt-6">
-                        <Button
-                            type="button"
-                            variant="plain"
-                            disabled={isPending}
-                            onClick={handleClose}
-                        >
-                            Cancelar
-                        </Button>
-                        <Button
-                            type="submit"
-                            variant="solid"
-                            loading={isPending}
-                        >
-                            {isEdit ? 'Actualizar' : 'Crear'}
-                        </Button>
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Código <span className="text-red-500">*</span>
+                        </label>
+                        <Input
+                            required
+                            type="text"
+                            placeholder="Ej: EST-A1"
+                            value={formData.code}
+                            disabled={isSubmitting}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    code: e.target.value,
+                                })
+                            }
+                        />
                     </div>
-                </form>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Tipo <span className="text-red-500">*</span>
+                        </label>
+                        <Select
+                            placeholder="Seleccione un tipo"
+                            value={
+                                LOCATION_TYPES.find(
+                                    (opt) => opt.value === formData.type
+                                ) || null
+                            }
+                            options={LOCATION_TYPES}
+                            onChange={(option) =>
+                                setFormData({
+                                    ...formData,
+                                    type:
+                                        (option?.value as LocationType) ||
+                                        'STORAGE',
+                                })
+                            }
+                        />
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Capacidad
+                        </label>
+                        <Input
+                            type="number"
+                            placeholder="Ej: 100"
+                            value={formData.capacity ?? ''}
+                            disabled={isSubmitting}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    capacity: e.target.value
+                                        ? Number(e.target.value)
+                                        : null,
+                                })
+                            }
+                        />
+                    </div>
+                </div>
+
+                <div className="flex items-center gap-3">
+                    <Switcher
+                        checked={formData.isActive}
+                        disabled={isSubmitting}
+                        onChange={(checked) =>
+                            setFormData({ ...formData, isActive: !checked })
+                        }
+                    />
+                    <label className="text-sm font-medium">Activo</label>
+                </div>
             </div>
-        </Dialog>
+        </form>
     )
 }
 

--- a/src/views/inventory/LocationsView/index.tsx
+++ b/src/views/inventory/LocationsView/index.tsx
@@ -1,15 +1,20 @@
-import { useState } from 'react'
 import DataTable, { ColumnDef } from '@/components/shared/DataTable'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
-import Dialog from '@/components/ui/Dialog'
 import Badge from '@/components/ui/Badge'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
-import { useLocations, useDeleteLocation } from '@/hooks/useLocations'
+import {
+    useLocations,
+    useDeleteLocation,
+    useCreateLocation,
+    useUpdateLocation,
+} from '@/hooks/useLocations'
 import { getErrorMessage } from '@/utils/getErrorMessage'
 import { useWarehouses } from '@/hooks/useWarehouses'
-import type { Location } from '@/services/LocationService'
+import { useCrudOperations } from '@/hooks'
+import { FormModal, DeleteConfirmDialog } from '@/components/shared'
+import type { Location, LocationInput } from '@/services/LocationService'
 import LocationForm from './LocationForm'
 import { HiOutlinePencil, HiOutlineTrash, HiPlus } from 'react-icons/hi'
 
@@ -21,73 +26,74 @@ const LOCATION_TYPE_LABELS: Record<string, string> = {
 }
 
 const LocationsView = () => {
-    const [isFormOpen, setIsFormOpen] = useState(false)
-    const [selectedLocation, setSelectedLocation] = useState<Location | null>(
-        null
-    )
-    const [deleteDialog, setDeleteDialog] = useState<{
-        open: boolean
-        location: Location | null
-    }>({ open: false, location: null })
+    const crud = useCrudOperations<Location>()
+    const offset = (crud.pageIndex - 1) * crud.pageSize
 
-    const [pageIndex, setPageIndex] = useState(1)
-    const [pageSize, setPageSize] = useState(10)
-    const offset = (pageIndex - 1) * pageSize
-
-    const { data, isLoading } = useLocations({ limit: pageSize, offset })
+    const { data, isLoading } = useLocations({ limit: crud.pageSize, offset })
     const locations = data?.items ?? []
     const total = data?.pagination?.total ?? 0
 
     const { data: warehousesData } = useWarehouses()
     const warehouses = warehousesData?.items ?? []
-    const deleteLocation = useDeleteLocation()
-
     const warehouseMap = new Map(warehouses.map((w) => [w.id, w.name]))
 
-    const handleCreate = () => {
-        setSelectedLocation(null)
-        setIsFormOpen(true)
-    }
+    const deleteLocation = useDeleteLocation()
+    const createLocation = useCreateLocation()
+    const updateLocation = useUpdateLocation()
+    const isPending = createLocation.isPending || updateLocation.isPending
 
-    const handleEdit = (location: Location) => {
-        setSelectedLocation(location)
-        setIsFormOpen(true)
-    }
-
-    const handleDeleteClick = (location: Location) => {
-        setDeleteDialog({ open: true, location })
-    }
-
-    const handleDeleteConfirm = async () => {
-        if (deleteDialog.location) {
-            try {
-                await deleteLocation.mutateAsync(deleteDialog.location.id)
+    const handleFormSubmit = async (formData: LocationInput) => {
+        try {
+            if (crud.isEditOpen && crud.selectedItem) {
+                await updateLocation.mutateAsync({
+                    id: crud.selectedItem.id,
+                    data: formData,
+                })
                 toast.push(
-                    <Notification title="Ubicación eliminada" type="success">
-                        La ubicación se eliminó correctamente
+                    <Notification title="Ubicación actualizada" type="success">
+                        La ubicación se actualizó correctamente
                     </Notification>,
                     { placement: 'top-center' }
                 )
-                setDeleteDialog({ open: false, location: null })
-            } catch (error: unknown) {
-                const errorMessage = getErrorMessage(
-                    error,
-                    'Error al eliminar la ubicación'
-                )
-
+            } else {
+                await createLocation.mutateAsync(formData)
                 toast.push(
-                    <Notification title="Error" type="danger">
-                        {errorMessage}
+                    <Notification title="Ubicación creada" type="success">
+                        La ubicación se creó correctamente
                     </Notification>,
                     { placement: 'top-center' }
                 )
             }
+            crud.closeAll()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al guardar la ubicación')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
         }
     }
 
-    const handleFormClose = () => {
-        setIsFormOpen(false)
-        setSelectedLocation(null)
+    const handleDeleteConfirm = async () => {
+        if (!crud.selectedItem) return
+        try {
+            await deleteLocation.mutateAsync(crud.selectedItem.id)
+            toast.push(
+                <Notification title="Ubicación eliminada" type="success">
+                    La ubicación se eliminó correctamente
+                </Notification>,
+                { placement: 'top-center' }
+            )
+            crud.closeAll()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al eliminar la ubicación')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
     }
 
     const columns: ColumnDef<Location>[] = [
@@ -191,13 +197,13 @@ const LocationsView = () => {
                             size="sm"
                             variant="plain"
                             icon={<HiOutlinePencil />}
-                            onClick={() => handleEdit(row.original)}
+                            onClick={() => crud.openEdit(row.original)}
                         />
                         <Button
                             size="sm"
                             variant="plain"
                             icon={<HiOutlineTrash />}
-                            onClick={() => handleDeleteClick(row.original)}
+                            onClick={() => crud.openDelete(row.original)}
                         />
                     </div>
                 )
@@ -222,7 +228,7 @@ const LocationsView = () => {
                             variant="solid"
                             size="sm"
                             icon={<HiPlus />}
-                            onClick={handleCreate}
+                            onClick={crud.openCreate}
                         >
                             Nueva Ubicación
                         </Button>
@@ -232,57 +238,47 @@ const LocationsView = () => {
                         columns={columns}
                         data={locations}
                         loading={isLoading}
-                        pagingData={{ total, pageIndex, pageSize }}
-                        onPaginationChange={setPageIndex}
-                        onSelectChange={(size) => {
-                            setPageSize(size)
-                            setPageIndex(1)
+                        pagingData={{
+                            total,
+                            pageIndex: crud.pageIndex,
+                            pageSize: crud.pageSize,
                         }}
+                        onPaginationChange={(idx) =>
+                            crud.onPaginationChange(idx, crud.pageSize)
+                        }
+                        onSelectChange={(size) =>
+                            crud.onPaginationChange(1, size)
+                        }
                     />
                 </div>
             </Card>
 
-            <LocationForm
-                open={isFormOpen}
-                location={selectedLocation}
-                onClose={handleFormClose}
-            />
-
-            <Dialog
-                isOpen={deleteDialog.open}
-                onClose={() => setDeleteDialog({ open: false, location: null })}
-                onRequestClose={() =>
-                    setDeleteDialog({ open: false, location: null })
-                }
+            <FormModal
+                formId="location-form"
+                isOpen={crud.isCreateOpen || crud.isEditOpen}
+                title={crud.isEditOpen ? 'Editar Ubicación' : 'Nueva Ubicación'}
+                isSubmitting={isPending}
+                onClose={crud.closeAll}
             >
-                <h5 className="mb-4">Confirmar Eliminación</h5>
-                <p className="mb-6">
-                    ¿Estás seguro de que deseas eliminar la ubicación{' '}
-                    <strong>
-                        {deleteDialog.location?.name} (
-                        {deleteDialog.location?.code})
-                    </strong>
-                    ? Esta acción no se puede deshacer.
-                </p>
-                <div className="flex justify-end gap-2">
-                    <Button
-                        variant="plain"
-                        disabled={deleteLocation.isPending}
-                        onClick={() =>
-                            setDeleteDialog({ open: false, location: null })
-                        }
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        variant="solid"
-                        loading={deleteLocation.isPending}
-                        onClick={handleDeleteConfirm}
-                    >
-                        Eliminar
-                    </Button>
-                </div>
-            </Dialog>
+                <LocationForm
+                    formId="location-form"
+                    location={crud.selectedItem}
+                    isSubmitting={isPending}
+                    onSubmit={handleFormSubmit}
+                />
+            </FormModal>
+
+            <DeleteConfirmDialog
+                isOpen={crud.isDeleteOpen}
+                itemName={
+                    crud.selectedItem
+                        ? `${crud.selectedItem.name} (${crud.selectedItem.code})`
+                        : undefined
+                }
+                isDeleting={deleteLocation.isPending}
+                onClose={crud.closeAll}
+                onConfirm={handleDeleteConfirm}
+            />
         </>
     )
 }

--- a/src/views/inventory/UnitsOfMeasureView/UnitOfMeasureForm.tsx
+++ b/src/views/inventory/UnitsOfMeasureView/UnitOfMeasureForm.tsx
@@ -1,30 +1,23 @@
 import { useState, useEffect } from 'react'
-import Dialog from '@/components/ui/Dialog'
 import Input from '@/components/ui/Input'
-import Button from '@/components/ui/Button'
 import Switcher from '@/components/ui/Switcher'
-import Notification from '@/components/ui/Notification'
-import toast from '@/components/ui/toast'
-import {
-    useCreateUnitOfMeasure,
-    useUpdateUnitOfMeasure,
-} from '@/hooks/useUnitsOfMeasure'
-import { getErrorMessage } from '@/utils/getErrorMessage'
 import type {
     UnitOfMeasure,
     UnitOfMeasureInput,
 } from '@/services/UnitOfMeasureService'
 
 interface UnitOfMeasureFormProps {
-    open: boolean
-    onClose: () => void
+    formId: string
     unitOfMeasure: UnitOfMeasure | null
+    isSubmitting?: boolean
+    onSubmit: (data: UnitOfMeasureInput) => void
 }
 
 const UnitOfMeasureForm = ({
-    open,
-    onClose,
+    formId,
     unitOfMeasure,
+    isSubmitting = false,
+    onSubmit,
 }: UnitOfMeasureFormProps) => {
     const [formData, setFormData] = useState<UnitOfMeasureInput>({
         name: '',
@@ -33,183 +26,91 @@ const UnitOfMeasureForm = ({
         isActive: true,
     })
 
-    const createUnit = useCreateUnitOfMeasure()
-    const updateUnit = useUpdateUnitOfMeasure()
-
-    const isEdit = !!unitOfMeasure
-
     useEffect(() => {
-        if (unitOfMeasure) {
-            setFormData({
-                name: unitOfMeasure.name,
-                symbol: unitOfMeasure.symbol,
-                description: unitOfMeasure.description || '',
-                isActive: unitOfMeasure.isActive,
-            })
-        } else {
-            setFormData({
-                name: '',
-                symbol: '',
-                description: '',
-                isActive: true,
-            })
-        }
-    }, [unitOfMeasure, open])
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-
-        try {
-            if (isEdit && unitOfMeasure) {
-                await updateUnit.mutateAsync({
-                    id: unitOfMeasure.id,
-                    data: formData,
-                })
-            } else {
-                await createUnit.mutateAsync(formData)
-            }
-
-            toast.push(
-                <Notification
-                    title={isEdit ? 'Unidad actualizada' : 'Unidad creada'}
-                    type="success"
-                >
-                    {isEdit
-                        ? 'La unidad de medida se actualizó correctamente'
-                        : 'La unidad de medida se creó correctamente'}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-
-            onClose()
-        } catch (error: unknown) {
-            const errorMessage = getErrorMessage(
-                error,
-                'Error al guardar la unidad de medida'
-            )
-
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {errorMessage}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-        }
-    }
-
-    const isPending = createUnit.isPending || updateUnit.isPending
-
-    const handleClose = () => {
-        if (!isPending) {
-            onClose()
-        }
-    }
+        setFormData(
+            unitOfMeasure
+                ? {
+                      name: unitOfMeasure.name,
+                      symbol: unitOfMeasure.symbol,
+                      description: unitOfMeasure.description || '',
+                      isActive: unitOfMeasure.isActive,
+                  }
+                : { name: '', symbol: '', description: '', isActive: true }
+        )
+    }, [unitOfMeasure])
 
     return (
-        <Dialog
-            isOpen={open}
-            onClose={handleClose}
-            onRequestClose={handleClose}
+        <form
+            id={formId}
+            onSubmit={(e) => {
+                e.preventDefault()
+                onSubmit(formData)
+            }}
         >
-            <div className="flex flex-col h-full justify-between">
-                <h5 className="mb-4">
-                    {isEdit
-                        ? 'Editar Unidad de Medida'
-                        : 'Nueva Unidad de Medida'}
-                </h5>
+            <div className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Nombre <span className="text-red-500">*</span>
+                    </label>
+                    <Input
+                        required
+                        type="text"
+                        placeholder="Ej: Kilogramo"
+                        value={formData.name}
+                        disabled={isSubmitting}
+                        onChange={(e) =>
+                            setFormData({ ...formData, name: e.target.value })
+                        }
+                    />
+                </div>
 
-                <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Nombre <span className="text-red-500">*</span>
-                            </label>
-                            <Input
-                                required
-                                type="text"
-                                placeholder="Ej: Kilogramo"
-                                value={formData.name}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        name: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Símbolo <span className="text-red-500">*</span>
+                    </label>
+                    <Input
+                        required
+                        type="text"
+                        placeholder="Ej: kg"
+                        value={formData.symbol}
+                        disabled={isSubmitting}
+                        onChange={(e) =>
+                            setFormData({ ...formData, symbol: e.target.value })
+                        }
+                    />
+                </div>
 
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Símbolo <span className="text-red-500">*</span>
-                            </label>
-                            <Input
-                                required
-                                type="text"
-                                placeholder="Ej: kg"
-                                value={formData.symbol}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        symbol: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Descripción
+                    </label>
+                    <Input
+                        textArea
+                        placeholder="Descripción de la unidad"
+                        value={formData.description || ''}
+                        style={{ minHeight: '80px' }}
+                        disabled={isSubmitting}
+                        onChange={(e) =>
+                            setFormData({
+                                ...formData,
+                                description: e.target.value,
+                            })
+                        }
+                    />
+                </div>
 
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Descripción
-                            </label>
-                            <Input
-                                textArea
-                                placeholder="Descripción de la unidad"
-                                value={formData.description || ''}
-                                style={{ minHeight: '80px' }}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        description: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
-
-                        <div className="flex items-center gap-3">
-                            <Switcher
-                                checked={formData.isActive}
-                                onChange={(checked) =>
-                                    setFormData({
-                                        ...formData,
-                                        isActive: checked,
-                                    })
-                                }
-                            />
-                            <label className="text-sm font-medium">
-                                Activo
-                            </label>
-                        </div>
-                    </div>
-
-                    <div className="flex justify-end gap-2 mt-6">
-                        <Button
-                            type="button"
-                            variant="plain"
-                            disabled={isPending}
-                            onClick={handleClose}
-                        >
-                            Cancelar
-                        </Button>
-                        <Button
-                            type="submit"
-                            variant="solid"
-                            loading={isPending}
-                        >
-                            {isEdit ? 'Actualizar' : 'Crear'}
-                        </Button>
-                    </div>
-                </form>
+                <div className="flex items-center gap-3">
+                    <Switcher
+                        checked={formData.isActive}
+                        disabled={isSubmitting}
+                        onChange={(checked) =>
+                            setFormData({ ...formData, isActive: checked })
+                        }
+                    />
+                    <label className="text-sm font-medium">Activo</label>
+                </div>
             </div>
-        </Dialog>
+        </form>
     )
 }
 

--- a/src/views/inventory/UnitsOfMeasureView/index.tsx
+++ b/src/views/inventory/UnitsOfMeasureView/index.tsx
@@ -3,81 +3,97 @@ import { HiOutlinePencil, HiOutlineTrash, HiPlus } from 'react-icons/hi'
 import {
     useDeleteUnitOfMeasure,
     useUnitsOfMeasure,
+    useCreateUnitOfMeasure,
+    useUpdateUnitOfMeasure,
 } from '@/hooks/useUnitsOfMeasure'
-
 import Badge from '@/components/ui/Badge'
 import Button from '@/components/ui/Button'
 import Card from '@/components/ui/Card'
-import Dialog from '@/components/ui/Dialog'
 import Notification from '@/components/ui/Notification'
-import type { UnitOfMeasure } from '@/services/UnitOfMeasureService'
+import type {
+    UnitOfMeasure,
+    UnitOfMeasureInput,
+} from '@/services/UnitOfMeasureService'
 import UnitOfMeasureForm from './UnitOfMeasureForm'
 import { getErrorMessage } from '@/utils/getErrorMessage'
 import toast from '@/components/ui/toast'
-import { useState } from 'react'
+import { useCrudOperations } from '@/hooks'
+import { FormModal, DeleteConfirmDialog } from '@/components/shared'
 
 const UnitsOfMeasureView = () => {
-    const [isFormOpen, setIsFormOpen] = useState(false)
-    const [selectedUnit, setSelectedUnit] = useState<UnitOfMeasure | null>(null)
-    const [deleteDialog, setDeleteDialog] = useState<{
-        open: boolean
-        unit: UnitOfMeasure | null
-    }>({ open: false, unit: null })
+    const crud = useCrudOperations<UnitOfMeasure>()
+    const offset = (crud.pageIndex - 1) * crud.pageSize
 
-    const [pageIndex, setPageIndex] = useState(1)
-    const [pageSize, setPageSize] = useState(10)
-    const offset = (pageIndex - 1) * pageSize
-
-    const { data, isLoading } = useUnitsOfMeasure({ limit: pageSize, offset })
+    const { data, isLoading } = useUnitsOfMeasure({
+        limit: crud.pageSize,
+        offset,
+    })
     const units = data?.items ?? []
     const total = data?.pagination?.total ?? 0
+
     const deleteUnit = useDeleteUnitOfMeasure()
+    const createUnit = useCreateUnitOfMeasure()
+    const updateUnit = useUpdateUnitOfMeasure()
+    const isPending = createUnit.isPending || updateUnit.isPending
 
-    const handleCreate = () => {
-        setSelectedUnit(null)
-        setIsFormOpen(true)
-    }
-
-    const handleEdit = (unit: UnitOfMeasure) => {
-        setSelectedUnit(unit)
-        setIsFormOpen(true)
-    }
-
-    const handleDeleteClick = (unit: UnitOfMeasure) => {
-        setDeleteDialog({ open: true, unit })
-    }
-
-    const handleDeleteConfirm = async () => {
-        if (deleteDialog.unit) {
-            try {
-                await deleteUnit.mutateAsync(deleteDialog.unit.id)
+    const handleFormSubmit = async (formData: UnitOfMeasureInput) => {
+        try {
+            if (crud.isEditOpen && crud.selectedItem) {
+                await updateUnit.mutateAsync({
+                    id: crud.selectedItem.id,
+                    data: formData,
+                })
                 toast.push(
-                    <Notification title="Unidad eliminada" type="success">
-                        La unidad de medida se eliminó correctamente
+                    <Notification title="Unidad actualizada" type="success">
+                        La unidad de medida se actualizó correctamente
                     </Notification>,
                     { placement: 'top-center' }
                 )
-                setDeleteDialog({ open: false, unit: null })
-            } catch (error: unknown) {
-                console.log('Error deleting unit of measure:', error)
-                const errorMessage = getErrorMessage(
-                    error,
-                    'Error al eliminar la unidad de medida'
-                )
-
+            } else {
+                await createUnit.mutateAsync(formData)
                 toast.push(
-                    <Notification title="Error" type="danger">
-                        {errorMessage}
+                    <Notification title="Unidad creada" type="success">
+                        La unidad de medida se creó correctamente
                     </Notification>,
                     { placement: 'top-center' }
                 )
             }
+            crud.closeAll()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(
+                        error,
+                        'Error al guardar la unidad de medida'
+                    )}
+                </Notification>,
+                { placement: 'top-center' }
+            )
         }
     }
 
-    const handleFormClose = () => {
-        setIsFormOpen(false)
-        setSelectedUnit(null)
+    const handleDeleteConfirm = async () => {
+        if (!crud.selectedItem) return
+        try {
+            await deleteUnit.mutateAsync(crud.selectedItem.id)
+            toast.push(
+                <Notification title="Unidad eliminada" type="success">
+                    La unidad de medida se eliminó correctamente
+                </Notification>,
+                { placement: 'top-center' }
+            )
+            crud.closeAll()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(
+                        error,
+                        'Error al eliminar la unidad de medida'
+                    )}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
     }
 
     const columns: ColumnDef<UnitOfMeasure>[] = [
@@ -151,13 +167,13 @@ const UnitsOfMeasureView = () => {
                             size="sm"
                             variant="plain"
                             icon={<HiOutlinePencil />}
-                            onClick={() => handleEdit(row.original)}
+                            onClick={() => crud.openEdit(row.original)}
                         />
                         <Button
                             size="sm"
                             variant="plain"
                             icon={<HiOutlineTrash />}
-                            onClick={() => handleDeleteClick(row.original)}
+                            onClick={() => crud.openDelete(row.original)}
                         />
                     </div>
                 )
@@ -182,7 +198,7 @@ const UnitsOfMeasureView = () => {
                             variant="solid"
                             size="sm"
                             icon={<HiPlus />}
-                            onClick={handleCreate}
+                            onClick={crud.openCreate}
                         >
                             Nueva Unidad
                         </Button>
@@ -192,56 +208,51 @@ const UnitsOfMeasureView = () => {
                         columns={columns}
                         data={units}
                         loading={isLoading}
-                        pagingData={{ total, pageIndex, pageSize }}
-                        onPaginationChange={setPageIndex}
-                        onSelectChange={(size) => {
-                            setPageSize(size)
-                            setPageIndex(1)
+                        pagingData={{
+                            total,
+                            pageIndex: crud.pageIndex,
+                            pageSize: crud.pageSize,
                         }}
+                        onPaginationChange={(idx) =>
+                            crud.onPaginationChange(idx, crud.pageSize)
+                        }
+                        onSelectChange={(size) =>
+                            crud.onPaginationChange(1, size)
+                        }
                     />
                 </div>
             </Card>
 
-            <UnitOfMeasureForm
-                open={isFormOpen}
-                unitOfMeasure={selectedUnit}
-                onClose={handleFormClose}
-            />
-
-            <Dialog
-                isOpen={deleteDialog.open}
-                onClose={() => setDeleteDialog({ open: false, unit: null })}
-                onRequestClose={() =>
-                    setDeleteDialog({ open: false, unit: null })
+            <FormModal
+                formId="unit-of-measure-form"
+                isOpen={crud.isCreateOpen || crud.isEditOpen}
+                title={
+                    crud.isEditOpen
+                        ? 'Editar Unidad de Medida'
+                        : 'Nueva Unidad de Medida'
                 }
+                isSubmitting={isPending}
+                onClose={crud.closeAll}
             >
-                <h5 className="mb-4">Confirmar Eliminación</h5>
-                <p className="mb-6">
-                    ¿Estás seguro de que deseas eliminar la unidad{' '}
-                    <strong>
-                        {deleteDialog.unit?.name} ({deleteDialog.unit?.symbol})
-                    </strong>
-                    ? Esta acción no se puede deshacer.
-                </p>
-                <div className="flex justify-end gap-2">
-                    <Button
-                        variant="plain"
-                        disabled={deleteUnit.isPending}
-                        onClick={() =>
-                            setDeleteDialog({ open: false, unit: null })
-                        }
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        variant="solid"
-                        loading={deleteUnit.isPending}
-                        onClick={handleDeleteConfirm}
-                    >
-                        Eliminar
-                    </Button>
-                </div>
-            </Dialog>
+                <UnitOfMeasureForm
+                    formId="unit-of-measure-form"
+                    unitOfMeasure={crud.selectedItem}
+                    isSubmitting={isPending}
+                    onSubmit={handleFormSubmit}
+                />
+            </FormModal>
+
+            <DeleteConfirmDialog
+                isOpen={crud.isDeleteOpen}
+                itemName={
+                    crud.selectedItem
+                        ? `${crud.selectedItem.name} (${crud.selectedItem.symbol})`
+                        : undefined
+                }
+                isDeleting={deleteUnit.isPending}
+                onClose={crud.closeAll}
+                onConfirm={handleDeleteConfirm}
+            />
         </>
     )
 }

--- a/src/views/inventory/WarehousesView/WarehouseForm.tsx
+++ b/src/views/inventory/WarehousesView/WarehouseForm.tsx
@@ -1,21 +1,21 @@
 import { useState, useEffect } from 'react'
-import Dialog from '@/components/ui/Dialog'
 import Input from '@/components/ui/Input'
-import Button from '@/components/ui/Button'
 import Switcher from '@/components/ui/Switcher'
-import Notification from '@/components/ui/Notification'
-import toast from '@/components/ui/toast'
-import { useCreateWarehouse, useUpdateWarehouse } from '@/hooks/useWarehouses'
-import { getErrorMessage } from '@/utils/getErrorMessage'
 import type { Warehouse, WarehouseInput } from '@/services/WarehouseService'
 
 interface WarehouseFormProps {
-    open: boolean
-    onClose: () => void
+    formId: string
     warehouse: Warehouse | null
+    isSubmitting?: boolean
+    onSubmit: (data: WarehouseInput) => void
 }
 
-const WarehouseForm = ({ open, onClose, warehouse }: WarehouseFormProps) => {
+const WarehouseForm = ({
+    formId,
+    warehouse,
+    isSubmitting = false,
+    onSubmit,
+}: WarehouseFormProps) => {
     const [formData, setFormData] = useState<WarehouseInput>({
         name: '',
         code: '',
@@ -29,303 +29,216 @@ const WarehouseForm = ({ open, onClose, warehouse }: WarehouseFormProps) => {
         email: '',
     })
 
-    const createWarehouse = useCreateWarehouse()
-    const updateWarehouse = useUpdateWarehouse()
-
-    const isEdit = !!warehouse
-
     useEffect(() => {
-        if (warehouse) {
-            setFormData({
-                name: warehouse.name,
-                code: warehouse.code,
-                address: warehouse.address || '',
-                city: warehouse.city || '',
-                country: warehouse.country || '',
-                isActive: warehouse.isActive,
-                isDefault: warehouse.isDefault,
-                manager: warehouse.manager || '',
-                phone: warehouse.phone || '',
-                email: warehouse.email || '',
-            })
-        } else {
-            setFormData({
-                name: '',
-                code: '',
-                address: '',
-                city: '',
-                country: '',
-                isActive: true,
-                isDefault: false,
-                manager: '',
-                phone: '',
-                email: '',
-            })
-        }
-    }, [warehouse, open])
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-
-        try {
-            if (isEdit && warehouse) {
-                await updateWarehouse.mutateAsync({
-                    id: warehouse.id,
-                    data: formData,
-                })
-            } else {
-                await createWarehouse.mutateAsync(formData)
-            }
-
-            toast.push(
-                <Notification
-                    title={isEdit ? 'Bodega actualizada' : 'Bodega creada'}
-                    type="success"
-                >
-                    {isEdit
-                        ? 'La bodega se actualizó correctamente'
-                        : 'La bodega se creó correctamente'}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-
-            onClose()
-        } catch (error: unknown) {
-            const errorMessage = getErrorMessage(
-                error,
-                'Error al guardar la bodega'
-            )
-
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {errorMessage}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-        }
-    }
-
-    const isPending = createWarehouse.isPending || updateWarehouse.isPending
-
-    const handleClose = () => {
-        if (!isPending) {
-            onClose()
-        }
-    }
+        setFormData(
+            warehouse
+                ? {
+                      name: warehouse.name,
+                      code: warehouse.code,
+                      address: warehouse.address || '',
+                      city: warehouse.city || '',
+                      country: warehouse.country || '',
+                      isActive: warehouse.isActive,
+                      isDefault: warehouse.isDefault,
+                      manager: warehouse.manager || '',
+                      phone: warehouse.phone || '',
+                      email: warehouse.email || '',
+                  }
+                : {
+                      name: '',
+                      code: '',
+                      address: '',
+                      city: '',
+                      country: '',
+                      isActive: true,
+                      isDefault: false,
+                      manager: '',
+                      phone: '',
+                      email: '',
+                  }
+        )
+    }, [warehouse])
 
     return (
-        <Dialog
-            isOpen={open}
-            width={600}
-            onClose={handleClose}
-            onRequestClose={handleClose}
+        <form
+            id={formId}
+            onSubmit={(e) => {
+                e.preventDefault()
+                onSubmit(formData)
+            }}
         >
-            <div className="flex flex-col h-full justify-between">
-                <h5 className="mb-4">
-                    {isEdit ? 'Editar Bodega' : 'Nueva Bodega'}
-                </h5>
-
-                <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Nombre{' '}
-                                    <span className="text-red-500">*</span>
-                                </label>
-                                <Input
-                                    required
-                                    type="text"
-                                    placeholder="Ej: Bodega Principal"
-                                    value={formData.name}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            name: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Código{' '}
-                                    <span className="text-red-500">*</span>
-                                </label>
-                                <Input
-                                    required
-                                    type="text"
-                                    placeholder="Ej: BOD-001"
-                                    value={formData.code}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            code: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-                        </div>
-
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Dirección
-                            </label>
-                            <Input
-                                type="text"
-                                placeholder="Dirección de la bodega"
-                                value={formData.address || ''}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        address: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
-
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Ciudad
-                                </label>
-                                <Input
-                                    type="text"
-                                    placeholder="Ej: Quito"
-                                    value={formData.city || ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            city: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    País
-                                </label>
-                                <Input
-                                    type="text"
-                                    placeholder="Ej: Ecuador"
-                                    value={formData.country || ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            country: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-                        </div>
-
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Responsable
-                                </label>
-                                <Input
-                                    type="text"
-                                    placeholder="Nombre del responsable"
-                                    value={formData.manager || ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            manager: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Teléfono
-                                </label>
-                                <Input
-                                    type="text"
-                                    placeholder="Ej: +593 99 999 9999"
-                                    value={formData.phone || ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            phone: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-                        </div>
-
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Email
-                            </label>
-                            <Input
-                                type="email"
-                                placeholder="bodega@ejemplo.com"
-                                value={formData.email || ''}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        email: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
-
-                        <div className="flex items-center gap-6">
-                            <div className="flex items-center gap-3">
-                                <Switcher
-                                    checked={formData.isActive}
-                                    onChange={(checked) =>
-                                        setFormData({
-                                            ...formData,
-                                            isActive: !checked,
-                                        })
-                                    }
-                                />
-                                <label className="text-sm font-medium">
-                                    Activo
-                                </label>
-                            </div>
-
-                            <div className="flex items-center gap-3">
-                                <Switcher
-                                    checked={formData.isDefault}
-                                    onChange={(checked) =>
-                                        setFormData({
-                                            ...formData,
-                                            isDefault: !checked,
-                                        })
-                                    }
-                                />
-                                <label className="text-sm font-medium">
-                                    Por defecto
-                                </label>
-                            </div>
-                        </div>
+            <div className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Nombre <span className="text-red-500">*</span>
+                        </label>
+                        <Input
+                            required
+                            type="text"
+                            placeholder="Ej: Bodega Principal"
+                            value={formData.name}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    name: e.target.value,
+                                })
+                            }
+                        />
                     </div>
 
-                    <div className="flex justify-end gap-2 mt-6">
-                        <Button
-                            type="button"
-                            variant="plain"
-                            disabled={isPending}
-                            onClick={handleClose}
-                        >
-                            Cancelar
-                        </Button>
-                        <Button
-                            type="submit"
-                            variant="solid"
-                            loading={isPending}
-                        >
-                            {isEdit ? 'Actualizar' : 'Crear'}
-                        </Button>
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Código <span className="text-red-500">*</span>
+                        </label>
+                        <Input
+                            required
+                            type="text"
+                            placeholder="Ej: BOD-001"
+                            value={formData.code}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    code: e.target.value,
+                                })
+                            }
+                        />
                     </div>
-                </form>
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Dirección
+                    </label>
+                    <Input
+                        type="text"
+                        placeholder="Dirección de la bodega"
+                        value={formData.address || ''}
+                        onChange={(e) =>
+                            setFormData({
+                                ...formData,
+                                address: e.target.value,
+                            })
+                        }
+                    />
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Ciudad
+                        </label>
+                        <Input
+                            type="text"
+                            placeholder="Ej: Quito"
+                            value={formData.city || ''}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    city: e.target.value,
+                                })
+                            }
+                        />
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            País
+                        </label>
+                        <Input
+                            type="text"
+                            placeholder="Ej: Ecuador"
+                            value={formData.country || ''}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    country: e.target.value,
+                                })
+                            }
+                        />
+                    </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Responsable
+                        </label>
+                        <Input
+                            type="text"
+                            placeholder="Nombre del responsable"
+                            value={formData.manager || ''}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    manager: e.target.value,
+                                })
+                            }
+                        />
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Teléfono
+                        </label>
+                        <Input
+                            type="text"
+                            placeholder="Ej: +593 99 999 9999"
+                            value={formData.phone || ''}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    phone: e.target.value,
+                                })
+                            }
+                        />
+                    </div>
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Email
+                    </label>
+                    <Input
+                        type="email"
+                        placeholder="bodega@ejemplo.com"
+                        value={formData.email || ''}
+                        onChange={(e) =>
+                            setFormData({ ...formData, email: e.target.value })
+                        }
+                    />
+                </div>
+
+                <div className="flex items-center gap-6">
+                    <div className="flex items-center gap-3">
+                        <Switcher
+                            checked={formData.isActive}
+                            disabled={isSubmitting}
+                            onChange={(checked) =>
+                                setFormData({ ...formData, isActive: !checked })
+                            }
+                        />
+                        <label className="text-sm font-medium">Activo</label>
+                    </div>
+
+                    <div className="flex items-center gap-3">
+                        <Switcher
+                            checked={formData.isDefault}
+                            disabled={isSubmitting}
+                            onChange={(checked) =>
+                                setFormData({
+                                    ...formData,
+                                    isDefault: !checked,
+                                })
+                            }
+                        />
+                        <label className="text-sm font-medium">
+                            Por defecto
+                        </label>
+                    </div>
+                </div>
             </div>
-        </Dialog>
+        </form>
     )
 }
 

--- a/src/views/inventory/WarehousesView/index.tsx
+++ b/src/views/inventory/WarehousesView/index.tsx
@@ -1,79 +1,87 @@
-import { useState } from 'react'
 import DataTable, { ColumnDef } from '@/components/shared/DataTable'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
-import Dialog from '@/components/ui/Dialog'
 import Badge from '@/components/ui/Badge'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
-import { useWarehouses, useDeleteWarehouse } from '@/hooks/useWarehouses'
+import {
+    useWarehouses,
+    useDeleteWarehouse,
+    useCreateWarehouse,
+    useUpdateWarehouse,
+} from '@/hooks/useWarehouses'
 import { getErrorMessage } from '@/utils/getErrorMessage'
-import type { Warehouse } from '@/services/WarehouseService'
+import { useCrudOperations } from '@/hooks'
+import { FormModal, DeleteConfirmDialog } from '@/components/shared'
+import type { Warehouse, WarehouseInput } from '@/services/WarehouseService'
 import WarehouseForm from './WarehouseForm'
 import { HiOutlinePencil, HiOutlineTrash, HiPlus } from 'react-icons/hi'
 
 const WarehousesView = () => {
-    const [isFormOpen, setIsFormOpen] = useState(false)
-    const [selectedWarehouse, setSelectedWarehouse] =
-        useState<Warehouse | null>(null)
-    const [deleteDialog, setDeleteDialog] = useState<{
-        open: boolean
-        warehouse: Warehouse | null
-    }>({ open: false, warehouse: null })
+    const crud = useCrudOperations<Warehouse>()
+    const offset = (crud.pageIndex - 1) * crud.pageSize
 
-    const [pageIndex, setPageIndex] = useState(1)
-    const [pageSize, setPageSize] = useState(10)
-    const offset = (pageIndex - 1) * pageSize
-
-    const { data, isLoading } = useWarehouses({ limit: pageSize, offset })
+    const { data, isLoading } = useWarehouses({ limit: crud.pageSize, offset })
     const warehouses = data?.items ?? []
     const total = data?.pagination?.total ?? 0
+
     const deleteWarehouse = useDeleteWarehouse()
+    const createWarehouse = useCreateWarehouse()
+    const updateWarehouse = useUpdateWarehouse()
+    const isPending = createWarehouse.isPending || updateWarehouse.isPending
 
-    const handleCreate = () => {
-        setSelectedWarehouse(null)
-        setIsFormOpen(true)
-    }
-
-    const handleEdit = (warehouse: Warehouse) => {
-        setSelectedWarehouse(warehouse)
-        setIsFormOpen(true)
-    }
-
-    const handleDeleteClick = (warehouse: Warehouse) => {
-        setDeleteDialog({ open: true, warehouse })
-    }
-
-    const handleDeleteConfirm = async () => {
-        if (deleteDialog.warehouse) {
-            try {
-                await deleteWarehouse.mutateAsync(deleteDialog.warehouse.id)
+    const handleFormSubmit = async (formData: WarehouseInput) => {
+        try {
+            if (crud.isEditOpen && crud.selectedItem) {
+                await updateWarehouse.mutateAsync({
+                    id: crud.selectedItem.id,
+                    data: formData,
+                })
                 toast.push(
-                    <Notification title="Bodega eliminada" type="success">
-                        La bodega se eliminó correctamente
+                    <Notification title="Bodega actualizada" type="success">
+                        La bodega se actualizó correctamente
                     </Notification>,
                     { placement: 'top-center' }
                 )
-                setDeleteDialog({ open: false, warehouse: null })
-            } catch (error: unknown) {
-                const errorMessage = getErrorMessage(
-                    error,
-                    'Error al eliminar la bodega'
-                )
-
+            } else {
+                await createWarehouse.mutateAsync(formData)
                 toast.push(
-                    <Notification title="Error" type="danger">
-                        {errorMessage}
+                    <Notification title="Bodega creada" type="success">
+                        La bodega se creó correctamente
                     </Notification>,
                     { placement: 'top-center' }
                 )
             }
+            crud.closeAll()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al guardar la bodega')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
         }
     }
 
-    const handleFormClose = () => {
-        setIsFormOpen(false)
-        setSelectedWarehouse(null)
+    const handleDeleteConfirm = async () => {
+        if (!crud.selectedItem) return
+        try {
+            await deleteWarehouse.mutateAsync(crud.selectedItem.id)
+            toast.push(
+                <Notification title="Bodega eliminada" type="success">
+                    La bodega se eliminó correctamente
+                </Notification>,
+                { placement: 'top-center' }
+            )
+            crud.closeAll()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al eliminar la bodega')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
     }
 
     const columns: ColumnDef<Warehouse>[] = [
@@ -172,13 +180,13 @@ const WarehousesView = () => {
                             size="sm"
                             variant="plain"
                             icon={<HiOutlinePencil />}
-                            onClick={() => handleEdit(row.original)}
+                            onClick={() => crud.openEdit(row.original)}
                         />
                         <Button
                             size="sm"
                             variant="plain"
                             icon={<HiOutlineTrash />}
-                            onClick={() => handleDeleteClick(row.original)}
+                            onClick={() => crud.openDelete(row.original)}
                         />
                     </div>
                 )
@@ -201,7 +209,7 @@ const WarehousesView = () => {
                             variant="solid"
                             size="sm"
                             icon={<HiPlus />}
-                            onClick={handleCreate}
+                            onClick={crud.openCreate}
                         >
                             Nueva Bodega
                         </Button>
@@ -211,59 +219,47 @@ const WarehousesView = () => {
                         columns={columns}
                         data={warehouses}
                         loading={isLoading}
-                        pagingData={{ total, pageIndex, pageSize }}
-                        onPaginationChange={setPageIndex}
-                        onSelectChange={(size) => {
-                            setPageSize(size)
-                            setPageIndex(1)
+                        pagingData={{
+                            total,
+                            pageIndex: crud.pageIndex,
+                            pageSize: crud.pageSize,
                         }}
+                        onPaginationChange={(idx) =>
+                            crud.onPaginationChange(idx, crud.pageSize)
+                        }
+                        onSelectChange={(size) =>
+                            crud.onPaginationChange(1, size)
+                        }
                     />
                 </div>
             </Card>
 
-            <WarehouseForm
-                open={isFormOpen}
-                warehouse={selectedWarehouse}
-                onClose={handleFormClose}
-            />
-
-            <Dialog
-                isOpen={deleteDialog.open}
-                onClose={() =>
-                    setDeleteDialog({ open: false, warehouse: null })
-                }
-                onRequestClose={() =>
-                    setDeleteDialog({ open: false, warehouse: null })
-                }
+            <FormModal
+                formId="warehouse-form"
+                isOpen={crud.isCreateOpen || crud.isEditOpen}
+                title={crud.isEditOpen ? 'Editar Bodega' : 'Nueva Bodega'}
+                isSubmitting={isPending}
+                onClose={crud.closeAll}
             >
-                <h5 className="mb-4">Confirmar Eliminación</h5>
-                <p className="mb-6">
-                    ¿Estás seguro de que deseas eliminar la bodega{' '}
-                    <strong>
-                        {deleteDialog.warehouse?.name} (
-                        {deleteDialog.warehouse?.code})
-                    </strong>
-                    ? Esta acción no se puede deshacer.
-                </p>
-                <div className="flex justify-end gap-2">
-                    <Button
-                        variant="plain"
-                        disabled={deleteWarehouse.isPending}
-                        onClick={() =>
-                            setDeleteDialog({ open: false, warehouse: null })
-                        }
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        variant="solid"
-                        loading={deleteWarehouse.isPending}
-                        onClick={handleDeleteConfirm}
-                    >
-                        Eliminar
-                    </Button>
-                </div>
-            </Dialog>
+                <WarehouseForm
+                    formId="warehouse-form"
+                    warehouse={crud.selectedItem}
+                    isSubmitting={isPending}
+                    onSubmit={handleFormSubmit}
+                />
+            </FormModal>
+
+            <DeleteConfirmDialog
+                isOpen={crud.isDeleteOpen}
+                itemName={
+                    crud.selectedItem
+                        ? `${crud.selectedItem.name} (${crud.selectedItem.code})`
+                        : undefined
+                }
+                isDeleting={deleteWarehouse.isPending}
+                onClose={crud.closeAll}
+                onConfirm={handleDeleteConfirm}
+            />
         </>
     )
 }


### PR DESCRIPTION
## Descripción

  - Extend FormModal with optional formId prop for HTML form submit wiring
  - Transform CategoryForm, UnitOfMeasureForm, WarehouseForm, LocationForm to form-body pattern: remove Dialog/buttons, add formId + onSubmit props
  - Refactor CategoriesView, UnitsOfMeasureView, WarehousesView, LocationsView to use useCrudOperations<T>, FormModal, and DeleteConfirmDialog

## Tipo de cambio

- [ ] 🐛 Bug fix
- [ ] ✨ Nueva funcionalidad
- [x] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
