### PR TITLE
feat(inventory): apply CRUD abstractions to ProductsView, SuppliersView, CustomersView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,24 @@
+# Dotfiles y dotfolders (ignorar todo salvo excepciones)
+.*
+!.gitignore
+!.env.example
+!.eslintrc.*
+!.eslintignore
+!.prettierrc
+!.prettierrc.*
+!.prettierignore
+!.github/
+
 # Dependencias
 node_modules
-.pnp
-.pnp.js
-
-# Testing
-coverage
 
 # Producción
 dist
 dist-ssr
 build
-*.local
+
+# Testing
+coverage
 
 # Logs
 logs
@@ -21,36 +29,16 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-# Entorno
-.env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
-# Editor y Sistema Operativo
-.vscode/*
-!.vscode/extensions.json
-!.vscode/settings.json
-.idea
-.DS_Store
-CLAUDE.md
+# Sistema Operativo
+Thumbs.db
 *.suo
 *.ntvs*
 *.njsproj
 *.sln
 *.sw?
 
-# Cache
-.vite-cache/
-.eslintcache
-.stylelintcache
 
-# Typescript
+# Typescript y Node.js
 *.tsbuildinfo
-
-# Otros
-.cache
-.temp
-.tmp
-.history
+*.pid
+*.seed

--- a/src/components/shared/FormModal.tsx
+++ b/src/components/shared/FormModal.tsx
@@ -9,6 +9,7 @@ interface FormModalProps {
     formId?: string
     title: string
     isSubmitting?: boolean
+    width?: number
     children: ReactNode
 }
 
@@ -19,10 +20,12 @@ const FormModal = ({
     formId,
     title,
     isSubmitting = false,
+    width,
     children,
 }: FormModalProps) => (
     <Dialog
         isOpen={isOpen}
+        width={width}
         shouldCloseOnEsc={!isSubmitting}
         shouldCloseOnOverlayClick={!isSubmitting}
         onClose={onClose}

--- a/src/views/inventory/CustomersView/CustomerForm.tsx
+++ b/src/views/inventory/CustomersView/CustomerForm.tsx
@@ -1,13 +1,7 @@
 import { useState, useEffect } from 'react'
-import Dialog from '@/components/ui/Dialog'
-import Button from '@/components/ui/Button'
 import Input from '@/components/ui/Input'
 import Select from '@/components/ui/Select'
 import Switcher from '@/components/ui/Switcher'
-import Notification from '@/components/ui/Notification'
-import toast from '@/components/ui/toast'
-import { useCreateCustomer, useUpdateCustomer } from '@/hooks/useCustomers'
-import { getErrorMessage } from '@/utils/getErrorMessage'
 import type {
     Customer,
     CustomerInput,
@@ -16,16 +10,22 @@ import type {
 import { TAX_TYPE_LABELS } from '@/services/CustomerService'
 
 interface CustomerFormProps {
-    open: boolean
-    onClose: () => void
+    formId: string
     customer?: Customer | null
+    isSubmitting?: boolean
+    onSubmit: (data: CustomerInput) => void
 }
 
-const CustomerForm = ({ open, onClose, customer }: CustomerFormProps) => {
+const CustomerForm = ({
+    formId,
+    customer,
+    isSubmitting = false,
+    onSubmit,
+}: CustomerFormProps) => {
     const [formData, setFormData] = useState<CustomerInput>({
         name: '',
         taxId: '',
-        taxType: 2, // Default to Cédula
+        taxType: 2,
         email: '',
         phone: '',
         address: '',
@@ -36,11 +36,6 @@ const CustomerForm = ({ open, onClose, customer }: CustomerFormProps) => {
         paymentTerms: undefined,
         isActive: true,
     })
-
-    const createCustomer = useCreateCustomer()
-    const updateCustomer = useUpdateCustomer()
-
-    const isEdit = !!customer
 
     const taxTypeOptions = [
         { value: 1, label: TAX_TYPE_LABELS[1] },
@@ -81,365 +76,271 @@ const CustomerForm = ({ open, onClose, customer }: CustomerFormProps) => {
                 isActive: true,
             })
         }
-    }, [customer, open])
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-
-        try {
-            if (isEdit && customer) {
-                await updateCustomer.mutateAsync({
-                    id: customer.id,
-                    data: formData,
-                })
-            } else {
-                await createCustomer.mutateAsync(formData)
-            }
-
-            toast.push(
-                <Notification
-                    title={isEdit ? 'Cliente actualizado' : 'Cliente creado'}
-                    type="success"
-                >
-                    {isEdit
-                        ? 'El cliente se actualizó correctamente'
-                        : 'El cliente se creó correctamente'}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-
-            onClose()
-        } catch (error: unknown) {
-            const errorMessage = getErrorMessage(
-                error,
-                'Error al guardar el cliente'
-            )
-
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {errorMessage}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-
-            console.error('Error saving customer:', error)
-        }
-    }
-
-    const handleClose = () => {
-        if (!createCustomer.isPending && !updateCustomer.isPending) {
-            onClose()
-        }
-    }
+    }, [customer])
 
     return (
-        <Dialog
-            isOpen={open}
-            width={800}
-            onClose={handleClose}
-            onRequestClose={handleClose}
+        <form
+            id={formId}
+            onSubmit={(e) => {
+                e.preventDefault()
+                onSubmit(formData)
+            }}
         >
-            <div className="flex flex-col h-full justify-between">
-                <h5 className="mb-4">
-                    {isEdit ? 'Editar Cliente' : 'Nuevo Cliente'}
-                </h5>
-
-                <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        {/* Basic Information */}
-                        <div>
-                            <h6 className="mb-3 text-sm font-semibold">
-                                Información Básica
-                            </h6>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                {/* Name */}
-                                <div className="md:col-span-2">
-                                    <label className="block text-sm font-medium mb-2">
-                                        Nombre{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Input
-                                        required
-                                        type="text"
-                                        placeholder="Nombre del cliente"
-                                        value={formData.name}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                name: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                {/* Tax ID */}
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Tax ID{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Input
-                                        required
-                                        type="text"
-                                        placeholder="RUC, Cédula, Pasaporte..."
-                                        value={formData.taxId}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                taxId: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                {/* Tax Type */}
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Tipo de ID{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Select
-                                        value={taxTypeOptions.find(
-                                            (opt) =>
-                                                opt.value === formData.taxType
-                                        )}
-                                        options={taxTypeOptions}
-                                        onChange={(option) =>
-                                            setFormData({
-                                                ...formData,
-                                                taxType:
-                                                    option?.value as TaxType,
-                                            })
-                                        }
-                                    />
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Contact Information */}
-                        <div>
-                            <h6 className="mb-3 text-sm font-semibold">
-                                Información de Contacto
-                            </h6>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                {/* Email */}
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Email
-                                    </label>
-                                    <Input
-                                        type="email"
-                                        placeholder="email@ejemplo.com"
-                                        value={formData.email}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                email: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                {/* Phone */}
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Teléfono
-                                    </label>
-                                    <Input
-                                        type="text"
-                                        placeholder="0987654321"
-                                        value={formData.phone}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                phone: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Address */}
-                        <div>
-                            <h6 className="mb-3 text-sm font-semibold">
-                                Dirección
-                            </h6>
-                            <div className="space-y-4">
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Dirección
-                                    </label>
-                                    <Input
-                                        type="text"
-                                        placeholder="Calle principal 123"
-                                        value={formData.address}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                address: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-                                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                                    {/* City */}
-                                    <div>
-                                        <label className="block text-sm font-medium mb-2">
-                                            Ciudad
-                                        </label>
-                                        <Input
-                                            type="text"
-                                            placeholder="Quito"
-                                            value={formData.city}
-                                            onChange={(e) =>
-                                                setFormData({
-                                                    ...formData,
-                                                    city: e.target.value,
-                                                })
-                                            }
-                                        />
-                                    </div>
-
-                                    {/* State */}
-                                    <div>
-                                        <label className="block text-sm font-medium mb-2">
-                                            Provincia/Estado
-                                        </label>
-                                        <Input
-                                            type="text"
-                                            placeholder="Pichincha"
-                                            value={formData.state}
-                                            onChange={(e) =>
-                                                setFormData({
-                                                    ...formData,
-                                                    state: e.target.value,
-                                                })
-                                            }
-                                        />
-                                    </div>
-
-                                    {/* Country */}
-                                    <div>
-                                        <label className="block text-sm font-medium mb-2">
-                                            País
-                                        </label>
-                                        <Input
-                                            type="text"
-                                            placeholder="Ecuador"
-                                            value={formData.country}
-                                            onChange={(e) =>
-                                                setFormData({
-                                                    ...formData,
-                                                    country: e.target.value,
-                                                })
-                                            }
-                                        />
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Financial Information */}
-                        <div>
-                            <h6 className="mb-3 text-sm font-semibold">
-                                Información Financiera
-                            </h6>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                {/* Credit Limit */}
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Límite de Crédito
-                                    </label>
-                                    <Input
-                                        type="number"
-                                        placeholder="0.00"
-                                        value={formData.creditLimit || ''}
-                                        min="0"
-                                        step="0.01"
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                creditLimit: e.target.value
-                                                    ? parseFloat(e.target.value)
-                                                    : undefined,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                {/* Payment Terms */}
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Términos de Pago (días)
-                                    </label>
-                                    <Input
-                                        type="number"
-                                        placeholder="30"
-                                        value={formData.paymentTerms || ''}
-                                        min="0"
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                paymentTerms: e.target.value
-                                                    ? parseInt(e.target.value)
-                                                    : undefined,
-                                            })
-                                        }
-                                    />
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Status */}
-                        <div>
+            <div className="space-y-4">
+                <div>
+                    <h6 className="mb-3 text-sm font-semibold">
+                        Información Básica
+                    </h6>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div className="md:col-span-2">
                             <label className="block text-sm font-medium mb-2">
