### PR TITLE
chore(lint): resolve mechanical react-hooks warnings (post React Compiler migration)

### DIFF
--- a/src/components/layouts/Layouts.tsx
+++ b/src/components/layouts/Layouts.tsx
@@ -1,4 +1,4 @@
-import { useMemo, lazy, Suspense } from 'react'
+import { lazy, Suspense } from 'react'
 import Loading from '@/components/shared/Loading'
 import { useThemeStore } from '@/stores'
 import {
@@ -23,6 +23,8 @@ const layouts = {
     [LAYOUT_TYPE_BLANK]: lazy(() => import('./BlankLayout')),
 }
 
+const AuthLayout = lazy(() => import('./AuthLayout'))
+
 const Layout = () => {
     const layoutType = useThemeStore((state) => state.layout.type)
 
@@ -32,12 +34,7 @@ const Layout = () => {
 
     useLocale()
 
-    const AppLayout = useMemo(() => {
-        if (authenticated) {
-            return layouts[layoutType]
-        }
-        return lazy(() => import('./AuthLayout'))
-    }, [layoutType, authenticated])
+    const AppLayout = authenticated ? layouts[layoutType] : AuthLayout
 
     return (
         <Suspense

--- a/src/components/shared/Affix.tsx
+++ b/src/components/shared/Affix.tsx
@@ -1,4 +1,4 @@
-import { useEffect, createRef } from 'react'
+import { useEffect, useRef } from 'react'
 import classNames from 'classnames'
 import type { CommonProps } from '@/@types/common'
 
@@ -15,12 +15,12 @@ interface AffixProps extends CommonProps {
 function Affix(props: AffixProps) {
     const { offset = 0, className, children } = props
 
-    const ref = createRef<HTMLDivElement>()
-    const prevStyle: AffixStyles = {
+    const ref = useRef<HTMLDivElement>(null)
+    const prevStyleRef = useRef<AffixStyles>({
         position: '',
         top: '',
         width: '',
-    }
+    })
 
     const checkPosition = (distanceToBody: number, width?: number) => {
         const scrollTop = window.scrollY
@@ -28,8 +28,8 @@ function Affix(props: AffixProps) {
         if (ref.current) {
             if (distanceToBody - scrollTop < offset) {
                 if (ref.current.style.position !== 'fixed') {
-                    for (const key in prevStyle) {
-                        prevStyle[key as keyof AffixStyles] =
+                    for (const key in prevStyleRef.current) {
+                        prevStyleRef.current[key as keyof AffixStyles] =
                             ref.current.style[key as keyof AffixStyles]
                     }
                     ref.current.style.position = 'fixed'
@@ -37,9 +37,9 @@ function Affix(props: AffixProps) {
                     ref.current.style.top = offset + 'px'
                 }
             } else {
-                for (const key in prevStyle) {
+                for (const key in prevStyleRef.current) {
                     ref.current.style[key as keyof AffixStyles] =
-                        prevStyle[key as keyof AffixStyles]
+                        prevStyleRef.current[key as keyof AffixStyles]
                 }
             }
         }

--- a/src/components/shared/DataTable.tsx
+++ b/src/components/shared/DataTable.tsx
@@ -216,6 +216,7 @@ function DataTable<T>(
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [columnsProp, selectable])
 
+    // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table v8 returns non-memoizable functions; React Compiler skip is expected.
     const table = useReactTable({
         data,
         // eslint-disable-next-line  @typescript-eslint/no-explicit-any

--- a/src/components/template/LanguageSelector.tsx
+++ b/src/components/template/LanguageSelector.tsx
@@ -13,7 +13,7 @@ import type { CommonProps } from '@/@types/common'
 
 const languageList = [{ label: 'English', value: 'en', flag: 'us' }]
 
-const _LanguageSelector = ({ className }: CommonProps) => {
+const LanguageSelector = ({ className }: CommonProps) => {
     const [loading, setLoading] = useState(false)
     const { currentLang, setLang } = useLocaleStore()
 
@@ -84,6 +84,6 @@ const _LanguageSelector = ({ className }: CommonProps) => {
     )
 }
 
-const LanguageSelector = withHeaderItem(_LanguageSelector)
+const LanguageSelectorHeader = withHeaderItem(LanguageSelector)
 
-export default LanguageSelector
+export default LanguageSelectorHeader

--- a/src/components/template/Notification.tsx
+++ b/src/components/template/Notification.tsx
@@ -113,7 +113,7 @@ const NotificationToggle = ({
     )
 }
 
-const _Notification = ({ className }: { className?: string }) => {
+const Notification = ({ className }: { className?: string }) => {
     const [notificationList, setNotificationList] = useState<
         NotificationList[]
     >([])
@@ -273,6 +273,6 @@ const _Notification = ({ className }: { className?: string }) => {
     )
 }
 
-const Notification = withHeaderItem(_Notification)
+const NotificationHeader = withHeaderItem(Notification)
 
-export default Notification
+export default NotificationHeader

--- a/src/components/template/Search.tsx
+++ b/src/components/template/Search.tsx
@@ -79,17 +79,19 @@ const ListItem = (props: {
     )
 }
 
-const _Search = ({ className }: { className?: string }) => {
+const Search = ({ className }: { className?: string }) => {
     const [searchDialogOpen, setSearchDialogOpen] = useState(false)
     const [searchResult, setSearchResult] =
         useState<SearchResult[]>(recommendedSearch)
     const [noResult, setNoResult] = useState(false)
+    const [searchTerm, setSearchTerm] = useState('')
 
     const inputRef = useRef<HTMLInputElement>(null)
 
     const handleReset = () => {
         setNoResult(false)
         setSearchResult(recommendedSearch)
+        setSearchTerm('')
     }
 
     const handleSearchOpen = () => {
@@ -120,6 +122,7 @@ const _Search = ({ className }: { className?: string }) => {
     }
 
     const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setSearchTerm(e.target.value)
         debounceFn(e.target.value)
     }
 
@@ -175,7 +178,7 @@ const _Search = ({ className }: { className?: string }) => {
                                         icon={data.icon}
                                         label={data.title}
                                         url={data.url}
-                                        keyWord={inputRef.current?.value || ''}
+                                        keyWord={searchTerm}
                                         onNavigate={handleNavigate}
                                     />
                                 ))}
@@ -186,7 +189,7 @@ const _Search = ({ className }: { className?: string }) => {
                                 <span>No results for </span>
                                 <span className="heading-text">
                                     {`'`}
-                                    {inputRef.current?.value}
+                                    {searchTerm}
                                     {`'`}
                                 </span>
                             </div>
@@ -198,6 +201,6 @@ const _Search = ({ className }: { className?: string }) => {
     )
 }
 
-const Search = withHeaderItem(_Search)
+const SearchHeader = withHeaderItem(Search)
 
-export default Search
+export default SearchHeader

--- a/src/components/template/SideNavToggle.tsx
+++ b/src/components/template/SideNavToggle.tsx
@@ -4,7 +4,7 @@ import useResponsive from '@/utils/hooks/useResponsive'
 import NavToggle from '@/components/shared/NavToggle'
 import type { CommonProps } from '@/@types/common'
 
-const _SideNavToggle = ({ className }: CommonProps) => {
+const SideNavToggle = ({ className }: CommonProps) => {
     const sideNavCollapse = useThemeStore(
         (state) => state.layout.sideNavCollapse
     )
@@ -29,6 +29,6 @@ const _SideNavToggle = ({ className }: CommonProps) => {
     )
 }
 
-const SideNavToggle = withHeaderItem(_SideNavToggle)
+const SideNavToggleHeader = withHeaderItem(SideNavToggle)
 
-export default SideNavToggle
+export default SideNavToggleHeader

--- a/src/components/template/SidePanel/SidePanel.tsx
+++ b/src/components/template/SidePanel/SidePanel.tsx
@@ -8,7 +8,7 @@ import type { CommonProps } from '@/@types/common'
 
 type SidePanelProps = SidePanelContentProps & CommonProps
 
-const _SidePanel = (props: SidePanelProps) => {
+const SidePanel = (props: SidePanelProps) => {
     const { className, ...rest } = props
 
     const panelExpand = useThemeStore((state) => state.panelExpand)
@@ -50,6 +50,6 @@ const _SidePanel = (props: SidePanelProps) => {
     )
 }
 
-const SidePanel = withHeaderItem(_SidePanel)
+const SidePanelHeader = withHeaderItem(SidePanel)
 
-export default SidePanel
+export default SidePanelHeader

--- a/src/components/template/UserDropdown.tsx
+++ b/src/components/template/UserDropdown.tsx
@@ -16,7 +16,7 @@ type DropdownList = {
 
 const dropdownItemList: DropdownList[] = []
 
-const _UserDropdown = ({ className }: CommonProps) => {
+const UserDropdown = ({ className }: CommonProps) => {
     const { signOut } = useAuth()
 
     const UserAvatar = (
@@ -83,6 +83,6 @@ const _UserDropdown = ({ className }: CommonProps) => {
     )
 }
 
-const UserDropdown = withHeaderItem(_UserDropdown)
+const UserDropdownHeader = withHeaderItem(UserDropdown)
 
-export default UserDropdown
+export default UserDropdownHeader

--- a/src/components/ui/DatePicker/BasePicker.tsx
+++ b/src/components/ui/DatePicker/BasePicker.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useState } from 'react'
 import dayjs from 'dayjs'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
 import { Input } from '../Input'
@@ -135,29 +135,28 @@ const BasePicker = (props: BasePickerProps) => {
         }
     }
 
-    const referenceRef = useRef<HTMLInputElement>(null)
-    const popperRef = useRef(null)
-
-    const { styles, attributes } = usePopper(
-        referenceRef.current,
-        popperRef.current,
-        {
-            placement: 'bottom-start',
-            modifiers: [
-                {
-                    name: 'offset',
-                    enabled: true,
-                    options: {
-                        offset: [0, 10],
-                    },
-                },
-            ],
-        }
+    const [referenceElement, setReferenceElement] =
+        useState<HTMLInputElement | null>(null)
+    const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
+        null
     )
 
+    const { styles, attributes } = usePopper(referenceElement, popperElement, {
+        placement: 'bottom-start',
+        modifiers: [
+            {
+                name: 'offset',
+                enabled: true,
+                options: {
+                    offset: [0, 10],
+                },
+            },
+        ],
+    })
+
     useRootClose(() => closeDropdown(), {
-        triggerTarget: referenceRef,
-        overlayTarget: popperRef,
+        triggerTarget: referenceElement,
+        overlayTarget: popperElement,
         disabled: !dropdownOpened,
         listenEscape: false,
     })
@@ -165,7 +164,7 @@ const BasePicker = (props: BasePickerProps) => {
     return (
         <>
             <Input
-                ref={useMergedRef(ref ?? null, referenceRef)}
+                ref={useMergedRef(ref ?? null, setReferenceElement)}
                 form={form}
                 field={field}
                 className={className}
@@ -187,7 +186,7 @@ const BasePicker = (props: BasePickerProps) => {
                 onChange={onChange}
             />
             <div
-                ref={popperRef}
+                ref={setPopperElement}
                 className="picker"
                 style={styles.popper}
                 {...attributes.popper}

--- a/src/components/ui/TimeInput/TimeInput.tsx
+++ b/src/components/ui/TimeInput/TimeInput.tsx
@@ -28,7 +28,7 @@ export interface TimeInputProps extends CommonProps {
     id?: string
     invalid?: boolean
     name?: string
-    nextRef?: RefObject<HTMLInputElement>
+    nextRef?: RefObject<HTMLInputElement | null>
     onChange?: (value: Value) => void
     pmLabel?: string
     prefix?: string | ReactNode
@@ -112,6 +112,7 @@ const TimeInput = (props: TimeInputProps) => {
         typeof onChange === 'function' && onChange(newDate)
     }
 
+    // eslint-disable-next-line react-hooks/refs -- nextRef.current is only accessed inside the returned event handler (focus/select on overflow), never during render.
     const handleHoursChange = createTimeHandler({
         onChange: (val, carryOver) => {
             setDate({
@@ -121,10 +122,11 @@ const TimeInput = (props: TimeInputProps) => {
         },
         min: format === '12' ? 1 : 0,
         max: format === '12' ? 12 : 23,
-        nextRef: minutesRef as RefObject<HTMLInputElement>,
+        nextRef: minutesRef,
         nextMax: 59,
     })
 
+    // eslint-disable-next-line react-hooks/refs -- see note above
     const handleMinutesChange = createTimeHandler({
         onChange: (val, carryOver) => {
             setDate({
@@ -134,24 +136,18 @@ const TimeInput = (props: TimeInputProps) => {
         },
         min: 0,
         max: 59,
-        nextRef: showSeconds
-            ? (secondsRef as RefObject<HTMLInputElement>)
-            : format === '12'
-            ? (amPmRef as RefObject<HTMLInputElement>)
-            : (nextRef as RefObject<HTMLInputElement>),
+        nextRef: showSeconds ? secondsRef : format === '12' ? amPmRef : nextRef,
         nextMax: showSeconds ? 59 : undefined,
     })
 
+    // eslint-disable-next-line react-hooks/refs -- see note above
     const handleSecondsChange = createTimeHandler({
         onChange: (val) => {
             setDate({ seconds: val })
         },
         min: 0,
         max: 59,
-        nextRef:
-            format === '12'
-                ? (amPmRef as RefObject<HTMLInputElement>)
-                : (nextRef as RefObject<HTMLInputElement>),
+        nextRef: format === '12' ? amPmRef : nextRef,
     })
 
     const handleAmPmChange = createAmPmHandler({

--- a/src/components/ui/TimeInput/TimeInputRange.tsx
+++ b/src/components/ui/TimeInput/TimeInputRange.tsx
@@ -21,7 +21,7 @@ export interface TimeInputRangeProps extends CommonProps {
     id?: string
     invalid?: boolean
     name?: string
-    nextRef?: RefObject<HTMLInputElement>
+    nextRef?: RefObject<HTMLInputElement | null>
     onChange?: (value: Value) => void
     pmLabel?: string
     prefix?: string | ReactNode
@@ -128,7 +128,7 @@ const TimeInputRange = (props: TimeInputRangeProps) => {
                     unstyle
                     value={_value[0]}
                     name={name}
-                    nextRef={toTimeRef as RefObject<HTMLInputElement>}
+                    nextRef={toTimeRef}
                     id={uuid}
                     clearable={false}
                     suffix={null}

--- a/src/components/ui/TimeInput/utils/createAmPmHandler.ts
+++ b/src/components/ui/TimeInput/utils/createAmPmHandler.ts
@@ -4,7 +4,7 @@ type CreateAmPmHandlerParams = {
     amLabel: string
     pmLabel: string
     onChange(value: string): void
-    nextRef?: RefObject<HTMLInputElement>
+    nextRef?: RefObject<HTMLInputElement | null>
 }
 
 export function createAmPmHandler({

--- a/src/components/ui/TimeInput/utils/createTimeHandler.ts
+++ b/src/components/ui/TimeInput/utils/createTimeHandler.ts
@@ -8,7 +8,7 @@ function allButLastDigit(value: number) {
 
 type CreateTimeHandlerParams = {
     onChange(value: string, carryOver?: string): void
-    nextRef?: RefObject<HTMLInputElement>
+    nextRef?: RefObject<HTMLInputElement | null>
     min: number
     max: number
     nextMax?: number

--- a/src/components/ui/hooks/useUniqueId.ts
+++ b/src/components/ui/hooks/useUniqueId.ts
@@ -1,13 +1,9 @@
-import { useRef } from 'react'
+import { useState } from 'react'
 import uniqueId from 'lodash/uniqueId'
 import createUID from '../utils/createUid'
 
 export default function useUniqueId(prefix = '', len = 10) {
-    const idRef = useRef<string | undefined>(undefined)
+    const [id] = useState(() => `${uniqueId(prefix)}-${createUID(len)}`)
 
-    if (!idRef.current) {
-        idRef.current = `${uniqueId(prefix)}-${createUID(len)}`
-    }
-
-    return idRef.current
+    return id
 }

--- a/src/views/purchases/PurchaseOrderDetailView/ReceiveForm.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/ReceiveForm.tsx
@@ -9,7 +9,7 @@ import toast from '@/components/ui/toast'
 import { useReceivePurchaseOrder } from '@/hooks/usePurchaseOrders'
 import { useLocations } from '@/hooks/useLocations'
 import { getErrorMessage } from '@/utils/getErrorMessage'
-import { useForm, useFieldArray } from 'react-hook-form'
+import { useForm, useFieldArray, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import type { PurchaseOrderItem } from '@/services/PurchaseOrderService'
@@ -78,7 +78,6 @@ const ReceiveForm = ({
         handleSubmit,
         control,
         reset,
-        watch,
         formState: { errors },
     } = useForm<ReceiveFormValues>({
         resolver: zodResolver(receiveFormSchema),
@@ -86,7 +85,7 @@ const ReceiveForm = ({
     })
 
     const { fields } = useFieldArray({ control, name: 'items' })
-    const watchedItems = watch('items')
+    const watchedItems = useWatch({ control, name: 'items' })
 
     useEffect(() => {
         if (open) {

--- a/src/views/settings/UsersView/ResetPasswordModal.tsx
+++ b/src/views/settings/UsersView/ResetPasswordModal.tsx
@@ -6,7 +6,7 @@ import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
 import { useResetUserPassword } from '@/hooks/useAdminUsers'
 import { getErrorMessage } from '@/utils/getErrorMessage'
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import type { AdminUserResponse } from '@/@types/auth'
@@ -41,7 +41,7 @@ const ResetPasswordModal = ({
     const {
         register,
         handleSubmit,
-        watch,
+        control,
         setValue,
         reset,
         formState: { errors },
@@ -50,7 +50,7 @@ const ResetPasswordModal = ({
         defaultValues: { password: '' },
     })
 
-    const password = watch('password')
+    const password = useWatch({ control, name: 'password' })
 
     useEffect(() => {
         if (open) {


### PR DESCRIPTION




## Descripción

  Drop 36 of 67 warnings surfaced by eslint-plugin-react-hooks v7 (React
  Compiler integration). Quedaron deferidos los 28 set-state-in-effect en
  forms legacy y UI primitives controlled/uncontrolled, además de los 3
  exhaustive-deps preexistentes ya suprimidos.

## Tipo de cambio

- [ ] 🐛 Bug fix
- [ ] ✨ Nueva funcionalidad
- [x] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
