### PR TITLE
feat(forms): migrate LotForm, SerialNumberForm and LocationForm to RHF+Zod

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -9,3 +9,14 @@ export {
     unitOfMeasureSchema,
     type UnitOfMeasureFormValues,
 } from './unitOfMeasure.schema'
+export {
+    lotCreateSchema,
+    lotUpdateSchema,
+    type LotCreateFormValues,
+    type LotUpdateFormValues,
+} from './lot.schema'
+export {
+    serialNumberSchema,
+    type SerialNumberFormValues,
+} from './serialNumber.schema'
+export { locationSchema, type LocationFormValues } from './location.schema'

--- a/src/schemas/location.schema.ts
+++ b/src/schemas/location.schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const locationSchema = z.object({
+    warehouseId: z
+        .number({ error: 'Debe seleccionar una bodega' })
+        .int()
+        .min(1, 'Debe seleccionar una bodega'),
+    name: z.string().min(1, 'Nombre requerido'),
+    code: z.string().min(1, 'Código requerido'),
+    type: z.enum(['STORAGE', 'RECEIVING', 'SHIPPING', 'RETURN']),
+    isActive: z.boolean().optional(),
+    capacity: z.number().int().min(0).nullable().optional(),
+})
+
+export type LocationFormValues = z.infer<typeof locationSchema>

--- a/src/schemas/lot.schema.ts
+++ b/src/schemas/lot.schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+export const lotCreateSchema = z.object({
+    lotNumber: z.string().min(1, 'Número de lote requerido'),
+    productId: z.number().int().min(1),
+    initialQuantity: z.number().int().min(1),
+    manufactureDate: z.string().optional(),
+    expirationDate: z.string().optional(),
+    notes: z.string().optional(),
+})
+
+export const lotUpdateSchema = z.object({
+    currentQuantity: z.number().int().min(0),
+    manufactureDate: z.string().optional(),
+    expirationDate: z.string().optional(),
+    notes: z.string().optional(),
+})
+
+export type LotCreateFormValues = z.infer<typeof lotCreateSchema>
+export type LotUpdateFormValues = z.infer<typeof lotUpdateSchema>

--- a/src/schemas/serialNumber.schema.ts
+++ b/src/schemas/serialNumber.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const serialNumberSchema = z.object({
+    serialNumber: z.string().min(1, 'Número de serie requerido'),
+    productId: z.number().int().min(1),
+    lotId: z.number().int().min(1).optional(),
+    notes: z.string().optional(),
+})
+
+export type SerialNumberFormValues = z.infer<typeof serialNumberSchema>

--- a/src/views/inventory/LocationsView/LocationForm.tsx
+++ b/src/views/inventory/LocationsView/LocationForm.tsx
@@ -1,10 +1,13 @@
-import { useState, useEffect } from 'react'
 import Input from '@/components/ui/Input'
