### PR TITLE
feat(a11y): asociar labels/id en formularios y aria-label en botones de tabla

### DIFF
--- a/src/views/inventory/CategoriesView/CategoryForm.tsx
+++ b/src/views/inventory/CategoriesView/CategoryForm.tsx
@@ -38,11 +38,13 @@ const CategoryForm = ({
                     <FormContainer>
                         <FormItem
                             asterisk
+                            htmlFor="name"
                             label="Nombre"
                             invalid={!!(errors.name && touched.name)}
                             errorMessage={errors.name}
                         >
                             <Field
+                                id="name"
                                 name="name"
                                 placeholder="Nombre de la categoría"
                                 component={Input}
@@ -51,6 +53,7 @@ const CategoryForm = ({
                         </FormItem>
 
                         <FormItem
+                            htmlFor="description"
                             label="Descripción"
                             invalid={
                                 !!(errors.description && touched.description)
@@ -59,6 +62,7 @@ const CategoryForm = ({
                         >
                             <Field
                                 textArea
+                                id="description"
                                 name="description"
                                 placeholder="Descripción de la categoría"
                                 style={{ minHeight: '80px' }}

--- a/src/views/inventory/CategoriesView/index.tsx
+++ b/src/views/inventory/CategoriesView/index.tsx
@@ -127,12 +127,14 @@ const CategoriesView = () => {
                         <Button
                             size="sm"
                             variant="plain"
+                            aria-label={`Editar ${row.original.name}`}
                             icon={<HiOutlinePencil />}
                             onClick={() => crud.openEdit(row.original)}
                         />
                         <Button
                             size="sm"
                             variant="plain"
+                            aria-label={`Eliminar ${row.original.name}`}
                             icon={<HiOutlineTrash />}
                             onClick={() => crud.openDelete(row.original)}
                         />

--- a/src/views/inventory/CustomersView/CustomerForm.tsx
+++ b/src/views/inventory/CustomersView/CustomerForm.tsx
@@ -80,11 +80,13 @@ const CustomerForm = ({
                             <div className="md:col-span-2">
                                 <FormItem
                                     asterisk
+                                    htmlFor="name"
                                     label="Nombre"
                                     invalid={!!(errors.name && touched.name)}
                                     errorMessage={errors.name}
                                 >
                                     <Field
+                                        id="name"
                                         name="name"
                                         type="text"
                                         placeholder="Nombre del cliente"
@@ -96,11 +98,13 @@ const CustomerForm = ({
 
                             <FormItem
                                 asterisk
+                                htmlFor="taxId"
                                 label="Tax ID"
                                 invalid={!!(errors.taxId && touched.taxId)}
                                 errorMessage={errors.taxId}
                             >
                                 <Field
+                                    id="taxId"
                                     name="taxId"
                                     type="text"
                                     placeholder="RUC, Cédula, Pasaporte..."
@@ -111,11 +115,13 @@ const CustomerForm = ({
 
                             <FormItem
                                 asterisk
+                                htmlFor="taxType"
                                 label="Tipo de ID"
                                 invalid={!!(errors.taxType && touched.taxType)}
                                 errorMessage={errors.taxType as string}
                             >
                                 <Select
+                                    inputId="taxType"
                                     isDisabled={isSubmitting}
                                     value={taxTypeOptions.find(
                                         (opt) => opt.value === values.taxType
@@ -139,11 +145,13 @@ const CustomerForm = ({
                         </h6>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <FormItem
+                                htmlFor="email"
                                 label="Email"
                                 invalid={!!(errors.email && touched.email)}
                                 errorMessage={errors.email}
                             >
                                 <Field
+                                    id="email"
                                     name="email"
                                     type="email"
                                     placeholder="email@ejemplo.com"
@@ -153,11 +161,13 @@ const CustomerForm = ({
                             </FormItem>
 
                             <FormItem
+                                htmlFor="phone"
                                 label="Teléfono"
                                 invalid={!!(errors.phone && touched.phone)}
                                 errorMessage={errors.phone}
                             >
                                 <Field
+                                    id="phone"
                                     name="phone"
                                     type="text"
                                     placeholder="0987654321"
@@ -172,11 +182,13 @@ const CustomerForm = ({
                         </h6>
                         <div className="space-y-4">
                             <FormItem
+                                htmlFor="address"
                                 label="Dirección"
                                 invalid={!!(errors.address && touched.address)}
                                 errorMessage={errors.address}
                             >
                                 <Field
+                                    id="address"
                                     name="address"
                                     type="text"
                                     placeholder="Calle principal 123"
@@ -186,11 +198,13 @@ const CustomerForm = ({
                             </FormItem>
                             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                                 <FormItem
+                                    htmlFor="city"
                                     label="Ciudad"
                                     invalid={!!(errors.city && touched.city)}
                                     errorMessage={errors.city}
                                 >
                                     <Field
+                                        id="city"
                                         name="city"
                                         type="text"
                                         placeholder="Quito"
@@ -200,11 +214,13 @@ const CustomerForm = ({
                                 </FormItem>
 
                                 <FormItem
+                                    htmlFor="state"
                                     label="Provincia/Estado"
                                     invalid={!!(errors.state && touched.state)}
                                     errorMessage={errors.state}
                                 >
                                     <Field
+                                        id="state"
                                         name="state"
                                         type="text"
                                         placeholder="Pichincha"
@@ -214,6 +230,7 @@ const CustomerForm = ({
                                 </FormItem>
 
                                 <FormItem
+                                    htmlFor="country"
                                     label="País"
                                     invalid={
                                         !!(errors.country && touched.country)
@@ -221,6 +238,7 @@ const CustomerForm = ({
                                     errorMessage={errors.country}
                                 >
                                     <Field
+                                        id="country"
                                         name="country"
                                         type="text"
                                         placeholder="Ecuador"
@@ -236,6 +254,7 @@ const CustomerForm = ({
                         </h6>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <FormItem
+                                htmlFor="creditLimit"
                                 label="Límite de Crédito"
                                 invalid={
                                     !!(
@@ -246,6 +265,7 @@ const CustomerForm = ({
                                 errorMessage={errors.creditLimit as string}
                             >
                                 <Input
+                                    id="creditLimit"
                                     type="number"
                                     placeholder="0.00"
                                     value={values.creditLimit ?? ''}
@@ -267,6 +287,7 @@ const CustomerForm = ({
                             </FormItem>
 
                             <FormItem
+                                htmlFor="paymentTerms"
                                 label="Términos de Pago (días)"
                                 invalid={
                                     !!(
@@ -277,6 +298,7 @@ const CustomerForm = ({
                                 errorMessage={errors.paymentTerms as string}
                             >
                                 <Input
+                                    id="paymentTerms"
                                     type="number"
                                     placeholder="30"
                                     value={values.paymentTerms ?? ''}
@@ -297,8 +319,9 @@ const CustomerForm = ({
                             </FormItem>
                         </div>
 
-                        <FormItem label="Estado">
+                        <FormItem htmlFor="isActive" label="Estado">
                             <Switcher
+                                id="isActive"
                                 checked={values.isActive}
                                 onChange={(checked) =>
                                     setFieldValue('isActive', checked)

--- a/src/views/inventory/CustomersView/index.tsx
+++ b/src/views/inventory/CustomersView/index.tsx
@@ -195,6 +195,7 @@ const CustomersView = () => {
                     <Button
                         size="sm"
                         variant="plain"
+                        aria-label={`Ver ${row.original.name}`}
                         icon={<HiOutlineEye />}
                         onClick={() =>
                             navigate(`/customers/${row.original.id}`)
@@ -203,12 +204,16 @@ const CustomersView = () => {
                     <Button
                         size="sm"
                         variant="plain"
+                        aria-label={`Editar ${row.original.name}`}
                         icon={<HiOutlinePencil />}
                         onClick={() => crud.openEdit(row.original)}
                     />
                     <Button
                         size="sm"
                         variant="plain"
+                        aria-label={`${
+                            row.original.isActive ? 'Desactivar' : 'Activar'
+                        } ${row.original.name}`}
                         icon={
                             row.original.isActive ? (
                                 <HiOutlineXCircle />
@@ -221,6 +226,7 @@ const CustomersView = () => {
                     <Button
                         size="sm"
                         variant="plain"
+                        aria-label={`Eliminar ${row.original.name}`}
                         icon={<HiOutlineTrash />}
                         onClick={() => crud.openDelete(row.original)}
                     />

--- a/src/views/inventory/ProductsView/ProductForm.tsx
+++ b/src/views/inventory/ProductsView/ProductForm.tsx
@@ -86,11 +86,13 @@ const ProductForm = ({
                     <FormContainer>
                         <FormItem
                             asterisk
+                            htmlFor="name"
                             label="Nombre"
                             invalid={!!(errors.name && touched.name)}
                             errorMessage={errors.name}
                         >
                             <Field
+                                id="name"
                                 name="name"
                                 type="text"
                                 placeholder="Nombre del producto"
@@ -101,11 +103,13 @@ const ProductForm = ({
 
                         <FormItem
                             asterisk
+                            htmlFor="sku"
                             label="SKU"
                             invalid={!!(errors.sku && touched.sku)}
                             errorMessage={errors.sku}
                         >
                             <Field
+                                id="sku"
                                 name="sku"
                                 type="text"
                                 placeholder="SKU del producto"
@@ -115,6 +119,7 @@ const ProductForm = ({
                         </FormItem>
 
                         <FormItem
+                            htmlFor="description"
                             label="Descripción"
                             invalid={
                                 !!(errors.description && touched.description)
@@ -123,6 +128,7 @@ const ProductForm = ({
                         >
                             <Field
                                 textArea
+                                id="description"
                                 name="description"
                                 placeholder="Descripción del producto"
                                 style={{ minHeight: '80px' }}
@@ -132,11 +138,13 @@ const ProductForm = ({
                         </FormItem>
 
                         <FormItem
+                            htmlFor="barcode"
                             label="Código de barras"
                             invalid={!!(errors.barcode && touched.barcode)}
                             errorMessage={errors.barcode as string}
                         >
                             <Field
+                                id="barcode"
                                 name="barcode"
                                 type="text"
                                 placeholder="Ej: 7501234567890"
@@ -146,6 +154,7 @@ const ProductForm = ({
                         </FormItem>
 
                         <FormItem
+                            htmlFor="categoryId"
                             label="Categoría"
                             invalid={
                                 !!(errors.categoryId && touched.categoryId)
@@ -153,6 +162,7 @@ const ProductForm = ({
                             errorMessage={errors.categoryId as string}
                         >
                             <Select
+                                inputId="categoryId"
                                 placeholder="Seleccione una categoría"
                                 isDisabled={isSubmitting}
                                 value={categoryOptions.find(
@@ -178,6 +188,7 @@ const ProductForm = ({
                         </FormItem>
 
                         <FormItem
+                            htmlFor="unitOfMeasureId"
                             label="Unidad de Medida"
                             invalid={
                                 !!(
@@ -188,6 +199,7 @@ const ProductForm = ({
                             errorMessage={errors.unitOfMeasureId as string}
                         >
                             <Select
+                                inputId="unitOfMeasureId"
                                 placeholder="Seleccione una unidad"
                                 isDisabled={isSubmitting}
                                 value={unitOptions.find(
@@ -216,6 +228,7 @@ const ProductForm = ({
 
                         <div className="grid grid-cols-2 gap-4">
                             <FormItem
+                                htmlFor="purchasePrice"
                                 label="Precio de compra"
                                 invalid={
                                     !!(
@@ -226,6 +239,7 @@ const ProductForm = ({
                                 errorMessage={errors.purchasePrice as string}
                             >
                                 <Input
+                                    id="purchasePrice"
                                     type="number"
                                     placeholder="0.00"
                                     value={values.purchasePrice ?? ''}
@@ -244,6 +258,7 @@ const ProductForm = ({
                                 />
                             </FormItem>
                             <FormItem
+                                htmlFor="salePrice"
                                 label="Precio de venta"
                                 invalid={
                                     !!(errors.salePrice && touched.salePrice)
@@ -251,6 +266,7 @@ const ProductForm = ({
                                 errorMessage={errors.salePrice as string}
                             >
                                 <Input
+                                    id="salePrice"
                                     type="number"
                                     placeholder="0.00"
                                     value={values.salePrice ?? ''}
@@ -273,23 +289,31 @@ const ProductForm = ({
                         <div className="flex gap-6">
                             <div className="flex items-center gap-3">
                                 <Switcher
+                                    id="isActive"
                                     checked={values.isActive}
                                     onChange={(checked) =>
                                         setFieldValue('isActive', checked)
                                     }
                                 />
-                                <label className="text-sm font-medium">
+                                <label
+                                    htmlFor="isActive"
+                                    className="text-sm font-medium"
+                                >
                                     Activo
                                 </label>
                             </div>
                             <div className="flex items-center gap-3">
                                 <Switcher
+                                    id="isService"
                                     checked={values.isService}
                                     onChange={(checked) =>
                                         setFieldValue('isService', checked)
                                     }
                                 />
-                                <label className="text-sm font-medium">
+                                <label
+                                    htmlFor="isService"
+                                    className="text-sm font-medium"
+                                >
                                     Es servicio
                                 </label>
                             </div>
@@ -297,6 +321,7 @@ const ProductForm = ({
 
                         <div className="grid grid-cols-2 gap-4">
                             <FormItem
+                                htmlFor="minStock"
                                 label="Stock mínimo"
                                 invalid={
                                     !!(errors.minStock && touched.minStock)
@@ -304,6 +329,7 @@ const ProductForm = ({
                                 errorMessage={errors.minStock as string}
                             >
                                 <Input
+                                    id="minStock"
                                     type="number"
                                     placeholder="0"
                                     value={values.minStock ?? ''}
@@ -322,6 +348,7 @@ const ProductForm = ({
                                 />
                             </FormItem>
                             <FormItem
+                                htmlFor="maxStock"
                                 label="Stock máximo"
                                 invalid={
                                     !!(errors.maxStock && touched.maxStock)
@@ -329,6 +356,7 @@ const ProductForm = ({
                                 errorMessage={errors.maxStock as string}
                             >
                                 <Input
+                                    id="maxStock"
                                     type="number"
                                     placeholder="Sin límite"
                                     value={values.maxStock ?? ''}
@@ -347,6 +375,7 @@ const ProductForm = ({
                                 />
                             </FormItem>
                             <FormItem
+                                htmlFor="reorderPoint"
                                 label="Punto de reorden"
                                 invalid={
                                     !!(
@@ -357,6 +386,7 @@ const ProductForm = ({
                                 errorMessage={errors.reorderPoint as string}
                             >
                                 <Input
+                                    id="reorderPoint"
                                     type="number"
                                     placeholder="0"
                                     value={values.reorderPoint ?? ''}
@@ -375,6 +405,7 @@ const ProductForm = ({
                                 />
                             </FormItem>
                             <FormItem
+                                htmlFor="leadTimeDays"
                                 label="Tiempo de entrega (días)"
                                 invalid={
                                     !!(
@@ -385,6 +416,7 @@ const ProductForm = ({
                                 errorMessage={errors.leadTimeDays as string}
                             >
                                 <Input
+                                    id="leadTimeDays"
                                     type="number"
                                     placeholder="Sin definir"
                                     value={values.leadTimeDays ?? ''}

--- a/src/views/inventory/ProductsView/index.tsx
+++ b/src/views/inventory/ProductsView/index.tsx
@@ -223,12 +223,14 @@ const ProductsView = () => {
                         <Button
                             size="sm"
                             variant="plain"
+                            aria-label={`Editar ${row.original.name}`}
                             icon={<HiOutlinePencil />}
                             onClick={() => crud.openEdit(row.original)}
                         />
                         <Button
                             size="sm"
                             variant="plain"
+                            aria-label={`Eliminar ${row.original.name}`}
                             icon={<HiOutlineTrash />}
                             onClick={() => crud.openDelete(row.original)}
                         />

--- a/src/views/inventory/SuppliersView/SupplierForm.tsx
+++ b/src/views/inventory/SuppliersView/SupplierForm.tsx
@@ -80,11 +80,13 @@ const SupplierForm = ({
                             <div className="md:col-span-2">
                                 <FormItem
                                     asterisk
+                                    htmlFor="name"
                                     label="Nombre"
                                     invalid={!!(errors.name && touched.name)}
                                     errorMessage={errors.name}
                                 >
                                     <Field
+                                        id="name"
                                         name="name"
                                         type="text"
                                         placeholder="Nombre del proveedor"
@@ -96,11 +98,13 @@ const SupplierForm = ({
 
                             <FormItem
                                 asterisk
+                                htmlFor="taxId"
                                 label="Tax ID"
                                 invalid={!!(errors.taxId && touched.taxId)}
                                 errorMessage={errors.taxId}
                             >
                                 <Field
+                                    id="taxId"
                                     name="taxId"
                                     type="text"
                                     placeholder="RUC, Cédula, Pasaporte..."
@@ -111,11 +115,13 @@ const SupplierForm = ({
 
                             <FormItem
                                 asterisk
+                                htmlFor="taxType"
                                 label="Tipo de ID"
                                 invalid={!!(errors.taxType && touched.taxType)}
                                 errorMessage={errors.taxType as string}
                             >
                                 <Select
+                                    inputId="taxType"
                                     isDisabled={isSubmitting}
                                     value={taxTypeOptions.find(
                                         (opt) => opt.value === values.taxType
@@ -139,11 +145,13 @@ const SupplierForm = ({
                         </h6>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <FormItem
+                                htmlFor="email"
                                 label="Email"
                                 invalid={!!(errors.email && touched.email)}
                                 errorMessage={errors.email}
                             >
                                 <Field
+                                    id="email"
                                     name="email"
                                     type="email"
                                     placeholder="email@ejemplo.com"
@@ -153,11 +161,13 @@ const SupplierForm = ({
                             </FormItem>
 
                             <FormItem
+                                htmlFor="phone"
                                 label="Teléfono"
                                 invalid={!!(errors.phone && touched.phone)}
                                 errorMessage={errors.phone}
                             >
                                 <Field
+                                    id="phone"
                                     name="phone"
                                     type="text"
                                     placeholder="0987654321"
@@ -172,11 +182,13 @@ const SupplierForm = ({
                         </h6>
                         <div className="space-y-4">
                             <FormItem
+                                htmlFor="address"
                                 label="Dirección"
                                 invalid={!!(errors.address && touched.address)}
                                 errorMessage={errors.address}
                             >
                                 <Field
+                                    id="address"
                                     name="address"
                                     type="text"
                                     placeholder="Calle principal 123"
@@ -186,11 +198,13 @@ const SupplierForm = ({
                             </FormItem>
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                 <FormItem
+                                    htmlFor="city"
                                     label="Ciudad"
                                     invalid={!!(errors.city && touched.city)}
                                     errorMessage={errors.city}
                                 >
                                     <Field
+                                        id="city"
                                         name="city"
                                         type="text"
                                         placeholder="Quito"
@@ -200,6 +214,7 @@ const SupplierForm = ({
                                 </FormItem>
 
                                 <FormItem
+                                    htmlFor="country"
                                     label="País"
                                     invalid={
                                         !!(errors.country && touched.country)
@@ -207,6 +222,7 @@ const SupplierForm = ({
                                     errorMessage={errors.country}
                                 >
                                     <Field
+                                        id="country"
                                         name="country"
                                         type="text"
                                         placeholder="Ecuador"
@@ -222,6 +238,7 @@ const SupplierForm = ({
                         </h6>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <FormItem
+                                htmlFor="paymentTerms"
                                 label="Términos de Pago (días)"
                                 invalid={
                                     !!(
@@ -232,6 +249,7 @@ const SupplierForm = ({
                                 errorMessage={errors.paymentTerms as string}
                             >
                                 <Input
+                                    id="paymentTerms"
                                     type="number"
                                     placeholder="30"
                                     value={values.paymentTerms ?? ''}
@@ -252,6 +270,7 @@ const SupplierForm = ({
                             </FormItem>
 
                             <FormItem
+                                htmlFor="leadTimeDays"
                                 label="Tiempo de Entrega (días)"
                                 invalid={
                                     !!(
@@ -262,6 +281,7 @@ const SupplierForm = ({
                                 errorMessage={errors.leadTimeDays as string}
                             >
                                 <Input
+                                    id="leadTimeDays"
                                     type="number"
                                     placeholder="7"
                                     value={values.leadTimeDays ?? ''}
@@ -283,12 +303,14 @@ const SupplierForm = ({
                         </div>
 
                         <FormItem
+                            htmlFor="notes"
                             label="Notas"
                             invalid={!!(errors.notes && touched.notes)}
                             errorMessage={errors.notes}
                         >
                             <Field
                                 textArea
+                                id="notes"
                                 name="notes"
                                 placeholder="Notas adicionales sobre el proveedor..."
                                 component={Input}
@@ -296,8 +318,9 @@ const SupplierForm = ({
                             />
                         </FormItem>
 
-                        <FormItem label="Estado">
+                        <FormItem htmlFor="isActive" label="Estado">
                             <Switcher
+                                id="isActive"
                                 checked={values.isActive}
                                 onChange={(checked) =>
                                     setFieldValue('isActive', checked)

--- a/src/views/inventory/SuppliersView/index.tsx
+++ b/src/views/inventory/SuppliersView/index.tsx
@@ -195,6 +195,7 @@ const SuppliersView = () => {
                     <Button
                         size="sm"
                         variant="plain"
+                        aria-label={`Ver ${row.original.name}`}
                         icon={<HiOutlineEye />}
                         onClick={() =>
                             navigate(`/suppliers/${row.original.id}`)
@@ -203,12 +204,16 @@ const SuppliersView = () => {
                     <Button
                         size="sm"
                         variant="plain"
+                        aria-label={`Editar ${row.original.name}`}
                         icon={<HiOutlinePencil />}
                         onClick={() => crud.openEdit(row.original)}
                     />
                     <Button
                         size="sm"
                         variant="plain"
+                        aria-label={`${
+                            row.original.isActive ? 'Desactivar' : 'Activar'
+                        } ${row.original.name}`}
                         icon={
                             row.original.isActive ? (
                                 <HiOutlineXCircle />
@@ -221,6 +226,7 @@ const SuppliersView = () => {
                     <Button
                         size="sm"
                         variant="plain"
+                        aria-label={`Eliminar ${row.original.name}`}
                         icon={<HiOutlineTrash />}
                         onClick={() => crud.openDelete(row.original)}
                     />

--- a/src/views/inventory/UnitsOfMeasureView/index.tsx
+++ b/src/views/inventory/UnitsOfMeasureView/index.tsx
@@ -166,12 +166,14 @@ const UnitsOfMeasureView = () => {
                         <Button
                             size="sm"
                             variant="plain"
+                            aria-label={`Editar ${row.original.name}`}
                             icon={<HiOutlinePencil />}
                             onClick={() => crud.openEdit(row.original)}
                         />
                         <Button
                             size="sm"
                             variant="plain"
+                            aria-label={`Eliminar ${row.original.name}`}
                             icon={<HiOutlineTrash />}
                             onClick={() => crud.openDelete(row.original)}
                         />

--- a/src/views/inventory/WarehousesView/index.tsx
+++ b/src/views/inventory/WarehousesView/index.tsx
@@ -179,12 +179,14 @@ const WarehousesView = () => {
                         <Button
                             size="sm"
                             variant="plain"
+                            aria-label={`Editar ${row.original.name}`}
                             icon={<HiOutlinePencil />}
                             onClick={() => crud.openEdit(row.original)}
                         />
                         <Button
                             size="sm"
                             variant="plain"
+                            aria-label={`Eliminar ${row.original.name}`}
                             icon={<HiOutlineTrash />}
                             onClick={() => crud.openDelete(row.original)}
                         />

--- a/src/views/pos/components/CashMovementDialog.tsx
+++ b/src/views/pos/components/CashMovementDialog.tsx
@@ -99,8 +99,14 @@ const CashMovementDialog = ({ isOpen, onClose }: CashMovementDialogProps) => {
             </div>
 
             <div>
-                <label className="block text-sm font-medium mb-1">Monto</label>
+                <label
+                    htmlFor="cash-amount"
+                    className="block text-sm font-medium mb-1"
+                >
+                    Monto
+                </label>
                 <Input
+                    id="cash-amount"
                     type="number"
                     prefix="$"
                     value={amount}
@@ -110,10 +116,14 @@ const CashMovementDialog = ({ isOpen, onClose }: CashMovementDialogProps) => {
             </div>
 
             <div className="mt-3">
-                <label className="block text-sm font-medium mb-1">
+                <label
+                    htmlFor="cash-reason"
+                    className="block text-sm font-medium mb-1"
+                >
                     Razon (opcional)
                 </label>
                 <Input
+                    id="cash-reason"
                     value={reason}
                     placeholder="Razon del movimiento"
                     onChange={(e) => setReason(e.target.value)}


### PR DESCRIPTION
## Descripción

  - Agrega htmlFor + id en CategoryForm, ProductForm, SupplierForm, CustomerForm y CashMovementDialog para cumplir WCAG 2.1 AA
  - Usa inputId en Select (react-select) e id en Switcher donde aplica
  - Agrega aria-label dinámico en botones de icono (editar/eliminar/ver/ toggle) en CategoriesView, ProductsView, SuppliersView, CustomersView, UnitsOfMeasureView y WarehousesView

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