-                                Estado
+                                Nombre <span className="text-red-500">*</span>
                             </label>
-                            <Switcher
-                                checked={formData.isActive}
-                                onChange={(checked) =>
+                            <Input
+                                required
+                                type="text"
+                                placeholder="Nombre del cliente"
+                                value={formData.name}
+                                disabled={isSubmitting}
+                                onChange={(e) =>
                                     setFormData({
                                         ...formData,
-                                        isActive: checked,
+                                        name: e.target.value,
                                     })
                                 }
                             />
-                            <p className="text-xs text-gray-500 mt-1">
-                                {formData.isActive
-                                    ? 'Cliente activo'
-                                    : 'Cliente inactivo'}
-                            </p>
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Tax ID <span className="text-red-500">*</span>
+                            </label>
+                            <Input
+                                required
+                                type="text"
+                                placeholder="RUC, Cédula, Pasaporte..."
+                                value={formData.taxId}
+                                disabled={isSubmitting}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        taxId: e.target.value,
+                                    })
+                                }
+                            />
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Tipo de ID{' '}
+                                <span className="text-red-500">*</span>
+                            </label>
+                            <Select
+                                isDisabled={isSubmitting}
+                                value={taxTypeOptions.find(
+                                    (opt) => opt.value === formData.taxType
+                                )}
+                                options={taxTypeOptions}
+                                onChange={(option) =>
+                                    setFormData({
+                                        ...formData,
+                                        taxType: option?.value as TaxType,
+                                    })
+                                }
+                            />
                         </div>
                     </div>
+                </div>
 
-                    {/* Buttons */}
-                    <div className="flex justify-end gap-2 mt-6 pt-4 border-t">
-                        <Button
-                            type="button"
-                            variant="plain"
-                            disabled={
-                                createCustomer.isPending ||
-                                updateCustomer.isPending
-                            }
-                            onClick={handleClose}
-                        >
-                            Cancelar
-                        </Button>
-                        <Button
-                            type="submit"
-                            variant="solid"
-                            loading={
-                                createCustomer.isPending ||
-                                updateCustomer.isPending
-                            }
-                        >
-                            {isEdit ? 'Actualizar' : 'Crear'}
-                        </Button>
+                <div>
+                    <h6 className="mb-3 text-sm font-semibold">
+                        Información de Contacto
+                    </h6>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Email
+                            </label>
+                            <Input
+                                type="email"
+                                placeholder="email@ejemplo.com"
+                                value={formData.email}
+                                disabled={isSubmitting}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        email: e.target.value,
+                                    })
+                                }
+                            />
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Teléfono
+                            </label>
+                            <Input
+                                type="text"
+                                placeholder="0987654321"
+                                value={formData.phone}
+                                disabled={isSubmitting}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        phone: e.target.value,
+                                    })
+                                }
+                            />
+                        </div>
                     </div>
-                </form>
+                </div>
+
+                <div>
+                    <h6 className="mb-3 text-sm font-semibold">Dirección</h6>
+                    <div className="space-y-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Dirección
+                            </label>
+                            <Input
+                                type="text"
+                                placeholder="Calle principal 123"
+                                value={formData.address}
+                                disabled={isSubmitting}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        address: e.target.value,
+                                    })
+                                }
+                            />
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                            <div>
+                                <label className="block text-sm font-medium mb-2">
+                                    Ciudad
+                                </label>
+                                <Input
+                                    type="text"
+                                    placeholder="Quito"
+                                    value={formData.city}
+                                    disabled={isSubmitting}
+                                    onChange={(e) =>
+                                        setFormData({
+                                            ...formData,
+                                            city: e.target.value,
+                                        })
+                                    }
+                                />
+                            </div>
+
+                            <div>
+                                <label className="block text-sm font-medium mb-2">
+                                    Provincia/Estado
+                                </label>
+                                <Input
+                                    type="text"
+                                    placeholder="Pichincha"
+                                    value={formData.state}
+                                    disabled={isSubmitting}
+                                    onChange={(e) =>
+                                        setFormData({
+                                            ...formData,
+                                            state: e.target.value,
+                                        })
+                                    }
+                                />
+                            </div>
+
+                            <div>
+                                <label className="block text-sm font-medium mb-2">
+                                    País
+                                </label>
+                                <Input
+                                    type="text"
+                                    placeholder="Ecuador"
+                                    value={formData.country}
+                                    disabled={isSubmitting}
+                                    onChange={(e) =>
+                                        setFormData({
+                                            ...formData,
+                                            country: e.target.value,
+                                        })
+                                    }
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div>
+                    <h6 className="mb-3 text-sm font-semibold">
+                        Información Financiera
+                    </h6>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Límite de Crédito
+                            </label>
+                            <Input
+                                type="number"
+                                placeholder="0.00"
+                                value={formData.creditLimit || ''}
+                                min="0"
+                                step="0.01"
+                                disabled={isSubmitting}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        creditLimit: e.target.value
+                                            ? parseFloat(e.target.value)
+                                            : undefined,
+                                    })
+                                }
+                            />
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Términos de Pago (días)
+                            </label>
+                            <Input
+                                type="number"
+                                placeholder="30"
+                                value={formData.paymentTerms || ''}
+                                min="0"
+                                disabled={isSubmitting}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        paymentTerms: e.target.value
+                                            ? parseInt(e.target.value)
+                                            : undefined,
+                                    })
+                                }
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Estado
+                    </label>
+                    <Switcher
+                        checked={formData.isActive}
+                        onChange={(checked) =>
+                            setFormData({ ...formData, isActive: checked })
+                        }
+                    />
+                    <p className="text-xs text-gray-500 mt-1">
+                        {formData.isActive
+                            ? 'Cliente activo'
+                            : 'Cliente inactivo'}
+                    </p>
+                </div>
             </div>
-        </Dialog>
+        </form>
     )
 }
 

--- a/src/views/inventory/CustomersView/index.tsx
+++ b/src/views/inventory/CustomersView/index.tsx
@@ -1,21 +1,23 @@
-import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
     useCustomers,
     useDeleteCustomer,
+    useCreateCustomer,
+    useUpdateCustomer,
     useActivateCustomer,
     useDeactivateCustomer,
+    useCrudOperations,
 } from '@/hooks'
 import DataTable, { ColumnDef } from '@/components/shared/DataTable'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
-import Dialog from '@/components/ui/Dialog'
 import Badge from '@/components/ui/Badge'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
-import type { Customer } from '@/services/CustomerService'
+import type { Customer, CustomerInput } from '@/services/CustomerService'
 import { TAX_TYPE_LABELS } from '@/services/CustomerService'
 import { getErrorMessage } from '@/utils/getErrorMessage'