-import Select from '@/components/ui/Select'
-import Switcher from '@/components/ui/Switcher'
-import Notification from '@/components/ui/Notification'
-import toast from '@/components/ui/toast'
+import { FormItem, FormContainer } from '@/components/ui/Form'
+import {
+    ControlledSelect,
+    ControlledSwitcher,
+} from '@/components/ui/Form/controlled'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { useWarehouses } from '@/hooks/useWarehouses'
+import { locationSchema, type LocationFormValues } from '@/schemas'
 import type {
     Location,
     LocationInput,
@@ -18,7 +21,7 @@ interface LocationFormProps {
     onSubmit: (data: LocationInput) => void
 }
 
-const LOCATION_TYPES: { value: LocationType; label: string }[] = [
+const locationTypeOptions: { value: LocationType; label: string }[] = [
     { value: 'STORAGE', label: 'Almacenamiento' },
     { value: 'RECEIVING', label: 'Recepción' },
     { value: 'SHIPPING', label: 'Despacho' },
@@ -31,15 +34,6 @@ const LocationForm = ({
     isSubmitting = false,
     onSubmit,
 }: LocationFormProps) => {
-    const [formData, setFormData] = useState<LocationInput>({
-        warehouseId: 0,
-        name: '',
-        code: '',
-        type: 'STORAGE',
-        isActive: true,
-        capacity: null,
-    })
-
     const { data: warehousesData } = useWarehouses({ isActive: true })
     const warehouses = warehousesData?.items ?? []
     const warehouseOptions = warehouses.map((w) => ({
@@ -47,162 +41,141 @@ const LocationForm = ({
         label: w.name,
     }))
 
-    useEffect(() => {
-        setFormData(
-            location
-                ? {
-                      warehouseId: location.warehouseId,
-                      name: location.name,
-                      code: location.code,
-                      type: location.type,
-                      isActive: location.isActive,
-                      capacity: location.capacity ?? null,
-                  }
-                : {
-                      warehouseId: 0,
-                      name: '',
-                      code: '',
-                      type: 'STORAGE',
-                      isActive: true,
-                      capacity: null,
-                  }
-        )
-    }, [location])
+    const {
+        register,
+        handleSubmit,
+        control,
+        formState: { errors },
+    } = useForm<LocationFormValues>({
+        resolver: zodResolver(locationSchema),
+        defaultValues: location
+            ? {
+                  warehouseId: location.warehouseId,
+                  name: location.name,
+                  code: location.code,
+                  type: location.type,
+                  isActive: location.isActive,
+                  capacity: location.capacity ?? null,
+              }
+            : {
+                  name: '',
+                  code: '',
+                  type: 'STORAGE',
+                  isActive: true,
+                  capacity: null,
+              },
+    })
 
-    const handleSubmit = (e: React.FormEvent) => {
-        e.preventDefault()
-        if (!formData.warehouseId) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    Debe seleccionar una bodega
-                </Notification>,
-                { placement: 'top-center' }
-            )
-            return
-        }
-        onSubmit({ ...formData, capacity: formData.capacity || null })
+    const onFormSubmit = (values: LocationFormValues) => {
+        onSubmit(values as LocationInput)
     }
 
     return (
-        <form id={formId} onSubmit={handleSubmit}>
-            <div className="space-y-4">
-                <div>
-                    <label className="block text-sm font-medium mb-2">
-                        Bodega <span className="text-red-500">*</span>
-                    </label>
-                    <Select
-                        placeholder="Seleccione una bodega"
-                        value={
-                            warehouseOptions.find(
-                                (opt) => opt.value === formData.warehouseId
-                            ) || null
-                        }
+        <form id={formId} onSubmit={handleSubmit(onFormSubmit)}>
+            <FormContainer>
+                <FormItem
+                    asterisk
+                    htmlFor="warehouseId"
+                    label="Bodega"
+                    invalid={!!errors.warehouseId}
+                    errorMessage={errors.warehouseId?.message}
+                >
+                    <ControlledSelect
+                        name="warehouseId"
+                        control={control}
                         options={warehouseOptions}
-                        onChange={(option) =>
-                            setFormData({
-                                ...formData,
-                                warehouseId: option?.value || 0,
-                            })
-                        }
+                        isDisabled={isSubmitting}
+                        placeholder="Seleccione una bodega"
                     />
-                </div>
+                </FormItem>
 
                 <div className="grid grid-cols-2 gap-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Nombre <span className="text-red-500">*</span>
-                        </label>
+                    <FormItem
+                        asterisk
+                        htmlFor="name"
+                        label="Nombre"
+                        invalid={!!errors.name}
+                        errorMessage={errors.name?.message}
+                    >
                         <Input
-                            required
-                            type="text"
+                            id="name"
                             placeholder="Ej: Estante A1"
-                            value={formData.name}
                             disabled={isSubmitting}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    name: e.target.value,
-                                })
-                            }
+                            invalid={!!errors.name}
+                            {...register('name')}
                         />
-                    </div>
+                    </FormItem>
 
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Código <span className="text-red-500">*</span>
-                        </label>
+                    <FormItem
+                        asterisk
+                        htmlFor="code"
+                        label="Código"
+                        invalid={!!errors.code}
+                        errorMessage={errors.code?.message}
+                    >
                         <Input
-                            required
-                            type="text"
+                            id="code"
                             placeholder="Ej: EST-A1"
-                            value={formData.code}
                             disabled={isSubmitting}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    code: e.target.value,
-                                })
-                            }
+                            invalid={!!errors.code}
+                            {...register('code')}
                         />
