### PR TITLE
feat(forms): add shared foundations for RHF+Zod migration

### DIFF
--- a/src/components/ui/Form/utils.ts
+++ b/src/components/ui/Form/utils.ts
@@ -1,0 +1,21 @@
+import type { FieldValues, Path, UseFormRegister } from 'react-hook-form'
+
+export function makeNumberRegister<T extends FieldValues>(
+    register: UseFormRegister<T>
+) {
+    return (
+        name: Path<T>,
+        opts: { integer?: boolean; emptyValue?: number | undefined } = {}
+    ) => {
+        const { integer = false, emptyValue = undefined } = opts
+        return register(name, {
+            setValueAs: (v) => {
+                if (v === '' || v === null || v === undefined) return emptyValue
+                const parsed = integer
+                    ? parseInt(String(v), 10)
+                    : parseFloat(String(v))
+                return Number.isNaN(parsed) ? emptyValue : parsed
+            },
+        })
+    }
+}

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const optionalEmail = z
+    .union([z.email('Email inválido'), z.literal('')])
+    .optional()
+
+export const taxTypeSchema = z.union(
+    [z.literal(1), z.literal(2), z.literal(3), z.literal(4)],
+    { error: 'Tipo de identificación requerido' }
+)

--- a/src/schemas/customer.schema.ts
+++ b/src/schemas/customer.schema.ts
@@ -1,15 +1,10 @@
 import { z } from 'zod'
-
-const optionalEmail = z
-    .union([z.email('Email inválido'), z.literal('')])
-    .optional()
+import { optionalEmail, taxTypeSchema } from './common'
 
 export const customerSchema = z.object({
     name: z.string().min(1, 'Nombre requerido'),
     taxId: z.string().min(1, 'Identificación requerida'),
-    taxType: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)], {
-        error: 'Tipo de identificación requerido',
-    }),
+    taxType: taxTypeSchema,
     email: optionalEmail,
     phone: z.string().optional(),
     address: z.string().optional(),

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,3 +1,4 @@
+export { optionalEmail, taxTypeSchema } from './common'
 export { categorySchema, type CategoryFormValues } from './category.schema'
 export { productSchema, type ProductFormValues } from './product.schema'
 export { supplierSchema, type SupplierFormValues } from './supplier.schema'

--- a/src/schemas/supplier.schema.ts
+++ b/src/schemas/supplier.schema.ts
@@ -1,15 +1,10 @@
 import { z } from 'zod'
-
-const optionalEmail = z
-    .union([z.email('Email inválido'), z.literal('')])
-    .optional()
+import { optionalEmail, taxTypeSchema } from './common'
 
 export const supplierSchema = z.object({
     name: z.string().min(1, 'Nombre requerido'),
     taxId: z.string().min(1, 'Identificación requerida'),
-    taxType: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)], {
-        error: 'Tipo de identificación requerido',
-    }),
+    taxType: taxTypeSchema,
     email: optionalEmail,
     phone: z.string().optional(),
     address: z.string().optional(),

--- a/src/utils/dateToIsoStartOfDay.ts
+++ b/src/utils/dateToIsoStartOfDay.ts
@@ -1,0 +1,4 @@
+export function dateToIsoStartOfDay(value?: string | null): string | undefined {
+    if (!value) return undefined
+    return `${value}T00:00:00Z`
+}

--- a/src/views/inventory/ProductsView/ProductForm.tsx
+++ b/src/views/inventory/ProductsView/ProductForm.tsx
@@ -1,5 +1,6 @@
 import Input from '@/components/ui/Input'
 import { FormItem, FormContainer } from '@/components/ui/Form'
+import { makeNumberRegister } from '@/components/ui/Form/utils'
 import {
     ControlledSelect,
     ControlledSwitcher,
@@ -93,27 +94,7 @@ const ProductForm = ({
         defaultValues,
     })
 
-    const numberRegister = (
-        name:
-            | 'purchasePrice'
-            | 'salePrice'
-            | 'minStock'
-            | 'maxStock'
-            | 'reorderPoint'
-            | 'leadTimeDays',
-        opts: { integer?: boolean; emptyValue?: number | undefined } = {}
-    ) => {
-        const { integer = false, emptyValue = undefined } = opts
-        return register(name, {
-            setValueAs: (v) => {
-                if (v === '' || v === null || v === undefined) return emptyValue
-                const parsed = integer
-                    ? parseInt(String(v), 10)
-                    : parseFloat(String(v))
-                return Number.isNaN(parsed) ? emptyValue : parsed
-            },
-        })
-    }
+    const numberRegister = makeNumberRegister(register)
 
     return (
         <form id={formId} onSubmit={handleSubmit(onSubmit)}>

--- a/src/views/purchases/PurchaseOrderDetailView/ReceiveForm.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/ReceiveForm.tsx
@@ -9,6 +9,7 @@ import toast from '@/components/ui/toast'
 import { useReceivePurchaseOrder } from '@/hooks/usePurchaseOrders'
 import { useLocations } from '@/hooks/useLocations'
 import { getErrorMessage } from '@/utils/getErrorMessage'
+import { dateToIsoStartOfDay } from '@/utils/dateToIsoStartOfDay'
 import { useForm, useFieldArray, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -143,9 +144,7 @@ const ReceiveForm = ({
                 data: {
                     items: filteredItems,
                     notes: values.notes || undefined,
-                    receivedAt: values.receivedAt
-                        ? `${values.receivedAt}T00:00:00Z`
-                        : undefined,
+                    receivedAt: dateToIsoStartOfDay(values.receivedAt),
                 },
             })
 

--- a/src/views/purchases/PurchaseOrdersView/PurchaseOrderForm.tsx
+++ b/src/views/purchases/PurchaseOrdersView/PurchaseOrderForm.tsx
@@ -9,6 +9,7 @@ import toast from '@/components/ui/toast'
 import { useCreatePurchaseOrder } from '@/hooks/usePurchaseOrders'
 import { useSuppliers } from '@/hooks/useSuppliers'
 import { getErrorMessage } from '@/utils/getErrorMessage'
+import { dateToIsoStartOfDay } from '@/utils/dateToIsoStartOfDay'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -77,9 +78,7 @@ const PurchaseOrderForm = ({
             const order = await createOrder.mutateAsync({
                 supplierId: values.supplierId,
                 notes: values.notes || undefined,
-                expectedDate: values.expectedDate
-                    ? `${values.expectedDate}T00:00:00Z`
-                    : undefined,
+                expectedDate: dateToIsoStartOfDay(values.expectedDate),
             })
 
             toast.push(


### PR DESCRIPTION
## Descripción

  - Add makeNumberRegister<T> helper in Form/utils.ts to replace per-form inline implementations
  - Add dateToIsoStartOfDay util to deduplicate ISO date conversion in onSubmit handlers
  - Extract optionalEmail and taxTypeSchema into schemas/common.ts; remove duplicate declarations from supplier and customer schemas
  - Re-export common from schemas/index.ts
  - Migrate ProductForm, PurchaseOrderForm and ReceiveForm to use the new helpers

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
