### PR TITLE
feat(forms): migrate WarehouseForm and UnitOfMeasureForm to RHF+Zod

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -4,3 +4,8 @@ export { productSchema, type ProductFormValues } from './product.schema'
 export { supplierSchema, type SupplierFormValues } from './supplier.schema'
 export { customerSchema, type CustomerFormValues } from './customer.schema'
 export { createUserSchema, type CreateUserFormValues } from './user.schema'
+export { warehouseSchema, type WarehouseFormValues } from './warehouse.schema'
+export {
+    unitOfMeasureSchema,
+    type UnitOfMeasureFormValues,
+} from './unitOfMeasure.schema'

--- a/src/schemas/unitOfMeasure.schema.ts
+++ b/src/schemas/unitOfMeasure.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const unitOfMeasureSchema = z.object({
+    name: z.string().min(1, 'Nombre requerido'),
+    symbol: z.string().min(1, 'Símbolo requerido'),
+    description: z.string().optional(),
+    isActive: z.boolean().optional(),
+})
+
+export type UnitOfMeasureFormValues = z.infer<typeof unitOfMeasureSchema>

--- a/src/schemas/warehouse.schema.ts
+++ b/src/schemas/warehouse.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+import { optionalEmail } from './common'
+
+export const warehouseSchema = z.object({
+    name: z.string().min(1, 'Nombre requerido').max(200),
+    code: z.string().min(1, 'Código requerido').max(50),
+    address: z.string().optional(),
+    city: z.string().optional(),
+    country: z.string().optional(),
+    manager: z.string().optional(),
+    phone: z.string().optional(),
+    email: optionalEmail,
+    isActive: z.boolean().optional(),
+    isDefault: z.boolean().optional(),
+})
+
+export type WarehouseFormValues = z.infer<typeof warehouseSchema>

--- a/src/views/inventory/UnitsOfMeasureView/UnitOfMeasureForm.tsx
+++ b/src/views/inventory/UnitsOfMeasureView/UnitOfMeasureForm.tsx
@@ -1,16 +1,23 @@
-import { useState, useEffect } from 'react'
 import Input from '@/components/ui/Input'