+import { FormModal, DeleteConfirmDialog } from '@/components/shared'
 import CustomerForm from './CustomerForm'
 import {
     HiOutlinePlus,
@@ -28,60 +30,64 @@ import {
 
 const CustomersView = () => {
     const navigate = useNavigate()
-    const deleteCustomer = useDeleteCustomer()
-    const activateCustomer = useActivateCustomer()
-    const deactivateCustomer = useDeactivateCustomer()
+    const crud = useCrudOperations<Customer>()
+    const offset = (crud.pageIndex - 1) * crud.pageSize
 
-    const [formOpen, setFormOpen] = useState(false)
-    const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(
-        null
-    )
-    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-    const [customerToDelete, setCustomerToDelete] = useState<Customer | null>(
-        null
-    )
-
-    const [pageIndex, setPageIndex] = useState(1)
-    const [pageSize, setPageSize] = useState(10)
-    const offset = (pageIndex - 1) * pageSize
-
-    const { data, isLoading } = useCustomers({ limit: pageSize, offset })
+    const { data, isLoading } = useCustomers({ limit: crud.pageSize, offset })
     const customers = data?.items ?? []
     const total = data?.pagination?.total ?? 0
 
-    const handleEdit = (customer: Customer) => {
-        setSelectedCustomer(customer)
-        setFormOpen(true)
-    }
+    const deleteCustomer = useDeleteCustomer()
+    const createCustomer = useCreateCustomer()
+    const updateCustomer = useUpdateCustomer()
+    const activateCustomer = useActivateCustomer()
+    const deactivateCustomer = useDeactivateCustomer()
+    const isPending = createCustomer.isPending || updateCustomer.isPending
 
-    const handleCreate = () => {
-        setSelectedCustomer(null)
-        setFormOpen(true)
-    }
-
-    const handleCloseForm = () => {
-        setFormOpen(false)
-        setSelectedCustomer(null)
-    }
-
-    const handleDeleteClick = (customer: Customer) => {
-        setCustomerToDelete(customer)
-        setDeleteDialogOpen(true)
+    const handleFormSubmit = async (formData: CustomerInput) => {
+        try {
+            if (crud.isEditOpen && crud.selectedItem) {
+                await updateCustomer.mutateAsync({
+                    id: crud.selectedItem.id,
+                    data: formData,
+                })
+                toast.push(
+                    <Notification title="Cliente actualizado" type="success">
+                        El cliente se actualizó correctamente
+                    </Notification>,
+                    { placement: 'top-center' }
+                )
+            } else {
+                await createCustomer.mutateAsync(formData)
+                toast.push(
+                    <Notification title="Cliente creado" type="success">
+                        El cliente se creó correctamente
+                    </Notification>,
+                    { placement: 'top-center' }
+                )
+            }
+            crud.closeAll()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al guardar el cliente')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
     }
 
     const handleDeleteConfirm = async () => {
-        if (!customerToDelete) return
-
+        if (!crud.selectedItem) return
         try {
-            await deleteCustomer.mutateAsync(customerToDelete.id)
+            await deleteCustomer.mutateAsync(crud.selectedItem.id)
             toast.push(
                 <Notification title="Cliente eliminado" type="success">
                     El cliente se eliminó correctamente
                 </Notification>,
                 { placement: 'top-center' }
             )
-            setDeleteDialogOpen(false)
-            setCustomerToDelete(null)
+            crud.closeAll()
         } catch (error: unknown) {
             toast.push(
                 <Notification title="Error" type="danger">
@@ -198,7 +204,7 @@ const CustomersView = () => {
                         size="sm"
                         variant="plain"
                         icon={<HiOutlinePencil />}
-                        onClick={() => handleEdit(row.original)}
+                        onClick={() => crud.openEdit(row.original)}
                     />
                     <Button
                         size="sm"
@@ -216,7 +222,7 @@ const CustomersView = () => {
                         size="sm"
                         variant="plain"
                         icon={<HiOutlineTrash />}
-                        onClick={() => handleDeleteClick(row.original)}
+                        onClick={() => crud.openDelete(row.original)}
                     />
                 </div>
             ),
@@ -238,7 +244,7 @@ const CustomersView = () => {
                             variant="solid"
                             size="sm"
                             icon={<HiOutlinePlus />}
-                            onClick={handleCreate}
+                            onClick={crud.openCreate}
                         >
                             Nuevo Cliente
                         </Button>
@@ -248,49 +254,44 @@ const CustomersView = () => {
                         columns={columns}
                         data={customers}
                         loading={isLoading}
-                        pagingData={{ total, pageIndex, pageSize }}
-                        onPaginationChange={setPageIndex}
-                        onSelectChange={(size) => {
-                            setPageSize(size)
-                            setPageIndex(1)
+                        pagingData={{
+                            total,
+                            pageIndex: crud.pageIndex,
+                            pageSize: crud.pageSize,
                         }}
+                        onPaginationChange={(idx) =>
+                            crud.onPaginationChange(idx, crud.pageSize)
+                        }
+                        onSelectChange={(size) =>
+                            crud.onPaginationChange(1, size)
+                        }
                     />
                 </div>
             </Card>
 
-            <CustomerForm
-                open={formOpen}
-                customer={selectedCustomer}
-                onClose={handleCloseForm}
-            />
-
-            <Dialog
-                isOpen={deleteDialogOpen}
-                onClose={() => setDeleteDialogOpen(false)}
-                onRequestClose={() => setDeleteDialogOpen(false)}
+            <FormModal
+                formId="customer-form"
+                width={800}
+                isOpen={crud.isCreateOpen || crud.isEditOpen}
+                title={crud.isEditOpen ? 'Editar Cliente' : 'Nuevo Cliente'}
+                isSubmitting={isPending}
+                onClose={crud.closeAll}
             >
-                <h5 className="mb-4">Confirmar eliminación</h5>
-                <p className="mb-6">
-                    ¿Está seguro que desea eliminar el cliente{' '}
-                    <strong>{customerToDelete?.name}</strong>? Esta acción no se
-                    puede deshacer.
-                </p>
-                <div className="flex justify-end gap-2">
-                    <Button
-                        variant="plain"
-                        onClick={() => setDeleteDialogOpen(false)}
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        variant="solid"
-                        loading={deleteCustomer.isPending}
-                        onClick={handleDeleteConfirm}
-                    >
-                        Eliminar
-                    </Button>
-                </div>
-            </Dialog>
+                <CustomerForm
+                    formId="customer-form"
+                    customer={crud.selectedItem}
+                    isSubmitting={isPending}
+                    onSubmit={handleFormSubmit}
+                />
+            </FormModal>
+
+            <DeleteConfirmDialog
+                isOpen={crud.isDeleteOpen}
+                itemName={crud.selectedItem?.name}
+                isDeleting={deleteCustomer.isPending}
+                onClose={crud.closeAll}
+                onConfirm={handleDeleteConfirm}
+            />
         </>
     )
 }

--- a/src/views/inventory/ProductsView/ProductForm.tsx
+++ b/src/views/inventory/ProductsView/ProductForm.tsx
@@ -1,24 +1,24 @@
 import { useState, useEffect } from 'react'
-import Dialog from '@/components/ui/Dialog'
-import Button from '@/components/ui/Button'
 import Input from '@/components/ui/Input'
 import Select from '@/components/ui/Select'
 import Switcher from '@/components/ui/Switcher'
-import Notification from '@/components/ui/Notification'
-import toast from '@/components/ui/toast'
-import { useCreateProduct, useUpdateProduct } from '@/hooks/useProducts'
-import { getErrorMessage } from '@/utils/getErrorMessage'
 import { useCategories } from '@/hooks/useCategories'
 import { useUnitsOfMeasure } from '@/hooks/useUnitsOfMeasure'
 import type { Product, ProductInput } from '@/services/ProductService'
 
 interface ProductFormProps {
-    open: boolean
-    onClose: () => void
+    formId: string
     product?: Product | null
+    isSubmitting?: boolean
+    onSubmit: (data: ProductInput) => void
 }
 
-const ProductForm = ({ open, onClose, product }: ProductFormProps) => {
+const ProductForm = ({
+    formId,
+    product,
+    isSubmitting = false,
+    onSubmit,
+}: ProductFormProps) => {
     const [formData, setFormData] = useState<ProductInput>({
         name: '',
         sku: '',
@@ -36,16 +36,11 @@ const ProductForm = ({ open, onClose, product }: ProductFormProps) => {
         leadTimeDays: undefined,
     })
 
-    const createProduct = useCreateProduct()
-    const updateProduct = useUpdateProduct()
     const { data: categoriesData } = useCategories()
     const categories = categoriesData?.items ?? []
     const { data: unitsData } = useUnitsOfMeasure()
     const unitsOfMeasure = unitsData?.items ?? []
 
-    const isEdit = !!product
-
-    // Create options for category select
     const categoryOptions = [
         { value: 0, label: 'Sin categoría' },
         ...categories.map((cat) => ({
@@ -54,7 +49,6 @@ const ProductForm = ({ open, onClose, product }: ProductFormProps) => {
         })),
     ]
 
-    // Create options for unit of measure select
     const unitOptions = [
         { value: 0, label: 'Sin unidad' },
         ...unitsOfMeasure
@@ -101,388 +95,289 @@ const ProductForm = ({ open, onClose, product }: ProductFormProps) => {
                 leadTimeDays: undefined,
             })
         }
-    }, [product, open])
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-
-        try {
-            if (isEdit && product) {
-                await updateProduct.mutateAsync({
-                    id: product.id,
-                    data: formData,
-                })
-            } else {
-                await createProduct.mutateAsync(formData)
-            }
-
-            toast.push(
-                <Notification
-                    title={isEdit ? 'Producto actualizado' : 'Producto creado'}
-                    type="success"
-                >
-                    {isEdit
-                        ? 'El producto se actualizó correctamente'
-                        : 'El producto se creó correctamente'}
-                </Notification>,
-                {
-                    placement: 'top-center',
-                }
-            )
-
-            onClose()
-        } catch (error: unknown) {
-            const errorMessage = getErrorMessage(
-                error,
-                'Error al guardar el producto'
-            )
-
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {errorMessage}
-                </Notification>,
-                {
-                    placement: 'top-center',
-                }
-            )
-
-            console.error('Error saving product:', error)
-        }
-    }
-
-    const handleClose = () => {
-        if (!createProduct.isPending && !updateProduct.isPending) {
-            onClose()
-        }
-    }
+    }, [product])
 
     return (
-        <Dialog
-            isOpen={open}
-            width={640}
-            onClose={handleClose}
-            onRequestClose={handleClose}
+        <form
+            id={formId}
+            onSubmit={(e) => {
+                e.preventDefault()
+                onSubmit(formData)
+            }}
         >
-            <div className="flex flex-col h-full justify-between">
-                <h5 className="mb-4">
-                    {isEdit ? 'Editar Producto' : 'Nuevo Producto'}
-                </h5>
+            <div className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Nombre <span className="text-red-500">*</span>
+                    </label>
+                    <Input
+                        required
+                        type="text"
+                        placeholder="Nombre del producto"
+                        value={formData.name}
+                        disabled={isSubmitting}
+                        onChange={(e) =>
+                            setFormData({ ...formData, name: e.target.value })
+                        }
+                    />
+                </div>
 
-                <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        {/* Name */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Nombre <span className="text-red-500">*</span>
-                            </label>
-                            <Input
-                                required
-                                type="text"
-                                placeholder="Nombre del producto"
-                                value={formData.name}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        name: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        SKU <span className="text-red-500">*</span>
+                    </label>
+                    <Input
+                        required
+                        type="text"
+                        placeholder="SKU del producto"
+                        value={formData.sku}
+                        disabled={isSubmitting}
+                        onChange={(e) =>
+                            setFormData({ ...formData, sku: e.target.value })
+                        }
+                    />
+                </div>
 
-                        {/* SKU */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                SKU <span className="text-red-500">*</span>
-                            </label>
-                            <Input
-                                required
-                                type="text"
-                                placeholder="SKU del producto"
-                                value={formData.sku}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        sku: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Descripción
+                    </label>
+                    <Input
+                        textArea
+                        placeholder="Descripción del producto"
+                        value={formData.description || ''}
+                        style={{ minHeight: '80px' }}
+                        disabled={isSubmitting}
+                        onChange={(e) =>
+                            setFormData({
+                                ...formData,
+                                description: e.target.value,
+                            })
+                        }
+                    />
+                </div>
 
-                        {/* Description */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Descripción
-                            </label>
-                            <Input
-                                textArea
-                                placeholder="Descripción del producto"
-                                value={formData.description || ''}
-                                style={{ minHeight: '80px' }}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        description: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Código de barras
+                    </label>
+                    <Input
+                        type="text"
+                        placeholder="Ej: 7501234567890"
+                        value={formData.barcode || ''}
+                        disabled={isSubmitting}
+                        onChange={(e) =>
+                            setFormData({
+                                ...formData,
+                                barcode: e.target.value || null,
+                            })
+                        }
+                    />
+                </div>
 
-                        {/* Barcode */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Código de barras
-                            </label>
-                            <Input
-                                type="text"
-                                placeholder="Ej: 7501234567890"
-                                value={formData.barcode || ''}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        barcode: e.target.value || null,
-                                    })
-                                }
-                            />
-                        </div>
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Categoría
+                    </label>
+                    <Select
+                        placeholder="Seleccione una categoría"
+                        isDisabled={isSubmitting}
+                        value={categoryOptions.find(
+                            (opt) => opt.value === (formData.categoryId || 0)
+                        )}
+                        options={categoryOptions}
+                        onChange={(option) =>
+                            setFormData({
+                                ...formData,
+                                categoryId:
+                                    option?.value === 0
+                                        ? undefined
+                                        : option?.value,
+                            })
+                        }
+                    />
+                    <p className="text-xs text-gray-500 mt-1">
+                        Opcional: Seleccione la categoría del producto
+                    </p>
+                </div>
 
-                        {/* Category */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Categoría
-                            </label>
-                            <Select
-                                placeholder="Seleccione una categoría"
-                                value={categoryOptions.find(
-                                    (opt) =>
-                                        opt.value === (formData.categoryId || 0)
-                                )}
-                                options={categoryOptions}
-                                onChange={(option) =>
-                                    setFormData({
-                                        ...formData,
-                                        categoryId:
-                                            option?.value === 0
-                                                ? undefined
-                                                : option?.value,
-                                    })
-                                }
-                            />
-                            <p className="text-xs text-gray-500 mt-1">
-                                Opcional: Seleccione la categoría del producto
-                            </p>
-                        </div>
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Unidad de Medida
+                    </label>
+                    <Select
+                        placeholder="Seleccione una unidad"
+                        isDisabled={isSubmitting}
+                        value={unitOptions.find(
+                            (opt) =>
+                                opt.value === (formData.unitOfMeasureId || 0)
+                        )}
+                        options={unitOptions}
+                        onChange={(option) =>
+                            setFormData({
+                                ...formData,
+                                unitOfMeasureId:
+                                    option?.value === 0
+                                        ? undefined
+                                        : option?.value,
+                            })
+                        }
+                    />
+                    <p className="text-xs text-gray-500 mt-1">
+                        Opcional: Seleccione la unidad de medida del producto
+                    </p>
+                </div>
 
-                        {/* Unit of Measure */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Unidad de Medida
-                            </label>
-                            <Select
-                                placeholder="Seleccione una unidad"
-                                value={unitOptions.find(
-                                    (opt) =>
-                                        opt.value ===
-                                        (formData.unitOfMeasureId || 0)
-                                )}
-                                options={unitOptions}
-                                onChange={(option) =>
-                                    setFormData({
-                                        ...formData,
-                                        unitOfMeasureId:
-                                            option?.value === 0
-                                                ? undefined
-                                                : option?.value,
-                                    })
-                                }
-                            />
-                            <p className="text-xs text-gray-500 mt-1">
-                                Opcional: Seleccione la unidad de medida del
-                                producto
-                            </p>
-                        </div>
-
-                        {/* Prices */}
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Precio de compra
-                                </label>
-                                <Input
-                                    type="number"
-                                    placeholder="0.00"
-                                    value={formData.purchasePrice ?? ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            purchasePrice:
-                                                e.target.value !== ''
-                                                    ? Number(e.target.value)
-                                                    : undefined,
-                                        })
-                                    }
-                                />
-                            </div>
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Precio de venta
-                                </label>
-                                <Input
-                                    type="number"
-                                    placeholder="0.00"
-                                    value={formData.salePrice ?? ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            salePrice:
-                                                e.target.value !== ''
-                                                    ? Number(e.target.value)
-                                                    : undefined,
-                                        })
-                                    }
-                                />
-                            </div>
-                        </div>
-
-                        {/* Toggles */}
-                        <div className="flex gap-6">
-                            <div className="flex items-center gap-3">
-                                <Switcher
-                                    checked={formData.isActive}
-                                    onChange={(checked) =>
-                                        setFormData({
-                                            ...formData,
-                                            isActive: checked,
-                                        })
-                                    }
-                                />
-                                <label className="text-sm font-medium">
-                                    Activo
-                                </label>
-                            </div>
-                            <div className="flex items-center gap-3">
-                                <Switcher
-                                    checked={formData.isService}
-                                    onChange={(checked) =>
-                                        setFormData({
-                                            ...formData,
-                                            isService: checked,
-                                        })
-                                    }
-                                />
-                                <label className="text-sm font-medium">
-                                    Es servicio
-                                </label>
-                            </div>
-                        </div>
-
-                        {/* Stock */}
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Stock mínimo
-                                </label>
-                                <Input
-                                    type="number"
-                                    placeholder="0"
-                                    value={formData.minStock ?? ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            minStock:
-                                                e.target.value !== ''
-                                                    ? Number(e.target.value)
-                                                    : 0,
-                                        })
-                                    }
-                                />
-                            </div>
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Stock máximo
-                                </label>
-                                <Input
-                                    type="number"
-                                    placeholder="Sin límite"
-                                    value={formData.maxStock ?? ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            maxStock:
-                                                e.target.value !== ''
-                                                    ? Number(e.target.value)
-                                                    : undefined,
-                                        })
-                                    }
-                                />
-                            </div>
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Punto de reorden
-                                </label>
-                                <Input
-                                    type="number"
-                                    placeholder="0"
-                                    value={formData.reorderPoint ?? ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            reorderPoint:
-                                                e.target.value !== ''
-                                                    ? Number(e.target.value)
-                                                    : 0,
-                                        })
-                                    }
-                                />
-                            </div>
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Tiempo de entrega (días)
-                                </label>
-                                <Input
-                                    type="number"
-                                    placeholder="Sin definir"
-                                    value={formData.leadTimeDays ?? ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            leadTimeDays:
-                                                e.target.value !== ''
-                                                    ? Number(e.target.value)
-                                                    : undefined,
-                                        })
-                                    }
-                                />
-                            </div>
-                        </div>
-                    </div>
-
-                    {/* Buttons */}
-                    <div className="flex justify-end gap-2 mt-6">
-                        <Button
-                            type="button"
-                            variant="plain"
-                            disabled={
-                                createProduct.isPending ||
-                                updateProduct.isPending
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Precio de compra
+                        </label>
+                        <Input
+                            type="number"
+                            placeholder="0.00"
+                            value={formData.purchasePrice ?? ''}
+                            disabled={isSubmitting}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    purchasePrice:
+                                        e.target.value !== ''
+                                            ? Number(e.target.value)
+                                            : undefined,
+                                })
                             }
