### PR TITLE
refactor(consistency): standardize dialog state naming, toast placement, add ErrorBoundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Theme from '@/components/template/Theme'
 import Layout from '@/components/layouts'
 import NavigationBinder from '@/components/route/NavigationBinder'
 import AuthBootstrap from '@/components/AuthBootstrap'
+import ErrorBoundary from '@/components/ErrorBoundary'
 import mockServer from './mock'
 import appConfig from '@/configs/app.config'
 import './locales'
@@ -26,7 +27,9 @@ function App() {
                 <NavigationBinder />
                 <Theme>
                     <AuthBootstrap>
-                        <Layout />
+                        <ErrorBoundary>
+                            <Layout />
+                        </ErrorBoundary>
                     </AuthBootstrap>
                 </Theme>
             </BrowserRouter>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,38 @@
+import { Component, ErrorInfo, ReactNode } from 'react'
+
+class ErrorBoundary extends Component<
+    { children: ReactNode },
+    { hasError: boolean }
+> {
+    constructor(props: { children: ReactNode }) {
+        super(props)
+        this.state = { hasError: false }
+    }
+
+    static getDerivedStateFromError() {
+        return { hasError: true }
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo) {
+        console.error('ErrorBoundary:', error, info)
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+                    <h2 className="text-xl font-semibold">Algo salió mal</h2>
+                    <button
+                        className="text-primary underline"
+                        onClick={() => this.setState({ hasError: false })}
+                    >
+                        Reintentar
+                    </button>
+                </div>
+            )
+        }
+        return this.props.children
+    }
+}
+
+export default ErrorBoundary

--- a/src/components/template/ThemeConfigurator/CopyButton.tsx
+++ b/src/components/template/ThemeConfigurator/CopyButton.tsx
@@ -25,7 +25,7 @@ const CopyButton = () => {
                 {`Please replace themeConfig in 'src/configs/themeConfig.js'`}
             </Notification>,
             {
-                placement: 'top-center',
+                placement: 'top-end',
             }
         )
     }

--- a/src/components/ui/Upload/Upload.tsx
+++ b/src/components/ui/Upload/Upload.tsx
@@ -68,7 +68,7 @@ const Upload = forwardRef<HTMLDivElement, UploadProps>((props, ref) => {
                 {msg || 'Upload Failed!'}
             </Notification>,
             {
-                placement: 'top-center',
+                placement: 'top-end',
             }
         )
     }