-                    </div>
+                    </FormItem>
                 </div>
 
                 <div className="grid grid-cols-2 gap-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Tipo <span className="text-red-500">*</span>
-                        </label>
-                        <Select
+                    <FormItem
+                        asterisk
+                        htmlFor="type"
+                        label="Tipo"
+                        invalid={!!errors.type}
+                        errorMessage={errors.type?.message}
+                    >
+                        <ControlledSelect
+                            name="type"
+                            control={control}
+                            options={locationTypeOptions}
+                            isDisabled={isSubmitting}
                             placeholder="Seleccione un tipo"
-                            value={
-                                LOCATION_TYPES.find(
-                                    (opt) => opt.value === formData.type
-                                ) || null
-                            }
-                            options={LOCATION_TYPES}
-                            onChange={(option) =>
-                                setFormData({
-                                    ...formData,
-                                    type:
-                                        (option?.value as LocationType) ||
-                                        'STORAGE',
-                                })
-                            }
                         />
-                    </div>
+                    </FormItem>
 
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Capacidad
-                        </label>
+                    <FormItem
+                        htmlFor="capacity"
+                        label="Capacidad"
+                        invalid={!!errors.capacity}
+                        errorMessage={errors.capacity?.message}
+                    >
                         <Input
+                            id="capacity"
                             type="number"
+                            min={0}
                             placeholder="Ej: 100"
-                            value={formData.capacity ?? ''}
                             disabled={isSubmitting}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    capacity: e.target.value
-                                        ? Number(e.target.value)
-                                        : null,
-                                })
-                            }
+                            invalid={!!errors.capacity}
+                            {...register('capacity', {
+                                setValueAs: (v) => {
+                                    if (
+                                        v === '' ||
+                                        v === null ||
+                                        v === undefined
+                                    )
+                                        return null
+                                    const parsed = parseInt(String(v), 10)
+                                    return Number.isNaN(parsed) ? null : parsed
+                                },
+                            })}
                         />
-                    </div>
+                    </FormItem>
                 </div>
 
                 <div className="flex items-center gap-3">
-                    <Switcher
-                        checked={formData.isActive}
-                        disabled={isSubmitting}
-                        onChange={(checked) =>
-                            setFormData({ ...formData, isActive: !checked })
-                        }
-                    />
-                    <label className="text-sm font-medium">Activo</label>
+                    <ControlledSwitcher name="isActive" control={control} />
+                    <label htmlFor="isActive" className="text-sm font-medium">
+                        Activo
+                    </label>
                 </div>
-            </div>
+            </FormContainer>
         </form>
     )
 }

--- a/src/views/inventory/LotsView/LotForm.tsx
+++ b/src/views/inventory/LotsView/LotForm.tsx
@@ -1,6 +1,279 @@
-import { useState, useEffect } from 'react'
 import Input from '@/components/ui/Input'
+import { FormItem, FormContainer } from '@/components/ui/Form'
+import { makeNumberRegister } from '@/components/ui/Form/utils'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+    lotCreateSchema,
+    lotUpdateSchema,
+    type LotCreateFormValues,
+    type LotUpdateFormValues,
+} from '@/schemas'
 import type { Lot, LotInput, LotUpdateInput } from '@/services/LotService'