-import Switcher from '@/components/ui/Switcher'
-import type {
-    UnitOfMeasure,
-    UnitOfMeasureInput,
-} from '@/services/UnitOfMeasureService'
+import { FormItem, FormContainer } from '@/components/ui/Form'
+import { ControlledSwitcher } from '@/components/ui/Form/controlled'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { unitOfMeasureSchema, type UnitOfMeasureFormValues } from '@/schemas'
+import type { UnitOfMeasure } from '@/services/UnitOfMeasureService'
 
 interface UnitOfMeasureFormProps {
     formId: string
     unitOfMeasure: UnitOfMeasure | null
     isSubmitting?: boolean
-    onSubmit: (data: UnitOfMeasureInput) => void
+    onSubmit: (data: UnitOfMeasureFormValues) => void
+}
+
+const emptyValues: UnitOfMeasureFormValues = {
+    name: '',
+    symbol: '',
+    description: '',
+    isActive: true,
 }
 
 const UnitOfMeasureForm = ({
@@ -19,97 +26,88 @@ const UnitOfMeasureForm = ({
     isSubmitting = false,
     onSubmit,
 }: UnitOfMeasureFormProps) => {
-    const [formData, setFormData] = useState<UnitOfMeasureInput>({
-        name: '',
-        symbol: '',
-        description: '',
-        isActive: true,
+    const defaultValues: UnitOfMeasureFormValues = unitOfMeasure
+        ? {
+              name: unitOfMeasure.name,
+              symbol: unitOfMeasure.symbol,
+              description: unitOfMeasure.description ?? '',
+              isActive: unitOfMeasure.isActive,
+          }
+        : emptyValues
+
+    const {
+        register,
+        handleSubmit,
+        control,
+        formState: { errors },
+    } = useForm<UnitOfMeasureFormValues>({
+        resolver: zodResolver(unitOfMeasureSchema),
+        defaultValues,
     })
 
-    useEffect(() => {
-        setFormData(
-            unitOfMeasure
-                ? {
-                      name: unitOfMeasure.name,
-                      symbol: unitOfMeasure.symbol,
-                      description: unitOfMeasure.description || '',
-                      isActive: unitOfMeasure.isActive,
-                  }
-                : { name: '', symbol: '', description: '', isActive: true }
-        )
-    }, [unitOfMeasure])
-
     return (
-        <form
-            id={formId}
-            onSubmit={(e) => {
-                e.preventDefault()
-                onSubmit(formData)
-            }}
-        >
-            <div className="space-y-4">
-                <div>
-                    <label className="block text-sm font-medium mb-2">
-                        Nombre <span className="text-red-500">*</span>
-                    </label>
+        <form id={formId} onSubmit={handleSubmit(onSubmit)}>
+            <FormContainer>
+                <FormItem
+                    asterisk
+                    htmlFor="name"
+                    label="Nombre"
+                    invalid={!!errors.name}
+                    errorMessage={errors.name?.message}
+                >
                     <Input
-                        required
-                        type="text"
+                        id="name"
                         placeholder="Ej: Kilogramo"
-                        value={formData.name}
                         disabled={isSubmitting}
-                        onChange={(e) =>
-                            setFormData({ ...formData, name: e.target.value })
-                        }
+                        invalid={!!errors.name}
+                        {...register('name')}
                     />
-                </div>
+                </FormItem>
 
-                <div>
-                    <label className="block text-sm font-medium mb-2">
-                        Símbolo <span className="text-red-500">*</span>
-                    </label>
+                <FormItem
+                    asterisk
+                    htmlFor="symbol"
+                    label="Símbolo"
+                    invalid={!!errors.symbol}
+                    errorMessage={errors.symbol?.message}
+                >
                     <Input
-                        required
-                        type="text"
+                        id="symbol"
                         placeholder="Ej: kg"
-                        value={formData.symbol}
                         disabled={isSubmitting}
-                        onChange={(e) =>
-                            setFormData({ ...formData, symbol: e.target.value })
-                        }
+                        invalid={!!errors.symbol}
+                        {...register('symbol')}
                     />
-                </div>
+                </FormItem>
 
-                <div>
-                    <label className="block text-sm font-medium mb-2">
-                        Descripción
-                    </label>
+                <FormItem
+                    htmlFor="description"
+                    label="Descripción"
+                    invalid={!!errors.description}
+                    errorMessage={errors.description?.message}
+                >
                     <Input
                         textArea
+                        id="description"
                         placeholder="Descripción de la unidad"
-                        value={formData.description || ''}
                         style={{ minHeight: '80px' }}
                         disabled={isSubmitting}
-                        onChange={(e) =>
-                            setFormData({
-                                ...formData,
-                                description: e.target.value,
-                            })
-                        }
+                        invalid={!!errors.description}
+                        {...register('description')}
                     />
-                </div>
+                </FormItem>
 
                 <div className="flex items-center gap-3">
-                    <Switcher
-                        checked={formData.isActive}
+                    <ControlledSwitcher
+                        name="isActive"
+                        control={control}
                         disabled={isSubmitting}
-                        onChange={(checked) =>
-                            setFormData({ ...formData, isActive: checked })
-                        }
                     />
-                    <label className="text-sm font-medium">Activo</label>
+                    <label htmlFor="isActive" className="text-sm font-medium">
+                        Activo
+                    </label>
                 </div>
-            </div>
+            </FormContainer>
         </form>
     )
 }

--- a/src/views/inventory/UnitsOfMeasureView/index.tsx
+++ b/src/views/inventory/UnitsOfMeasureView/index.tsx
@@ -14,6 +14,7 @@ import type {
     UnitOfMeasure,
     UnitOfMeasureInput,
 } from '@/services/UnitOfMeasureService'
+import type { UnitOfMeasureFormValues } from '@/schemas'
 import UnitOfMeasureForm from './UnitOfMeasureForm'
 import { getErrorMessage } from '@/utils/getErrorMessage'
 import toast from '@/components/ui/toast'
@@ -36,12 +37,12 @@ const UnitsOfMeasureView = () => {
     const updateUnit = useUpdateUnitOfMeasure()
     const isPending = createUnit.isPending || updateUnit.isPending
 
-    const handleFormSubmit = async (formData: UnitOfMeasureInput) => {
+    const handleFormSubmit = async (formData: UnitOfMeasureFormValues) => {
         try {
             if (crud.isEditOpen && crud.selectedItem) {
                 await updateUnit.mutateAsync({
                     id: crud.selectedItem.id,
-                    data: formData,
+                    data: formData as UnitOfMeasureInput,
                 })
                 toast.push(
                     <Notification title="Unidad actualizada" type="success">
@@ -50,7 +51,7 @@ const UnitsOfMeasureView = () => {
                     { placement: 'top-center' }
                 )
             } else {
-                await createUnit.mutateAsync(formData)
+                await createUnit.mutateAsync(formData as UnitOfMeasureInput)
                 toast.push(
                     <Notification title="Unidad creada" type="success">
                         La unidad de medida se creó correctamente

--- a/src/views/inventory/WarehousesView/WarehouseForm.tsx
+++ b/src/views/inventory/WarehousesView/WarehouseForm.tsx
@@ -1,13 +1,29 @@
-import { useState, useEffect } from 'react'
 import Input from '@/components/ui/Input'
-import Switcher from '@/components/ui/Switcher'
-import type { Warehouse, WarehouseInput } from '@/services/WarehouseService'
+import { FormItem, FormContainer } from '@/components/ui/Form'
+import { ControlledSwitcher } from '@/components/ui/Form/controlled'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { warehouseSchema, type WarehouseFormValues } from '@/schemas'
+import type { Warehouse } from '@/services/WarehouseService'
 
 interface WarehouseFormProps {
     formId: string
     warehouse: Warehouse | null
     isSubmitting?: boolean
-    onSubmit: (data: WarehouseInput) => void
+    onSubmit: (data: WarehouseFormValues) => void
+}
+
+const emptyValues: WarehouseFormValues = {
+    name: '',
+    code: '',
+    address: '',
+    city: '',
+    country: '',
+    manager: '',
+    phone: '',
+    email: '',
+    isActive: true,
+    isDefault: false,
 }
 
 const WarehouseForm = ({
@@ -16,228 +32,193 @@ const WarehouseForm = ({
     isSubmitting = false,
     onSubmit,
 }: WarehouseFormProps) => {
-    const [formData, setFormData] = useState<WarehouseInput>({
-        name: '',
-        code: '',
-        address: '',
-        city: '',
-        country: '',
-        isActive: true,
-        isDefault: false,
-        manager: '',
-        phone: '',
-        email: '',
+    const defaultValues: WarehouseFormValues = warehouse
+        ? {
+              name: warehouse.name,
+              code: warehouse.code,
+              address: warehouse.address ?? '',
+              city: warehouse.city ?? '',
+              country: warehouse.country ?? '',
+              manager: warehouse.manager ?? '',
+              phone: warehouse.phone ?? '',
+              email: warehouse.email ?? '',
+              isActive: warehouse.isActive,
+              isDefault: warehouse.isDefault,
+          }
+        : emptyValues
+
+    const {
+        register,
+        handleSubmit,
+        control,
+        formState: { errors },
+    } = useForm<WarehouseFormValues>({
+        resolver: zodResolver(warehouseSchema),
+        defaultValues,
     })
 
-    useEffect(() => {
-        setFormData(
-            warehouse
-                ? {
-                      name: warehouse.name,
-                      code: warehouse.code,
-                      address: warehouse.address || '',
-                      city: warehouse.city || '',
-                      country: warehouse.country || '',
-                      isActive: warehouse.isActive,
-                      isDefault: warehouse.isDefault,
-                      manager: warehouse.manager || '',
-                      phone: warehouse.phone || '',
-                      email: warehouse.email || '',
-                  }
-                : {
-                      name: '',
-                      code: '',
-                      address: '',
-                      city: '',
-                      country: '',
-                      isActive: true,
-                      isDefault: false,
-                      manager: '',
-                      phone: '',
-                      email: '',
-                  }
-        )
-    }, [warehouse])
-
     return (
-        <form
-            id={formId}
-            onSubmit={(e) => {
-                e.preventDefault()
-                onSubmit(formData)
-            }}
-        >
-            <div className="space-y-4">
+        <form id={formId} onSubmit={handleSubmit(onSubmit)}>
+            <FormContainer>
                 <div className="grid grid-cols-2 gap-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Nombre <span className="text-red-500">*</span>
-                        </label>
+                    <FormItem
+                        asterisk
+                        htmlFor="name"
+                        label="Nombre"
+                        invalid={!!errors.name}
+                        errorMessage={errors.name?.message}
+                    >
                         <Input
-                            required
-                            type="text"
+                            id="name"
                             placeholder="Ej: Bodega Principal"
-                            value={formData.name}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    name: e.target.value,
-                                })
-                            }
+                            disabled={isSubmitting}
+                            invalid={!!errors.name}
+                            {...register('name')}
                         />
-                    </div>
+                    </FormItem>
 
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Código <span className="text-red-500">*</span>
-                        </label>
+                    <FormItem
+                        asterisk
+                        htmlFor="code"
+                        label="Código"
+                        invalid={!!errors.code}
+                        errorMessage={errors.code?.message}
+                    >
                         <Input
-                            required
-                            type="text"
+                            id="code"
                             placeholder="Ej: BOD-001"
-                            value={formData.code}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    code: e.target.value,
-                                })
-                            }
+                            disabled={isSubmitting}
+                            invalid={!!errors.code}
+                            {...register('code')}
                         />
-                    </div>
+                    </FormItem>
                 </div>
 
-                <div>
-                    <label className="block text-sm font-medium mb-2">
-                        Dirección
-                    </label>
+                <FormItem
+                    htmlFor="address"
+                    label="Dirección"
+                    invalid={!!errors.address}
+                    errorMessage={errors.address?.message}
+                >
                     <Input
-                        type="text"
+                        id="address"
                         placeholder="Dirección de la bodega"
-                        value={formData.address || ''}
-                        onChange={(e) =>
-                            setFormData({
-                                ...formData,
-                                address: e.target.value,
-                            })
-                        }
+                        disabled={isSubmitting}
+                        invalid={!!errors.address}
+                        {...register('address')}
                     />
-                </div>
+                </FormItem>
 
                 <div className="grid grid-cols-2 gap-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Ciudad
-                        </label>
+                    <FormItem
+                        htmlFor="city"
+                        label="Ciudad"
+                        invalid={!!errors.city}
+                        errorMessage={errors.city?.message}
+                    >
                         <Input
-                            type="text"
+                            id="city"
                             placeholder="Ej: Quito"
-                            value={formData.city || ''}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    city: e.target.value,
-                                })
-                            }
+                            disabled={isSubmitting}
+                            invalid={!!errors.city}
+                            {...register('city')}
                         />
-                    </div>
+                    </FormItem>
 
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            País
-                        </label>
+                    <FormItem
+                        htmlFor="country"
+                        label="País"
+                        invalid={!!errors.country}
+                        errorMessage={errors.country?.message}
+                    >
                         <Input
-                            type="text"
+                            id="country"
                             placeholder="Ej: Ecuador"
-                            value={formData.country || ''}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    country: e.target.value,
-                                })
-                            }
+                            disabled={isSubmitting}
+                            invalid={!!errors.country}
+                            {...register('country')}
                         />
-                    </div>
+                    </FormItem>
                 </div>
 
                 <div className="grid grid-cols-2 gap-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Responsable
-                        </label>
+                    <FormItem
+                        htmlFor="manager"
+                        label="Responsable"
+                        invalid={!!errors.manager}
+                        errorMessage={errors.manager?.message}
+                    >
                         <Input
-                            type="text"
+                            id="manager"
                             placeholder="Nombre del responsable"
-                            value={formData.manager || ''}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    manager: e.target.value,
-                                })
-                            }
+                            disabled={isSubmitting}
+                            invalid={!!errors.manager}
+                            {...register('manager')}
                         />
-                    </div>
+                    </FormItem>
 
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Teléfono
-                        </label>
+                    <FormItem
+                        htmlFor="phone"
+                        label="Teléfono"
+                        invalid={!!errors.phone}
+                        errorMessage={errors.phone?.message}
+                    >
                         <Input
-                            type="text"
+                            id="phone"
                             placeholder="Ej: +593 99 999 9999"
-                            value={formData.phone || ''}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    phone: e.target.value,
-                                })
-                            }
+                            disabled={isSubmitting}
+                            invalid={!!errors.phone}
+                            {...register('phone')}
                         />