-                            onClick={handleClose}
-                        >
-                            Cancelar
-                        </Button>
-                        <Button
-                            type="submit"
-                            variant="solid"
-                            loading={
-                                createProduct.isPending ||
-                                updateProduct.isPending
-                            }
-                        >
-                            {isEdit ? 'Actualizar' : 'Crear'}
-                        </Button>
+                        />
                     </div>
-                </form>
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Precio de venta
+                        </label>
+                        <Input
+                            type="number"
+                            placeholder="0.00"
+                            value={formData.salePrice ?? ''}
+                            disabled={isSubmitting}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    salePrice:
+                                        e.target.value !== ''
+                                            ? Number(e.target.value)
+                                            : undefined,
+                                })
+                            }
+                        />
+                    </div>
+                </div>
+
+                <div className="flex gap-6">
+                    <div className="flex items-center gap-3">
+                        <Switcher
+                            checked={formData.isActive}
+                            onChange={(checked) =>
+                                setFormData({ ...formData, isActive: checked })
+                            }
+                        />
+                        <label className="text-sm font-medium">Activo</label>
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <Switcher
+                            checked={formData.isService}
+                            onChange={(checked) =>
+                                setFormData({ ...formData, isService: checked })
+                            }
+                        />
+                        <label className="text-sm font-medium">
+                            Es servicio
+                        </label>
+                    </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Stock mínimo
+                        </label>
+                        <Input
+                            type="number"
+                            placeholder="0"
+                            value={formData.minStock ?? ''}
+                            disabled={isSubmitting}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    minStock:
+                                        e.target.value !== ''
+                                            ? Number(e.target.value)
+                                            : 0,
+                                })
+                            }
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Stock máximo
+                        </label>
+                        <Input
+                            type="number"
+                            placeholder="Sin límite"
+                            value={formData.maxStock ?? ''}
+                            disabled={isSubmitting}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    maxStock:
+                                        e.target.value !== ''
+                                            ? Number(e.target.value)
+                                            : undefined,
+                                })
+                            }
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Punto de reorden
+                        </label>
+                        <Input
+                            type="number"
+                            placeholder="0"
+                            value={formData.reorderPoint ?? ''}
+                            disabled={isSubmitting}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    reorderPoint:
+                                        e.target.value !== ''
+                                            ? Number(e.target.value)
+                                            : 0,
+                                })
+                            }
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium mb-2">
+                            Tiempo de entrega (días)
+                        </label>
+                        <Input
+                            type="number"
+                            placeholder="Sin definir"
+                            value={formData.leadTimeDays ?? ''}
+                            disabled={isSubmitting}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    leadTimeDays:
+                                        e.target.value !== ''
+                                            ? Number(e.target.value)
+                                            : undefined,
+                                })
+                            }
+                        />
+                    </div>
+                </div>
             </div>