+
+// ─── LotCreateForm ────────────────────────────────────────────────────────────
+
+interface LotCreateFormProps {
+    formId: string
+    isSubmitting?: boolean
+    onSubmit: (data: LotInput) => void
+}
+
+const LotCreateForm = ({
+    formId,
+    isSubmitting = false,
+    onSubmit,
+}: LotCreateFormProps) => {
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+    } = useForm<LotCreateFormValues>({
+        resolver: zodResolver(lotCreateSchema),
+        defaultValues: {
+            lotNumber: '',
+            initialQuantity: 1,
+            manufactureDate: '',
+            expirationDate: '',
+            notes: '',
+        },
+    })
+
+    const numberRegister = makeNumberRegister(register)
+
+    const onFormSubmit = (values: LotCreateFormValues) => {
+        onSubmit({
+            lotNumber: values.lotNumber,
+            productId: values.productId,
+            initialQuantity: values.initialQuantity,
+            manufactureDate: values.manufactureDate || undefined,
+            expirationDate: values.expirationDate || undefined,
+            notes: values.notes || undefined,
+        })
+    }
+
+    return (
+        <form id={formId} onSubmit={handleSubmit(onFormSubmit)}>
+            <FormContainer>
+                <div className="grid grid-cols-2 gap-4">
+                    <FormItem
+                        asterisk
+                        htmlFor="lotNumber"
+                        label="Número de Lote"
+                        invalid={!!errors.lotNumber}
+                        errorMessage={errors.lotNumber?.message}
+                    >
+                        <Input
+                            id="lotNumber"
+                            placeholder="Ej: LOT-001"
+                            disabled={isSubmitting}
+                            invalid={!!errors.lotNumber}
+                            {...register('lotNumber')}
+                        />
+                    </FormItem>
+
+                    <FormItem
+                        asterisk
+                        htmlFor="productId"
+                        label="ID Producto"
+                        invalid={!!errors.productId}
+                        errorMessage={errors.productId?.message}
+                    >
+                        <Input
+                            id="productId"
+                            type="number"
+                            min={1}
+                            placeholder="ID del producto"
+                            disabled={isSubmitting}
+                            invalid={!!errors.productId}
+                            {...numberRegister('productId', { integer: true })}
+                        />
+                    </FormItem>
+                </div>
+
+                <FormItem
+                    asterisk
+                    htmlFor="initialQuantity"
+                    label="Cantidad Inicial"
+                    invalid={!!errors.initialQuantity}
+                    errorMessage={errors.initialQuantity?.message}
+                >
+                    <Input
+                        id="initialQuantity"
+                        type="number"
+                        min={1}
+                        placeholder="1"
+                        disabled={isSubmitting}
+                        invalid={!!errors.initialQuantity}
+                        {...numberRegister('initialQuantity', {
+                            integer: true,
+                        })}
+                    />
+                </FormItem>
+
+                <div className="grid grid-cols-2 gap-4">
+                    <FormItem
+                        htmlFor="manufactureDate"
+                        label="Fecha de Manufactura"
+                        invalid={!!errors.manufactureDate}
+                        errorMessage={errors.manufactureDate?.message}
+                    >
+                        <Input
+                            id="manufactureDate"
+                            type="date"
+                            disabled={isSubmitting}
+                            {...register('manufactureDate')}
+                        />
+                    </FormItem>
+
+                    <FormItem
+                        htmlFor="expirationDate"
+                        label="Fecha de Vencimiento"
+                        invalid={!!errors.expirationDate}
+                        errorMessage={errors.expirationDate?.message}
+                    >
+                        <Input
+                            id="expirationDate"
+                            type="date"
+                            disabled={isSubmitting}
+                            {...register('expirationDate')}
+                        />
+                    </FormItem>
+                </div>
+
+                <FormItem
+                    htmlFor="notes"
+                    label="Notas"
+                    invalid={!!errors.notes}
+                    errorMessage={errors.notes?.message}
+                >
+                    <Input
+                        textArea
+                        id="notes"
+                        placeholder="Notas adicionales sobre el lote"
+                        disabled={isSubmitting}
+                        {...register('notes')}
+                    />
+                </FormItem>
+            </FormContainer>
+        </form>
+    )
+}
+
+// ─── LotUpdateForm ────────────────────────────────────────────────────────────
+
+interface LotUpdateFormProps {
+    formId: string
+    lot: Lot
+    isSubmitting?: boolean
+    onSubmit: (data: LotUpdateInput) => void
+}
+
+const LotUpdateForm = ({
+    formId,
+    lot,
+    isSubmitting = false,
+    onSubmit,
+}: LotUpdateFormProps) => {
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+    } = useForm<LotUpdateFormValues>({
+        resolver: zodResolver(lotUpdateSchema),
+        defaultValues: {
+            currentQuantity: lot.currentQuantity,
+            manufactureDate: lot.manufactureDate || '',
+            expirationDate: lot.expirationDate || '',
+            notes: lot.notes || '',
+        },
+    })
+
+    const numberRegister = makeNumberRegister(register)
+
+    const onFormSubmit = (values: LotUpdateFormValues) => {
+        onSubmit({
+            currentQuantity: values.currentQuantity,
+            manufactureDate: values.manufactureDate || undefined,
+            expirationDate: values.expirationDate || undefined,
+            notes: values.notes || undefined,
+        })
+    }
+
+    return (
+        <form id={formId} onSubmit={handleSubmit(onFormSubmit)}>
+            <FormContainer>
+                <FormItem
+                    asterisk
+                    htmlFor="currentQuantity"
+                    label="Cantidad Actual"
+                    invalid={!!errors.currentQuantity}
+                    errorMessage={errors.currentQuantity?.message}
+                >
+                    <Input
+                        id="currentQuantity"
+                        type="number"
+                        min={0}
+                        placeholder="0"
+                        disabled={isSubmitting}
+                        invalid={!!errors.currentQuantity}
+                        {...numberRegister('currentQuantity', {
+                            integer: true,
+                            emptyValue: 0,
+                        })}
+                    />
+                </FormItem>
+
+                <div className="grid grid-cols-2 gap-4">
+                    <FormItem
+                        htmlFor="manufactureDate"
+                        label="Fecha de Manufactura"
+                        invalid={!!errors.manufactureDate}
+                        errorMessage={errors.manufactureDate?.message}
+                    >
+                        <Input
+                            id="manufactureDate"
+                            type="date"
+                            disabled={isSubmitting}
+                            {...register('manufactureDate')}
+                        />
+                    </FormItem>
+
+                    <FormItem
+                        htmlFor="expirationDate"
+                        label="Fecha de Vencimiento"
+                        invalid={!!errors.expirationDate}
+                        errorMessage={errors.expirationDate?.message}
+                    >
+                        <Input
+                            id="expirationDate"
+                            type="date"
+                            disabled={isSubmitting}
+                            {...register('expirationDate')}
+                        />
+                    </FormItem>
+                </div>
+
+                <FormItem
+                    htmlFor="notes"
+                    label="Notas"
+                    invalid={!!errors.notes}
+                    errorMessage={errors.notes?.message}
+                >
+                    <Input
+                        textArea
+                        id="notes"
+                        placeholder="Notas adicionales sobre el lote"
+                        disabled={isSubmitting}
+                        {...register('notes')}
+                    />
+                </FormItem>
+            </FormContainer>
+        </form>
+    )
+}
+
+// ─── LotForm (wrapper) ────────────────────────────────────────────────────────
 
 interface LotFormProps {
     formId: string
@@ -9,263 +282,20 @@ interface LotFormProps {
     onSubmit: (data: LotInput | LotUpdateInput) => void
 }
 
-const LotForm = ({ formId, lot, onSubmit }: LotFormProps) => {
-    const [formData, setFormData] = useState<LotInput>({
-        lotNumber: '',
-        productId: 0,
-        initialQuantity: 1,
-        manufactureDate: '',
-        expirationDate: '',
-        notes: '',
-    })
-
-    const [editData, setEditData] = useState<LotUpdateInput>({
-        currentQuantity: 0,
-        manufactureDate: '',
-        expirationDate: '',
-        notes: '',
-    })
-
-    const isEdit = !!lot
-
-    useEffect(() => {
-        if (lot) {
-            setEditData({
-                currentQuantity: lot.currentQuantity,
-                manufactureDate: lot.manufactureDate || '',
-                expirationDate: lot.expirationDate || '',
-                notes: lot.notes || '',
-            })
-        } else {
-            setFormData({
-                lotNumber: '',
-                productId: 0,
-                initialQuantity: 1,
-                manufactureDate: '',
-                expirationDate: '',
-                notes: '',
-            })
-        }
-    }, [lot])
-
-    const handleSubmit = (e: React.FormEvent) => {
-        e.preventDefault()
-        if (isEdit) {
-            const submitData: LotUpdateInput = {
-                currentQuantity: editData.currentQuantity,
-                manufactureDate: editData.manufactureDate || undefined,
-                expirationDate: editData.expirationDate || undefined,
-                notes: editData.notes || undefined,
-            }
-            onSubmit(submitData)
-        } else {
-            const submitData: LotInput = {
-                ...formData,
-                manufactureDate: formData.manufactureDate || undefined,
-                expirationDate: formData.expirationDate || undefined,
-                notes: formData.notes || undefined,
-            }
-            onSubmit(submitData)
-        }
-    }
-
-    return (
-        <form id={formId} onSubmit={handleSubmit}>
-            <div className="space-y-4">
-                {isEdit ? (
-                    <>
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Cantidad Actual{' '}
-                                <span className="text-red-500">*</span>
-                            </label>
-                            <Input
-                                required
-                                type="number"
-                                min={0}
-                                placeholder="0"
-                                value={editData.currentQuantity ?? ''}
-                                onChange={(e) =>
-                                    setEditData({
-                                        ...editData,
-                                        currentQuantity:
-                                            parseInt(e.target.value) || 0,
-                                    })
-                                }
-                            />
-                        </div>
-
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Fecha de Manufactura
-                                </label>
-                                <Input
-                                    type="date"
-                                    value={editData.manufactureDate || ''}
-                                    onChange={(e) =>
-                                        setEditData({
-                                            ...editData,
-                                            manufactureDate: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Fecha de Vencimiento
-                                </label>
-                                <Input
-                                    type="date"
-                                    value={editData.expirationDate || ''}
-                                    onChange={(e) =>
-                                        setEditData({
-                                            ...editData,
-                                            expirationDate: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-                        </div>
-
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Notas
-                            </label>
-                            <Input
-                                textArea
-                                placeholder="Notas adicionales sobre el lote"
-                                value={editData.notes || ''}
-                                onChange={(e) =>
-                                    setEditData({
-                                        ...editData,
-                                        notes: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
-                    </>
-                ) : (
-                    <>
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Número de Lote{' '}
-                                    <span className="text-red-500">*</span>
-                                </label>
-                                <Input
-                                    required
-                                    type="text"
-                                    placeholder="Ej: LOT-001"
-                                    value={formData.lotNumber}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            lotNumber: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    ID Producto{' '}
-                                    <span className="text-red-500">*</span>
-                                </label>
-                                <Input
-                                    required
-                                    type="number"
-                                    min={1}
-                                    placeholder="ID del producto"
-                                    value={formData.productId || ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            productId:
-                                                parseInt(e.target.value) || 0,
-                                        })
-                                    }
-                                />
-                            </div>
-                        </div>
-
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Cantidad Inicial{' '}
-                                <span className="text-red-500">*</span>
-                            </label>
-                            <Input
-                                required
-                                type="number"
-                                min={1}
-                                placeholder="1"
-                                value={formData.initialQuantity || ''}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        initialQuantity:
-                                            parseInt(e.target.value) || 0,
-                                    })
-                                }
-                            />
-                        </div>
-
-                        <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Fecha de Manufactura
-                                </label>
-                                <Input
-                                    type="date"
-                                    value={formData.manufactureDate || ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            manufactureDate: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Fecha de Vencimiento
-                                </label>
-                                <Input
-                                    type="date"
-                                    value={formData.expirationDate || ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            expirationDate: e.target.value,
-                                        })
-                                    }
-                                />
-                            </div>
-                        </div>
-
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Notas
-                            </label>
-                            <Input
-                                textArea
-                                placeholder="Notas adicionales sobre el lote"
-                                value={formData.notes || ''}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        notes: e.target.value,
-                                    })
-                                }
-                            />
-                        </div>
-                    </>
-                )}
-            </div>
-        </form>
+const LotForm = ({ formId, lot, isSubmitting, onSubmit }: LotFormProps) =>
+    lot ? (
+        <LotUpdateForm
+            formId={formId}
+            lot={lot}
+            isSubmitting={isSubmitting}
+            onSubmit={onSubmit}
+        />
+    ) : (
+        <LotCreateForm
+            formId={formId}
+            isSubmitting={isSubmitting}
+            onSubmit={onSubmit}
+        />
     )
-}
 
 export default LotForm

--- a/src/views/inventory/SerialNumbersView/SerialNumberForm.tsx
+++ b/src/views/inventory/SerialNumbersView/SerialNumberForm.tsx
@@ -1,5 +1,9 @@
-import { useState, useEffect } from 'react'
 import Input from '@/components/ui/Input'
+import { FormItem, FormContainer } from '@/components/ui/Form'
+import { makeNumberRegister } from '@/components/ui/Form/utils'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { serialNumberSchema, type SerialNumberFormValues } from '@/schemas'
 import type { SerialNumberInput } from '@/services/SerialNumberService'
 
 interface SerialNumberFormProps {
@@ -8,113 +12,105 @@ interface SerialNumberFormProps {
     onSubmit: (data: SerialNumberInput) => void
 }
 
-const SerialNumberForm = ({ formId, onSubmit }: SerialNumberFormProps) => {
-    const [formData, setFormData] = useState<SerialNumberInput>({
-        serialNumber: '',
-        productId: 0,
-        lotId: undefined,
-        notes: '',
+const SerialNumberForm = ({
+    formId,
+    isSubmitting = false,
+    onSubmit,
+}: SerialNumberFormProps) => {
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+    } = useForm<SerialNumberFormValues>({
+        resolver: zodResolver(serialNumberSchema),
+        defaultValues: {
+            serialNumber: '',
+            notes: '',
+        },
     })
 
-    useEffect(() => {
-        setFormData({
-            serialNumber: '',
-            productId: 0,
-            lotId: undefined,
-            notes: '',
-        })
-    }, [formId])
+    const numberRegister = makeNumberRegister(register)
 
-    const handleSubmit = (e: React.FormEvent) => {
-        e.preventDefault()
+    const onFormSubmit = (values: SerialNumberFormValues) => {
         onSubmit({
-            serialNumber: formData.serialNumber,
-            productId: formData.productId,
-            lotId: formData.lotId || undefined,
-            notes: formData.notes || undefined,
+            serialNumber: values.serialNumber,
+            productId: values.productId,
+            lotId: values.lotId,
+            notes: values.notes || undefined,
         })
     }
 
     return (
-        <form id={formId} onSubmit={handleSubmit}>
-            <div className="space-y-4">
+        <form id={formId} onSubmit={handleSubmit(onFormSubmit)}>
+            <FormContainer>
                 <div className="grid grid-cols-2 gap-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Número de Serie{' '}
-                            <span className="text-red-500">*</span>
-                        </label>
+                    <FormItem
+                        asterisk
+                        htmlFor="serialNumber"
+                        label="Número de Serie"
+                        invalid={!!errors.serialNumber}
+                        errorMessage={errors.serialNumber?.message}
+                    >
                         <Input
-                            required
-                            type="text"
+                            id="serialNumber"
                             placeholder="Ej: SN-001-2024"
-                            value={formData.serialNumber}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    serialNumber: e.target.value,
-                                })
-                            }
+                            disabled={isSubmitting}
+                            invalid={!!errors.serialNumber}
+                            {...register('serialNumber')}
                         />
-                    </div>
+                    </FormItem>
 
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            ID Producto <span className="text-red-500">*</span>
-                        </label>
+                    <FormItem
+                        asterisk
+                        htmlFor="productId"
+                        label="ID Producto"
+                        invalid={!!errors.productId}
+                        errorMessage={errors.productId?.message}
+                    >
                         <Input
-                            required
+                            id="productId"
                             type="number"
                             min={1}
                             placeholder="ID del producto"
-                            value={formData.productId || ''}
-                            onChange={(e) =>
-                                setFormData({
-                                    ...formData,
-                                    productId: parseInt(e.target.value) || 0,
-                                })
-                            }
+                            disabled={isSubmitting}
+                            invalid={!!errors.productId}
+                            {...numberRegister('productId', { integer: true })}
                         />
-                    </div>
+                    </FormItem>
                 </div>
 
-                <div>
-                    <label className="block text-sm font-medium mb-2">
-                        ID Lote
-                    </label>
+                <FormItem
+                    htmlFor="lotId"
+                    label="ID Lote"
+                    invalid={!!errors.lotId}
+                    errorMessage={errors.lotId?.message}
+                >
                     <Input
+                        id="lotId"
                         type="number"
                         min={1}
                         placeholder="ID del lote (opcional)"
-                        value={formData.lotId || ''}
-                        onChange={(e) =>
-                            setFormData({
-                                ...formData,
-                                lotId: e.target.value
-                                    ? parseInt(e.target.value)
-                                    : undefined,
-                            })
-                        }
+                        disabled={isSubmitting}
+                        invalid={!!errors.lotId}
+                        {...numberRegister('lotId', { integer: true })}
                     />
-                </div>
+                </FormItem>
 
-                <div>
-                    <label className="block text-sm font-medium mb-2">
-                        Notas
-                    </label>
+                <FormItem
+                    htmlFor="notes"
+                    label="Notas"
+                    invalid={!!errors.notes}
+                    errorMessage={errors.notes?.message}
+                >
                     <Input
                         textArea
+                        id="notes"
                         placeholder="Notas adicionales"
-                        value={formData.notes || ''}
-                        onChange={(e) =>
-                            setFormData({
-                                ...formData,
-                                notes: e.target.value,
-                            })
-                        }
+                        disabled={isSubmitting}
+                        {...register('notes')}
                     />
-                </div>
-            </div>
+                </FormItem>
+            </FormContainer>
         </form>
     )
 }


### PR DESCRIPTION

## Descripción

  - Add lot.schema.ts (lotCreateSchema / lotUpdateSchema), serialNumber.schema.ts and location.schema.ts; re-export from schemas/index.ts
  - Split LotForm into LotCreateForm + LotUpdateForm sub-components with a thin wrapper; eliminates dual useState (formData / editData)
  - Migrate SerialNumberForm to RHF + zodResolver; removes useState + manual submit
  - Migrate LocationForm to RHF + zodResolver; replaces bare <Select> with <ControlledSelect> for warehouse and type, and <Switcher> with <ControlledSwitcher> for isActive — fixes the inversion bug
  - Validation for missing warehouse moves from a manual toast to a Zod field error

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