-                    </div>
+                    </FormItem>
                 </div>
 
-                <div>
-                    <label className="block text-sm font-medium mb-2">
-                        Email
-                    </label>
+                <FormItem
+                    htmlFor="email"
+                    label="Email"
+                    invalid={!!errors.email}
+                    errorMessage={errors.email?.message}
+                >
                     <Input
+                        id="email"
                         type="email"
                         placeholder="bodega@ejemplo.com"
-                        value={formData.email || ''}
-                        onChange={(e) =>
-                            setFormData({ ...formData, email: e.target.value })
-                        }
+                        disabled={isSubmitting}
+                        invalid={!!errors.email}
+                        {...register('email')}
                     />
-                </div>
+                </FormItem>
 
                 <div className="flex items-center gap-6">
                     <div className="flex items-center gap-3">
-                        <Switcher
-                            checked={formData.isActive}
+                        <ControlledSwitcher
+                            name="isActive"
+                            control={control}
                             disabled={isSubmitting}
-                            onChange={(checked) =>
-                                setFormData({ ...formData, isActive: !checked })
-                            }
                         />
-                        <label className="text-sm font-medium">Activo</label>
+                        <label
+                            htmlFor="isActive"
+                            className="text-sm font-medium"
+                        >
+                            Activo
+                        </label>
                     </div>
 
                     <div className="flex items-center gap-3">