-        </Dialog>
+        </form>
     )
 }
 

--- a/src/views/inventory/ProductsView/index.tsx
+++ b/src/views/inventory/ProductsView/index.tsx
@@ -2,35 +2,33 @@ import { useState, useMemo } from 'react'
 import DataTable, { ColumnDef } from '@/components/shared/DataTable'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
-import Dialog from '@/components/ui/Dialog'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
-import { useProducts, useDeleteProduct } from '@/hooks/useProducts'
+import {
+    useProducts,
+    useDeleteProduct,
+    useCreateProduct,
+    useUpdateProduct,
+} from '@/hooks/useProducts'
 import { getErrorMessage } from '@/utils/getErrorMessage'
 import { useCategories } from '@/hooks/useCategories'
 import { useUnitsOfMeasure } from '@/hooks/useUnitsOfMeasure'
-import type { Product } from '@/services/ProductService'
+import { useCrudOperations } from '@/hooks'
+import { FormModal, DeleteConfirmDialog } from '@/components/shared'
+import type { Product, ProductInput } from '@/services/ProductService'
 import ProductForm from './ProductForm'
 import Select from '@/components/ui/Select'
 import { HiOutlinePencil, HiOutlineTrash, HiPlus } from 'react-icons/hi'
 
 const ProductsView = () => {
-    const [isFormOpen, setIsFormOpen] = useState(false)
-    const [selectedProduct, setSelectedProduct] = useState<Product | null>(null)
-    const [deleteDialog, setDeleteDialog] = useState<{
-        open: boolean
-        product: Product | null
-    }>({ open: false, product: null })
-
-    const [pageIndex, setPageIndex] = useState(1)
-    const [pageSize, setPageSize] = useState(10)
+    const crud = useCrudOperations<Product>()
     const [filterCategoryId, setFilterCategoryId] = useState<
         number | undefined
     >(undefined)
-    const offset = (pageIndex - 1) * pageSize
+    const offset = (crud.pageIndex - 1) * crud.pageSize
 
     const { data, isLoading } = useProducts({
-        limit: pageSize,
+        limit: crud.pageSize,
         offset,
         categoryId: filterCategoryId,
     })
@@ -40,6 +38,9 @@ const ProductsView = () => {
     const { data: categoriesData } = useCategories()
     const { data: unitsData } = useUnitsOfMeasure()
     const deleteProduct = useDeleteProduct()
+    const createProduct = useCreateProduct()
+    const updateProduct = useUpdateProduct()
+    const isPending = createProduct.isPending || updateProduct.isPending
 
     const categoryMap = useMemo(() => {
         const categories = categoriesData?.items ?? []
@@ -63,50 +64,58 @@ const ProductsView = () => {
         return map
     }, [unitsData])
 
-    const handleCreate = () => {
-        setSelectedProduct(null)
-        setIsFormOpen(true)
-    }
-
-    const handleEdit = (product: Product) => {
-        setSelectedProduct(product)
-        setIsFormOpen(true)
-    }
-
-    const handleDeleteClick = (product: Product) => {
-        setDeleteDialog({ open: true, product })
-    }
-
-    const handleDeleteConfirm = async () => {
-        if (deleteDialog.product) {
-            try {
-                await deleteProduct.mutateAsync(deleteDialog.product.id)
+    const handleFormSubmit = async (formData: ProductInput) => {
+        try {
+            if (crud.isEditOpen && crud.selectedItem) {
+                await updateProduct.mutateAsync({
+                    id: crud.selectedItem.id,
+                    data: formData,
+                })
                 toast.push(
-                    <Notification title="Producto eliminado" type="success">
-                        El producto se eliminó correctamente
+                    <Notification title="Producto actualizado" type="success">
+                        El producto se actualizó correctamente
                     </Notification>,
                     { placement: 'top-center' }
                 )
-                setDeleteDialog({ open: false, product: null })
-            } catch (error: unknown) {
-                const errorMessage = getErrorMessage(
-                    error,
-                    'Error al eliminar el producto'
-                )
-
+            } else {
+                await createProduct.mutateAsync(formData)
                 toast.push(
-                    <Notification title="Error" type="danger">
-                        {errorMessage}
+                    <Notification title="Producto creado" type="success">
+                        El producto se creó correctamente
                     </Notification>,
                     { placement: 'top-center' }
                 )
             }
+            crud.closeAll()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al guardar el producto')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
         }
     }
 
-    const handleFormClose = () => {
-        setIsFormOpen(false)
-        setSelectedProduct(null)
+    const handleDeleteConfirm = async () => {
+        if (!crud.selectedItem) return
+        try {
+            await deleteProduct.mutateAsync(crud.selectedItem.id)
+            toast.push(
+                <Notification title="Producto eliminado" type="success">
+                    El producto se eliminó correctamente
+                </Notification>,
+                { placement: 'top-center' }
+            )
+            crud.closeAll()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al eliminar el producto')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
     }
 
     const columns: ColumnDef<Product>[] = [
@@ -215,13 +224,13 @@ const ProductsView = () => {
                             size="sm"
                             variant="plain"
                             icon={<HiOutlinePencil />}
-                            onClick={() => handleEdit(row.original)}
+                            onClick={() => crud.openEdit(row.original)}
                         />
                         <Button
                             size="sm"
                             variant="plain"
                             icon={<HiOutlineTrash />}
-                            onClick={() => handleDeleteClick(row.original)}
+                            onClick={() => crud.openDelete(row.original)}
                         />
                     </div>
                 )
@@ -258,14 +267,14 @@ const ProductsView = () => {
                                     setFilterCategoryId(
                                         option?.value || undefined
                                     )
-                                    setPageIndex(1)
+                                    crud.onPaginationChange(1, crud.pageSize)
                                 }}
                             />
                             <Button
                                 variant="solid"
                                 size="sm"
                                 icon={<HiPlus />}
-                                onClick={handleCreate}
+                                onClick={crud.openCreate}
                             >
                                 Nuevo Producto
                             </Button>
@@ -276,54 +285,44 @@ const ProductsView = () => {
                         columns={columns}
                         data={items}
                         loading={isLoading}
-                        pagingData={{ total, pageIndex, pageSize }}
-                        onPaginationChange={setPageIndex}
-                        onSelectChange={(size) => {
-                            setPageSize(size)
-                            setPageIndex(1)
+                        pagingData={{
+                            total,
+                            pageIndex: crud.pageIndex,
+                            pageSize: crud.pageSize,
                         }}
+                        onPaginationChange={(idx) =>
+                            crud.onPaginationChange(idx, crud.pageSize)
+                        }
+                        onSelectChange={(size) =>
+                            crud.onPaginationChange(1, size)
+                        }
                     />
                 </div>
             </Card>
 
-            <ProductForm
-                open={isFormOpen}
-                product={selectedProduct}
-                onClose={handleFormClose}
-            />
-
-            <Dialog
-                isOpen={deleteDialog.open}
-                onClose={() => setDeleteDialog({ open: false, product: null })}
-                onRequestClose={() =>
-                    setDeleteDialog({ open: false, product: null })
-                }
+            <FormModal
+                formId="product-form"
+                width={640}
+                isOpen={crud.isCreateOpen || crud.isEditOpen}
+                title={crud.isEditOpen ? 'Editar Producto' : 'Nuevo Producto'}
+                isSubmitting={isPending}
+                onClose={crud.closeAll}
             >
-                <h5 className="mb-4">Confirmar Eliminación</h5>
-                <p className="mb-6">
-                    ¿Estás seguro de que deseas eliminar el producto{' '}
-                    <strong>{deleteDialog.product?.name}</strong>? Esta acción
-                    no se puede deshacer.
-                </p>
-                <div className="flex justify-end gap-2">
-                    <Button
-                        variant="plain"
-                        disabled={deleteProduct.isPending}
-                        onClick={() =>
-                            setDeleteDialog({ open: false, product: null })
-                        }
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        variant="solid"
-                        loading={deleteProduct.isPending}
-                        onClick={handleDeleteConfirm}
-                    >
-                        Eliminar
-                    </Button>
-                </div>
-            </Dialog>
+                <ProductForm
+                    formId="product-form"
+                    product={crud.selectedItem}
+                    isSubmitting={isPending}
+                    onSubmit={handleFormSubmit}
+                />
+            </FormModal>
+
+            <DeleteConfirmDialog
+                isOpen={crud.isDeleteOpen}
+                itemName={crud.selectedItem?.name}
+                isDeleting={deleteProduct.isPending}
+                onClose={crud.closeAll}
+                onConfirm={handleDeleteConfirm}
+            />
         </>
     )
 }

--- a/src/views/inventory/SuppliersView/SupplierForm.tsx
+++ b/src/views/inventory/SuppliersView/SupplierForm.tsx
@@ -1,13 +1,7 @@
 import { useState, useEffect } from 'react'
-import Dialog from '@/components/ui/Dialog'
-import Button from '@/components/ui/Button'
 import Input from '@/components/ui/Input'
 import Select from '@/components/ui/Select'
 import Switcher from '@/components/ui/Switcher'
-import Notification from '@/components/ui/Notification'
-import toast from '@/components/ui/toast'
-import { useCreateSupplier, useUpdateSupplier } from '@/hooks/useSuppliers'
-import { getErrorMessage } from '@/utils/getErrorMessage'
 import type {
     Supplier,
     SupplierInput,
@@ -16,12 +10,18 @@ import type {
 import { TAX_TYPE_LABELS } from '@/services/SupplierService'
 
 interface SupplierFormProps {
-    open: boolean
-    onClose: () => void
+    formId: string
     supplier?: Supplier | null
+    isSubmitting?: boolean
+    onSubmit: (data: SupplierInput) => void
 }
 
-const SupplierForm = ({ open, onClose, supplier }: SupplierFormProps) => {
+const SupplierForm = ({
+    formId,
+    supplier,
+    isSubmitting = false,
+    onSubmit,
+}: SupplierFormProps) => {
     const [formData, setFormData] = useState<SupplierInput>({
         name: '',
         taxId: '',
@@ -36,11 +36,6 @@ const SupplierForm = ({ open, onClose, supplier }: SupplierFormProps) => {
         notes: '',
         isActive: true,
     })
-
-    const createSupplier = useCreateSupplier()
-    const updateSupplier = useUpdateSupplier()
-
-    const isEdit = !!supplier
 
     const taxTypeOptions = [
         { value: 1, label: TAX_TYPE_LABELS[1] },
@@ -81,366 +76,267 @@ const SupplierForm = ({ open, onClose, supplier }: SupplierFormProps) => {
                 isActive: true,
             })
         }
-    }, [supplier, open])
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-
-        try {
-            if (isEdit && supplier) {
-                await updateSupplier.mutateAsync({
-                    id: supplier.id,
-                    data: formData,
-                })
-            } else {
-                await createSupplier.mutateAsync(formData)
-            }
-
-            toast.push(
-                <Notification
-                    title={
-                        isEdit ? 'Proveedor actualizado' : 'Proveedor creado'
-                    }
-                    type="success"
-                >
-                    {isEdit
-                        ? 'El proveedor se actualizó correctamente'
-                        : 'El proveedor se creó correctamente'}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-
-            onClose()
-        } catch (error: unknown) {
-            const errorMessage = getErrorMessage(
-                error,
-                'Error al guardar el proveedor'
-            )
-
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {errorMessage}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-
-            console.error('Error saving supplier:', error)
-        }
-    }
-
-    const handleClose = () => {
-        if (!createSupplier.isPending && !updateSupplier.isPending) {
-            onClose()
-        }
-    }
+    }, [supplier])
 
     return (
-        <Dialog
-            isOpen={open}
-            width={800}
-            onClose={handleClose}
-            onRequestClose={handleClose}
+        <form
+            id={formId}
+            onSubmit={(e) => {
+                e.preventDefault()
+                onSubmit(formData)
+            }}
         >
-            <div className="flex flex-col h-full justify-between">
-                <h5 className="mb-4">
-                    {isEdit ? 'Editar Proveedor' : 'Nuevo Proveedor'}
-                </h5>
-
-                <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        {/* Basic Information */}
-                        <div>
-                            <h6 className="mb-3 text-sm font-semibold">
-                                Información Básica
-                            </h6>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                {/* Name */}
-                                <div className="md:col-span-2">
-                                    <label className="block text-sm font-medium mb-2">
-                                        Nombre{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Input
-                                        required
-                                        type="text"
-                                        placeholder="Nombre del proveedor"
-                                        value={formData.name}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                name: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                {/* Tax ID */}
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Tax ID{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Input
-                                        required
-                                        type="text"
-                                        placeholder="RUC, Cédula, Pasaporte..."
-                                        value={formData.taxId}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                taxId: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                {/* Tax Type */}
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Tipo de ID{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Select
-                                        value={taxTypeOptions.find(
-                                            (opt) =>
-                                                opt.value === formData.taxType
-                                        )}
-                                        options={taxTypeOptions}
-                                        onChange={(option) =>
-                                            setFormData({
-                                                ...formData,
-                                                taxType:
-                                                    option?.value as TaxType,
-                                            })
-                                        }
-                                    />
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Contact Information */}
-                        <div>
-                            <h6 className="mb-3 text-sm font-semibold">
-                                Información de Contacto
-                            </h6>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                {/* Email */}
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Email
-                                    </label>
-                                    <Input
-                                        type="email"
-                                        placeholder="email@ejemplo.com"
-                                        value={formData.email}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                email: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                {/* Phone */}
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Teléfono
-                                    </label>
-                                    <Input
-                                        type="text"
-                                        placeholder="0987654321"
-                                        value={formData.phone}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                phone: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Address */}
-                        <div>
-                            <h6 className="mb-3 text-sm font-semibold">
-                                Dirección
-                            </h6>
-                            <div className="space-y-4">
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Dirección
-                                    </label>
-                                    <Input
-                                        type="text"
-                                        placeholder="Calle principal 123"
-                                        value={formData.address}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                address: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                    {/* City */}
-                                    <div>
-                                        <label className="block text-sm font-medium mb-2">
-                                            Ciudad
-                                        </label>
-                                        <Input
-                                            type="text"
-                                            placeholder="Quito"
-                                            value={formData.city}
-                                            onChange={(e) =>
-                                                setFormData({
-                                                    ...formData,
-                                                    city: e.target.value,
-                                                })
-                                            }
-                                        />
-                                    </div>
-
-                                    {/* Country */}
-                                    <div>
-                                        <label className="block text-sm font-medium mb-2">
-                                            País
-                                        </label>
-                                        <Input
-                                            type="text"
-                                            placeholder="Ecuador"
-                                            value={formData.country}
-                                            onChange={(e) =>
-                                                setFormData({
-                                                    ...formData,
-                                                    country: e.target.value,
-                                                })
-                                            }
-                                        />
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Financial & Supply Information */}
-                        <div>
-                            <h6 className="mb-3 text-sm font-semibold">
-                                Información Financiera y de Abastecimiento
-                            </h6>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                {/* Payment Terms */}
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Términos de Pago (días)
-                                    </label>
-                                    <Input
-                                        type="number"
-                                        placeholder="30"
-                                        value={formData.paymentTerms || ''}
-                                        min="0"
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                paymentTerms: e.target.value
-                                                    ? parseInt(e.target.value)
-                                                    : undefined,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                {/* Lead Time Days */}
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Tiempo de Entrega (días)
-                                    </label>
-                                    <Input
-                                        type="number"
-                                        placeholder="7"
-                                        value={formData.leadTimeDays || ''}
-                                        min="0"
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                leadTimeDays: e.target.value
-                                                    ? parseInt(e.target.value)
-                                                    : undefined,
-                                            })
-                                        }
-                                    />
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Notes */}
-                        <div>
+            <div className="space-y-4">
+                <div>
+                    <h6 className="mb-3 text-sm font-semibold">
+                        Información Básica
+                    </h6>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div className="md:col-span-2">
                             <label className="block text-sm font-medium mb-2">
-                                Notas
+                                Nombre <span className="text-red-500">*</span>
                             </label>
                             <Input
-                                textArea
-                                placeholder="Notas adicionales sobre el proveedor..."
-                                value={formData.notes}
+                                required
+                                type="text"
+                                placeholder="Nombre del proveedor"
+                                value={formData.name}
+                                disabled={isSubmitting}
                                 onChange={(e) =>
                                     setFormData({
                                         ...formData,
-                                        notes: e.target.value,
+                                        name: e.target.value,
                                     })
                                 }
                             />
                         </div>
 
-                        {/* Status */}
                         <div>
                             <label className="block text-sm font-medium mb-2">
-                                Estado
+                                Tax ID <span className="text-red-500">*</span>
                             </label>
-                            <Switcher
-                                checked={formData.isActive}
-                                onChange={(checked) =>
+                            <Input
+                                required
+                                type="text"
+                                placeholder="RUC, Cédula, Pasaporte..."
+                                value={formData.taxId}
+                                disabled={isSubmitting}
+                                onChange={(e) =>
                                     setFormData({
                                         ...formData,
-                                        isActive: !checked,
+                                        taxId: e.target.value,
                                     })
                                 }
                             />
-                            <p className="text-xs text-gray-500 mt-1">
-                                {formData.isActive
-                                    ? 'Proveedor activo'
-                                    : 'Proveedor inactivo'}
-                            </p>
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Tipo de ID{' '}
+                                <span className="text-red-500">*</span>
+                            </label>
+                            <Select
+                                isDisabled={isSubmitting}
+                                value={taxTypeOptions.find(
+                                    (opt) => opt.value === formData.taxType
+                                )}
+                                options={taxTypeOptions}
+                                onChange={(option) =>
+                                    setFormData({
+                                        ...formData,
+                                        taxType: option?.value as TaxType,
+                                    })
+                                }
+                            />
                         </div>
                     </div>
+                </div>
 
-                    {/* Buttons */}
-                    <div className="flex justify-end gap-2 mt-6 pt-4 border-t">
-                        <Button
-                            type="button"
-                            variant="plain"
-                            disabled={
-                                createSupplier.isPending ||
-                                updateSupplier.isPending
-                            }
-                            onClick={handleClose}
-                        >
-                            Cancelar
-                        </Button>
-                        <Button
-                            type="submit"
-                            variant="solid"
-                            loading={
-                                createSupplier.isPending ||
-                                updateSupplier.isPending
-                            }
-                        >
-                            {isEdit ? 'Actualizar' : 'Crear'}
-                        </Button>
+                <div>
+                    <h6 className="mb-3 text-sm font-semibold">
+                        Información de Contacto
+                    </h6>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Email
+                            </label>
+                            <Input
+                                type="email"
+                                placeholder="email@ejemplo.com"
+                                value={formData.email}
+                                disabled={isSubmitting}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        email: e.target.value,
+                                    })
+                                }
+                            />
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Teléfono
+                            </label>
+                            <Input
+                                type="text"
+                                placeholder="0987654321"
+                                value={formData.phone}
+                                disabled={isSubmitting}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        phone: e.target.value,
+                                    })
+                                }
+                            />
+                        </div>
                     </div>
-                </form>
+                </div>
+
+                <div>
+                    <h6 className="mb-3 text-sm font-semibold">Dirección</h6>
+                    <div className="space-y-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Dirección
+                            </label>
+                            <Input
+                                type="text"
+                                placeholder="Calle principal 123"
+                                value={formData.address}
+                                disabled={isSubmitting}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        address: e.target.value,
+                                    })
+                                }
+                            />
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                                <label className="block text-sm font-medium mb-2">
+                                    Ciudad
+                                </label>
+                                <Input
+                                    type="text"
+                                    placeholder="Quito"
+                                    value={formData.city}
+                                    disabled={isSubmitting}
+                                    onChange={(e) =>
+                                        setFormData({
+                                            ...formData,
+                                            city: e.target.value,
+                                        })
+                                    }
+                                />
+                            </div>
+
+                            <div>
+                                <label className="block text-sm font-medium mb-2">
+                                    País
+                                </label>
+                                <Input
+                                    type="text"
+                                    placeholder="Ecuador"
+                                    value={formData.country}
+                                    disabled={isSubmitting}
+                                    onChange={(e) =>
+                                        setFormData({
+                                            ...formData,
+                                            country: e.target.value,
+                                        })
+                                    }
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div>
+                    <h6 className="mb-3 text-sm font-semibold">
+                        Información Financiera y de Abastecimiento
+                    </h6>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Términos de Pago (días)
+                            </label>
+                            <Input
+                                type="number"
+                                placeholder="30"
+                                value={formData.paymentTerms || ''}
+                                min="0"
+                                disabled={isSubmitting}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        paymentTerms: e.target.value
+                                            ? parseInt(e.target.value)
+                                            : undefined,
+                                    })
+                                }
+                            />
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium mb-2">
+                                Tiempo de Entrega (días)
+                            </label>
+                            <Input
+                                type="number"
+                                placeholder="7"
+                                value={formData.leadTimeDays || ''}
+                                min="0"
+                                disabled={isSubmitting}
+                                onChange={(e) =>
+                                    setFormData({
+                                        ...formData,
+                                        leadTimeDays: e.target.value
+                                            ? parseInt(e.target.value)
+                                            : undefined,
+                                    })
+                                }
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Notas
+                    </label>
+                    <Input
+                        textArea
+                        placeholder="Notas adicionales sobre el proveedor..."
+                        value={formData.notes}
+                        disabled={isSubmitting}
+                        onChange={(e) =>
+                            setFormData({ ...formData, notes: e.target.value })
+                        }
+                    />
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium mb-2">
+                        Estado
+                    </label>
+                    <Switcher
+                        checked={formData.isActive}
+                        onChange={(checked) =>
+                            setFormData({ ...formData, isActive: checked })
+                        }
+                    />
+                    <p className="text-xs text-gray-500 mt-1">
+                        {formData.isActive
+                            ? 'Proveedor activo'
+                            : 'Proveedor inactivo'}
+                    </p>
+                </div>
             </div>