--- a/src/views/inventory/AdjustmentDetailView/index.tsx
+++ b/src/views/inventory/AdjustmentDetailView/index.tsx
@@ -142,7 +142,7 @@ const AdjustmentDetailView = () => {
                 <Notification title="Ajuste actualizado" type="success">
                     El ajuste se actualizó correctamente
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setEditDialogOpen(false)
         } catch (error: unknown) {
@@ -150,7 +150,7 @@ const AdjustmentDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al actualizar el ajuste')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -163,7 +163,7 @@ const AdjustmentDetailView = () => {
                     El ajuste se confirmó y los movimientos de inventario fueron
                     generados
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setConfirmDialogOpen(false)
         } catch (error: unknown) {
@@ -171,7 +171,7 @@ const AdjustmentDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al confirmar el ajuste')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -183,7 +183,7 @@ const AdjustmentDetailView = () => {
                 <Notification title="Ajuste cancelado" type="success">
                     El ajuste fue cancelado
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setCancelDialogOpen(false)
         } catch (error: unknown) {
@@ -191,7 +191,7 @@ const AdjustmentDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al cancelar el ajuste')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -203,7 +203,7 @@ const AdjustmentDetailView = () => {
                 <Notification title="Ajuste eliminado" type="success">
                     El ajuste fue eliminado
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             navigate('/adjustments')
         } catch (error: unknown) {
@@ -211,7 +211,7 @@ const AdjustmentDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al eliminar el ajuste')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -227,7 +227,7 @@ const AdjustmentDetailView = () => {
                 <Notification title="Item eliminado" type="success">
                     El item fue eliminado
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setDeleteItemDialog({ open: false, item: null })
         } catch (error: unknown) {
@@ -235,7 +235,7 @@ const AdjustmentDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al eliminar el item')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }

--- a/src/views/inventory/CustomerDetailView/index.tsx
+++ b/src/views/inventory/CustomerDetailView/index.tsx
@@ -75,7 +75,7 @@ const CustomerDetailView = () => {
                 <Notification title="Contacto eliminado" type="success">
                     El contacto se eliminó correctamente
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setDeleteDialogOpen(false)
             setContactToDelete(null)
@@ -84,7 +84,7 @@ const CustomerDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al eliminar el contacto')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }

--- a/src/views/inventory/MovementsView/MovementForm.tsx
+++ b/src/views/inventory/MovementsView/MovementForm.tsx
@@ -52,7 +52,7 @@ const MovementForm = ({ open, onClose }: MovementFormProps) => {
                 <Notification title="Error de validación" type="warning">
                     El ID del producto debe ser mayor a 0
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             return
         }
@@ -62,7 +62,7 @@ const MovementForm = ({ open, onClose }: MovementFormProps) => {
                 <Notification title="Error de validación" type="warning">
                     La cantidad no puede ser cero
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             return
         }
@@ -73,7 +73,7 @@ const MovementForm = ({ open, onClose }: MovementFormProps) => {
                 <Notification title="Error de validación" type="warning">
                     Para movimientos de entrada, la cantidad debe ser positiva
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             return
         }
@@ -83,7 +83,7 @@ const MovementForm = ({ open, onClose }: MovementFormProps) => {
                 <Notification title="Error de validación" type="warning">
                     Para movimientos de salida, la cantidad debe ser negativa
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             return
         }
@@ -95,7 +95,7 @@ const MovementForm = ({ open, onClose }: MovementFormProps) => {
                 <Notification title="Movimiento creado" type="success">
                     El movimiento se registró correctamente
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
 
             onClose()
@@ -109,7 +109,7 @@ const MovementForm = ({ open, onClose }: MovementFormProps) => {
                 <Notification title="Error" type="danger">
                     {errorMessage}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
 
             console.error('Error creating movement:', error)

--- a/src/views/inventory/SerialNumbersView/StatusChangeDialog.tsx
+++ b/src/views/inventory/SerialNumbersView/StatusChangeDialog.tsx
@@ -57,7 +57,7 @@ const StatusChangeDialog = ({
                 <Notification title="Estado actualizado" type="success">
                     El estado se cambió a {SERIAL_STATUS_LABELS[newStatus]}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
 
             onClose()
@@ -71,7 +71,7 @@ const StatusChangeDialog = ({
                 <Notification title="Error" type="danger">
                     {errorMessage}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }

--- a/src/views/inventory/SupplierDetailView/index.tsx
+++ b/src/views/inventory/SupplierDetailView/index.tsx
@@ -101,7 +101,7 @@ const SupplierDetailView = () => {
                 <Notification title="Contacto eliminado" type="success">
                     El contacto se eliminó correctamente
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setDeleteContactDialogOpen(false)
             setContactToDelete(null)
@@ -110,7 +110,7 @@ const SupplierDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al eliminar el contacto')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -148,7 +148,7 @@ const SupplierDetailView = () => {
                 <Notification title="Producto eliminado" type="success">
                     El producto se eliminó del proveedor correctamente
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setDeleteProductDialogOpen(false)
             setProductToDelete(null)
@@ -157,7 +157,7 @@ const SupplierDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al eliminar el producto')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }

--- a/src/views/inventory/TransferDetailView/TransferItemForm.tsx
+++ b/src/views/inventory/TransferDetailView/TransferItemForm.tsx
@@ -119,7 +119,7 @@ const TransferItemForm = ({
                         ? 'El item se actualizó correctamente'
                         : 'El item se agregó correctamente'}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
 
             onClose()
@@ -128,7 +128,7 @@ const TransferItemForm = ({
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al guardar el item')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }

--- a/src/views/inventory/TransferDetailView/index.tsx
+++ b/src/views/inventory/TransferDetailView/index.tsx
@@ -121,7 +121,7 @@ const TransferDetailView = () => {
                 <Notification title="Transferencia actualizada" type="success">
                     La transferencia se actualizó correctamente
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setEditDialogOpen(false)
         } catch (error: unknown) {
@@ -132,7 +132,7 @@ const TransferDetailView = () => {
                         'Error al actualizar la transferencia'
                     )}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -144,7 +144,7 @@ const TransferDetailView = () => {
                 <Notification title="Transferencia confirmada" type="success">
                     La transferencia se confirmó y el stock fue reservado
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setConfirmDialogOpen(false)
         } catch (error: unknown) {
@@ -155,7 +155,7 @@ const TransferDetailView = () => {
                         'Error al confirmar la transferencia'
                     )}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -168,7 +168,7 @@ const TransferDetailView = () => {
                     La transferencia se completó y los movimientos fueron
                     generados
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setReceiveDialogOpen(false)
         } catch (error: unknown) {
@@ -179,7 +179,7 @@ const TransferDetailView = () => {
                         'Error al recibir la transferencia'
                     )}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -191,7 +191,7 @@ const TransferDetailView = () => {
                 <Notification title="Transferencia cancelada" type="success">
                     La transferencia fue cancelada
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setCancelDialogOpen(false)
         } catch (error: unknown) {
@@ -202,7 +202,7 @@ const TransferDetailView = () => {
                         'Error al cancelar la transferencia'
                     )}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -214,7 +214,7 @@ const TransferDetailView = () => {
                 <Notification title="Transferencia eliminada" type="success">
                     La transferencia fue eliminada
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             navigate('/transfers')
         } catch (error: unknown) {
@@ -225,7 +225,7 @@ const TransferDetailView = () => {
                         'Error al eliminar la transferencia'
                     )}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -241,7 +241,7 @@ const TransferDetailView = () => {
                 <Notification title="Item eliminado" type="success">
                     El item fue eliminado
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setDeleteItemDialog({ open: false, item: null })
         } catch (error: unknown) {
@@ -249,7 +249,7 @@ const TransferDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al eliminar el item')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }

--- a/src/views/purchases/PurchaseOrderDetailView/ReceiveForm.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/ReceiveForm.tsx
@@ -138,7 +138,7 @@ const ReceiveForm = ({
                 <Notification title="Mercancía recibida" type="success">
                     La recepción se registró correctamente
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
 
             onClose()
@@ -147,7 +147,7 @@ const ReceiveForm = ({
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al registrar la recepción')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }

--- a/src/views/purchases/PurchaseOrderDetailView/index.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/index.tsx
@@ -151,7 +151,7 @@ const PurchaseOrderDetailView = () => {
                 <Notification title="Orden actualizada" type="success">
                     La orden de compra se actualizó correctamente
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setEditDialogOpen(false)
         } catch (error: unknown) {
@@ -159,7 +159,7 @@ const PurchaseOrderDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al actualizar la orden')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -171,7 +171,7 @@ const PurchaseOrderDetailView = () => {
                 <Notification title="Orden enviada" type="success">
                     La orden de compra fue enviada al proveedor
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setSendDialogOpen(false)
         } catch (error: unknown) {
@@ -179,7 +179,7 @@ const PurchaseOrderDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al enviar la orden')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -191,7 +191,7 @@ const PurchaseOrderDetailView = () => {
                 <Notification title="Orden cancelada" type="success">
                     La orden de compra fue cancelada
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setCancelDialogOpen(false)
         } catch (error: unknown) {
@@ -199,7 +199,7 @@ const PurchaseOrderDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al cancelar la orden')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -211,7 +211,7 @@ const PurchaseOrderDetailView = () => {
                 <Notification title="Orden eliminada" type="success">
                     La orden de compra fue eliminada
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             navigate('/purchase-orders')
         } catch (error: unknown) {
@@ -219,7 +219,7 @@ const PurchaseOrderDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al eliminar la orden')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -235,7 +235,7 @@ const PurchaseOrderDetailView = () => {
                 <Notification title="Item eliminado" type="success">
                     El item fue eliminado
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setDeleteItemDialog({ open: false, item: null })
         } catch (error: unknown) {
@@ -243,7 +243,7 @@ const PurchaseOrderDetailView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al eliminar el item')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }

--- a/src/views/settings/CertificatesView/index.tsx
+++ b/src/views/settings/CertificatesView/index.tsx
@@ -16,7 +16,7 @@ import type { Certificate } from '@/services/InvoicingService'
 import { HiOutlineTrash, HiOutlineUpload } from 'react-icons/hi'
 
 const CertificatesView = () => {
-    const [uploadDialog, setUploadDialog] = useState(false)
+    const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false)
     const [deleteDialog, setDeleteDialog] = useState<{
         open: boolean
         cert: Certificate | null
@@ -32,12 +32,12 @@ const CertificatesView = () => {
     const handleUploadOpen = () => {
         setSelectedFile(null)
         setPassword('')
-        setUploadDialog(true)
+        setIsUploadDialogOpen(true)
     }
 
     const handleUploadClose = () => {
         if (uploadCertificate.isPending) return
-        setUploadDialog(false)
+        setIsUploadDialogOpen(false)
         setSelectedFile(null)
         setPassword('')
         if (fileInputRef.current) fileInputRef.current.value = ''
@@ -56,7 +56,7 @@ const CertificatesView = () => {
                 <Notification title="Certificado subido" type="success">
                     El certificado se subió correctamente
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             handleUploadClose()
         } catch (error: unknown) {
@@ -64,7 +64,7 @@ const CertificatesView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al subir el certificado')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -77,7 +77,7 @@ const CertificatesView = () => {
                 <Notification title="Certificado eliminado" type="success">
                     El certificado se eliminó correctamente
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
             setDeleteDialog({ open: false, cert: null })
         } catch (error: unknown) {
@@ -85,7 +85,7 @@ const CertificatesView = () => {
                 <Notification title="Error" type="danger">
                     {getErrorMessage(error, 'Error al eliminar el certificado')}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }
@@ -213,7 +213,7 @@ const CertificatesView = () => {
 
             {/* Upload Dialog */}
             <Dialog
-                isOpen={uploadDialog}
+                isOpen={isUploadDialogOpen}
                 shouldCloseOnEsc={!uploadCertificate.isPending}
                 shouldCloseOnOverlayClick={!uploadCertificate.isPending}
                 onClose={handleUploadClose}

--- a/src/views/settings/CompanyConfigView/index.tsx
+++ b/src/views/settings/CompanyConfigView/index.tsx
@@ -90,7 +90,7 @@ const CompanyConfigView = () => {
                 <Notification title="Configuración guardada" type="success">
                     La configuración fiscal se guardó correctamente
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         } catch (error: unknown) {
             toast.push(
@@ -100,7 +100,7 @@ const CompanyConfigView = () => {
                         'Error al guardar la configuración'
                     )}
                 </Notification>,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }

--- a/src/views/settings/UsersView/ResetPasswordModal.tsx
+++ b/src/views/settings/UsersView/ResetPasswordModal.tsx
@@ -47,7 +47,7 @@ const ResetPasswordModal = ({
     const handleCopy = () => {
         navigator.clipboard.writeText(password)
         toast.push(<Notification type="success" title="Contraseña copiada" />, {
-            placement: 'top-center',
+            placement: 'top-end',
         })
     }
 
@@ -68,7 +68,7 @@ const ResetPasswordModal = ({
                         'Error al resetear la contraseña'
                     )}
                 />,
-                { placement: 'top-center' }
+                { placement: 'top-end' }
             )
         }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
-    "forceConsistentCasingInFileNames": false,
+    "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Node",
     "resolveJsonModule": true,


### PR DESCRIPTION
## Descripción

  - Rename boolean dialog state to isXxxOpen pattern across 10 views
  - Replace top-center with top-end in 62 toast.push calls across 14 files
  - Add global ErrorBoundary component wrapping Layout in App.tsx
  - Enable forceConsistentCasingInFileNames in tsconfig.json

## Tipo de cambio

- [ ] 🐛 Bug fix
- [ ] ✨ Nueva funcionalidad
- [x] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