-                        <Switcher
-                            checked={formData.isDefault}
+                        <ControlledSwitcher
+                            name="isDefault"
+                            control={control}
                             disabled={isSubmitting}
-                            onChange={(checked) =>
-                                setFormData({
-                                    ...formData,
-                                    isDefault: !checked,
-                                })
-                            }
                         />
-                        <label className="text-sm font-medium">
+                        <label
+                            htmlFor="isDefault"
+                            className="text-sm font-medium"
+                        >
                             Por defecto
                         </label>
                     </div>
                 </div>
-            </div>
+            </FormContainer>
         </form>
     )
 }

--- a/src/views/inventory/WarehousesView/index.tsx
+++ b/src/views/inventory/WarehousesView/index.tsx
@@ -14,6 +14,7 @@ import { getErrorMessage } from '@/utils/getErrorMessage'
 import { useCrudOperations } from '@/hooks'
 import { FormModal, DeleteConfirmDialog } from '@/components/shared'
 import type { Warehouse, WarehouseInput } from '@/services/WarehouseService'
+import type { WarehouseFormValues } from '@/schemas'
 import WarehouseForm from './WarehouseForm'
 import { HiOutlinePencil, HiOutlineTrash, HiPlus } from 'react-icons/hi'
 
@@ -30,12 +31,12 @@ const WarehousesView = () => {
     const updateWarehouse = useUpdateWarehouse()
     const isPending = createWarehouse.isPending || updateWarehouse.isPending
 
-    const handleFormSubmit = async (formData: WarehouseInput) => {
+    const handleFormSubmit = async (formData: WarehouseFormValues) => {
         try {
             if (crud.isEditOpen && crud.selectedItem) {
                 await updateWarehouse.mutateAsync({
                     id: crud.selectedItem.id,
-                    data: formData,
+                    data: formData as WarehouseInput,
                 })
                 toast.push(
                     <Notification title="Bodega actualizada" type="success">
@@ -44,7 +45,7 @@ const WarehousesView = () => {
                     { placement: 'top-center' }
                 )
             } else {
-                await createWarehouse.mutateAsync(formData)
+                await createWarehouse.mutateAsync(formData as WarehouseInput)
                 toast.push(
                     <Notification title="Bodega creada" type="success">
                         La bodega se creó correctamente


### PR DESCRIPTION
## Descripción

  - Add warehouseSchema and unitOfMeasureSchema in /src/schemas/
  - Replace useState+manual validation with useForm+zodResolver in both forms
  - Fix switcher bug in WarehouseForm (isActive and isDefault)
  - Replace raw <Switcher> and <label> with <ControlledSwitcher> and <FormItem>
  - Cast FormValues → *Input at mutateAsync call sites; services untouched

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