-        </Dialog>
+        </form>
     )
 }
 

--- a/src/views/inventory/SuppliersView/index.tsx
+++ b/src/views/inventory/SuppliersView/index.tsx
@@ -1,21 +1,23 @@
-import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
     useSuppliers,
     useDeleteSupplier,
+    useCreateSupplier,
+    useUpdateSupplier,
     useActivateSupplier,
     useDeactivateSupplier,
+    useCrudOperations,
 } from '@/hooks'
 import DataTable, { ColumnDef } from '@/components/shared/DataTable'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
-import Dialog from '@/components/ui/Dialog'
 import Badge from '@/components/ui/Badge'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
-import type { Supplier } from '@/services/SupplierService'
+import type { Supplier, SupplierInput } from '@/services/SupplierService'
 import { TAX_TYPE_LABELS } from '@/services/SupplierService'
 import { getErrorMessage } from '@/utils/getErrorMessage'
+import { FormModal, DeleteConfirmDialog } from '@/components/shared'
 import SupplierForm from './SupplierForm'
 import {
     HiOutlinePlus,
@@ -28,60 +30,64 @@ import {
 
 const SuppliersView = () => {
     const navigate = useNavigate()
-    const deleteSupplier = useDeleteSupplier()
-    const activateSupplier = useActivateSupplier()
-    const deactivateSupplier = useDeactivateSupplier()
+    const crud = useCrudOperations<Supplier>()
+    const offset = (crud.pageIndex - 1) * crud.pageSize
 
-    const [formOpen, setFormOpen] = useState(false)
-    const [selectedSupplier, setSelectedSupplier] = useState<Supplier | null>(
-        null
-    )
-    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-    const [supplierToDelete, setSupplierToDelete] = useState<Supplier | null>(
-        null
-    )
-
-    const [pageIndex, setPageIndex] = useState(1)
-    const [pageSize, setPageSize] = useState(10)
-    const offset = (pageIndex - 1) * pageSize
-
-    const { data, isLoading } = useSuppliers({ limit: pageSize, offset })
+    const { data, isLoading } = useSuppliers({ limit: crud.pageSize, offset })
     const suppliers = data?.items ?? []
     const total = data?.pagination?.total ?? 0
 
-    const handleEdit = (supplier: Supplier) => {
-        setSelectedSupplier(supplier)
-        setFormOpen(true)
-    }
+    const deleteSupplier = useDeleteSupplier()
+    const createSupplier = useCreateSupplier()
+    const updateSupplier = useUpdateSupplier()
+    const activateSupplier = useActivateSupplier()
+    const deactivateSupplier = useDeactivateSupplier()
+    const isPending = createSupplier.isPending || updateSupplier.isPending
 
-    const handleCreate = () => {
-        setSelectedSupplier(null)
-        setFormOpen(true)
-    }
-
-    const handleCloseForm = () => {
-        setFormOpen(false)
-        setSelectedSupplier(null)
-    }
-
-    const handleDeleteClick = (supplier: Supplier) => {
-        setSupplierToDelete(supplier)
-        setDeleteDialogOpen(true)
+    const handleFormSubmit = async (formData: SupplierInput) => {
+        try {
+            if (crud.isEditOpen && crud.selectedItem) {
+                await updateSupplier.mutateAsync({
+                    id: crud.selectedItem.id,
+                    data: formData,
+                })
+                toast.push(
+                    <Notification title="Proveedor actualizado" type="success">
+                        El proveedor se actualizó correctamente
+                    </Notification>,
+                    { placement: 'top-center' }
+                )
+            } else {
+                await createSupplier.mutateAsync(formData)
+                toast.push(
+                    <Notification title="Proveedor creado" type="success">
+                        El proveedor se creó correctamente
+                    </Notification>,
+                    { placement: 'top-center' }
+                )
+            }
+            crud.closeAll()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al guardar el proveedor')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
     }
 
     const handleDeleteConfirm = async () => {
-        if (!supplierToDelete) return
-
+        if (!crud.selectedItem) return
         try {
-            await deleteSupplier.mutateAsync(supplierToDelete.id)
+            await deleteSupplier.mutateAsync(crud.selectedItem.id)
             toast.push(
                 <Notification title="Proveedor eliminado" type="success">
                     El proveedor se eliminó correctamente
                 </Notification>,
                 { placement: 'top-center' }
             )
-            setDeleteDialogOpen(false)
-            setSupplierToDelete(null)
+            crud.closeAll()
         } catch (error: unknown) {
             toast.push(
                 <Notification title="Error" type="danger">
@@ -198,7 +204,7 @@ const SuppliersView = () => {
                         size="sm"
                         variant="plain"
                         icon={<HiOutlinePencil />}
-                        onClick={() => handleEdit(row.original)}
+                        onClick={() => crud.openEdit(row.original)}
                     />
                     <Button
                         size="sm"
@@ -216,7 +222,7 @@ const SuppliersView = () => {
                         size="sm"
                         variant="plain"
                         icon={<HiOutlineTrash />}
-                        onClick={() => handleDeleteClick(row.original)}
+                        onClick={() => crud.openDelete(row.original)}
                     />
                 </div>
             ),
@@ -240,7 +246,7 @@ const SuppliersView = () => {
                             variant="solid"
                             size="sm"
                             icon={<HiOutlinePlus />}
-                            onClick={handleCreate}
+                            onClick={crud.openCreate}
                         >
                             Nuevo Proveedor
                         </Button>
@@ -250,49 +256,44 @@ const SuppliersView = () => {
                         columns={columns}
                         data={suppliers}
                         loading={isLoading}
-                        pagingData={{ total, pageIndex, pageSize }}
-                        onPaginationChange={setPageIndex}
-                        onSelectChange={(size) => {
-                            setPageSize(size)
-                            setPageIndex(1)
+                        pagingData={{
+                            total,
+                            pageIndex: crud.pageIndex,
+                            pageSize: crud.pageSize,
                         }}
+                        onPaginationChange={(idx) =>
+                            crud.onPaginationChange(idx, crud.pageSize)
+                        }
+                        onSelectChange={(size) =>
+                            crud.onPaginationChange(1, size)
+                        }
                     />
                 </div>
             </Card>
 
-            <SupplierForm
-                open={formOpen}
-                supplier={selectedSupplier}
-                onClose={handleCloseForm}
-            />
-
-            <Dialog
-                isOpen={deleteDialogOpen}
-                onClose={() => setDeleteDialogOpen(false)}
-                onRequestClose={() => setDeleteDialogOpen(false)}
+            <FormModal
+                formId="supplier-form"
+                width={800}
+                isOpen={crud.isCreateOpen || crud.isEditOpen}
+                title={crud.isEditOpen ? 'Editar Proveedor' : 'Nuevo Proveedor'}
+                isSubmitting={isPending}
+                onClose={crud.closeAll}
             >
-                <h5 className="mb-4">Confirmar eliminación</h5>
-                <p className="mb-6">
-                    ¿Está seguro que desea eliminar el proveedor{' '}
-                    <strong>{supplierToDelete?.name}</strong>? Esta acción no se
-                    puede deshacer.
-                </p>
-                <div className="flex justify-end gap-2">
-                    <Button
-                        variant="plain"
-                        onClick={() => setDeleteDialogOpen(false)}
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        variant="solid"
-                        loading={deleteSupplier.isPending}
-                        onClick={handleDeleteConfirm}
-                    >
-                        Eliminar
-                    </Button>
-                </div>
-            </Dialog>
+                <SupplierForm
+                    formId="supplier-form"
+                    supplier={crud.selectedItem}
+                    isSubmitting={isPending}
+                    onSubmit={handleFormSubmit}
+                />
+            </FormModal>
+
+            <DeleteConfirmDialog
+                isOpen={crud.isDeleteOpen}
+                itemName={crud.selectedItem?.name}
+                isDeleting={deleteSupplier.isPending}
+                onClose={crud.closeAll}
+                onConfirm={handleDeleteConfirm}
+            />
         </>
     )
 }


### PR DESCRIPTION
## Descripción

Refactor three inventory views to use the shared useCrudOperations hook,
  FormModal, and DeleteConfirmDialog components.

  - Extract Dialog/API/toast logic out of ProductForm, SupplierForm, and CustomerForm — forms are now pure UI components (formId + onSubmit pattern)
  - Move create/update mutations and toast notifications to each parent view
  - Replace manual useState (modales, paginación) with useCrudOperations<T>()
  - Replace inline <Dialog> delete confirmations with <DeleteConfirmDialog>
  - Wrap form components in <FormModal> (width=640 products, width=800 suppliers/customers)
  - Add optional width prop to FormModal to support variable dialog sizes
  - Fix bug in SupplierForm: Switcher isActive was inverted (→ checked)

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
