### PR TITLE
feat(forms): migrate CustomerContactForm and SupplierContactForm to RHF+Zod

### DIFF
--- a/src/schemas/contact.schema.ts
+++ b/src/schemas/contact.schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+import { optionalEmail } from './common'
+
+export const contactSchema = z.object({
+    name: z.string().min(1, 'Nombre requerido'),
+    role: z.string().optional(),
+    email: optionalEmail,
+    phone: z.string().optional(),
+})
+
+export type ContactFormValues = z.infer<typeof contactSchema>

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -20,3 +20,4 @@ export {
     type SerialNumberFormValues,
 } from './serialNumber.schema'
 export { locationSchema, type LocationFormValues } from './location.schema'
+export { contactSchema, type ContactFormValues } from './contact.schema'

--- a/src/views/inventory/CustomerDetailView/ContactForm.tsx
+++ b/src/views/inventory/CustomerDetailView/ContactForm.tsx
@@ -1,18 +1,19 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import Dialog from '@/components/ui/Dialog'
 import Button from '@/components/ui/Button'
 import Input from '@/components/ui/Input'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
+import { FormItem } from '@/components/ui/Form'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import {
     useCreateCustomerContact,
     useUpdateCustomerContact,
 } from '@/hooks/useCustomerContacts'
 import { getErrorMessage } from '@/utils/getErrorMessage'
-import type {
-    CustomerContact,
-    CustomerContactInput,
-} from '@/services/CustomerContactService'
+import { contactSchema, type ContactFormValues } from '@/schemas'
+import type { CustomerContact } from '@/services/CustomerContactService'
 
 interface ContactFormProps {
     open: boolean
@@ -27,85 +28,67 @@ const ContactForm = ({
     customerId,
     contact,
 }: ContactFormProps) => {
-    const [formData, setFormData] = useState<CustomerContactInput>({
-        name: '',
-        role: '',
-        email: '',
-        phone: '',
-    })
-
     const createContact = useCreateCustomerContact()
     const updateContact = useUpdateCustomerContact()
-
     const isEdit = !!contact
 
+    const {
+        register,
+        handleSubmit,
+        reset,
+        formState: { errors, isSubmitting },
+    } = useForm<ContactFormValues>({
+        resolver: zodResolver(contactSchema),
+        defaultValues: { name: '', role: '', email: '', phone: '' },
+    })
+
     useEffect(() => {
-        if (contact) {
-            setFormData({
-                name: contact.name,
-                role: contact.role || '',
-                email: contact.email || '',
-                phone: contact.phone || '',
-            })
-        } else {
-            setFormData({
-                name: '',
-                role: '',
-                email: '',
-                phone: '',
-            })
+        if (open) {
+            reset(
+                contact
+                    ? {
+                          name: contact.name,
+                          role: contact.role ?? '',
+                          email: contact.email ?? '',
+                          phone: contact.phone ?? '',
+                      }
+                    : { name: '', role: '', email: '', phone: '' }
+            )
         }
-    }, [contact, open])
+    }, [contact, open, reset])
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
+    const handleClose = () => {
+        if (!isSubmitting) {
+            reset()
+            onClose()
+        }
+    }
 
+    const onSubmit = async (values: ContactFormValues) => {
         try {
             if (isEdit && contact) {
                 await updateContact.mutateAsync({
                     id: contact.id,
-                    contact: formData,
+                    contact: values,
                 })
             } else {
-                await createContact.mutateAsync({
-                    customerId,
-                    contact: formData,
-                })
+                await createContact.mutateAsync({ customerId, contact: values })
             }
-
             toast.push(
                 <Notification
                     title={isEdit ? 'Contacto actualizado' : 'Contacto creado'}
                     type="success"
-                >
-                    {isEdit
-                        ? 'El contacto se actualizó correctamente'
-                        : 'El contacto se creó correctamente'}
-                </Notification>,
+                />,
                 { placement: 'top-center' }
             )
-
             onClose()
         } catch (error: unknown) {
-            const errorMessage = getErrorMessage(
-                error,
-                'Error al guardar el contacto'
-            )
-
             toast.push(
                 <Notification title="Error" type="danger">
-                    {errorMessage}
+                    {getErrorMessage(error, 'Error al guardar el contacto')}
                 </Notification>,
                 { placement: 'top-center' }
             )
-
-            console.error('Error saving contact:', error)
-        }
-    }
-
-    const handleClose = () => {
-        if (!createContact.isPending && !updateContact.isPending) {
-            onClose()
         }
     }
 
@@ -119,92 +102,58 @@ const ContactForm = ({
                 <h5 className="mb-4">
                     {isEdit ? 'Editar Contacto' : 'Nuevo Contacto'}
                 </h5>
-
-                <form className="flex-1" onSubmit={handleSubmit}>
+                <form className="flex-1" onSubmit={handleSubmit(onSubmit)}>
                     <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        {/* Name */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Nombre <span className="text-red-500">*</span>
-                            </label>
+                        <FormItem
+                            asterisk
+                            label="Nombre"
+                            invalid={!!errors.name}
+                            errorMessage={errors.name?.message}
+                        >
                             <Input
-                                required
-                                type="text"
                                 placeholder="Nombre del contacto"
-                                value={formData.name}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        name: e.target.value,
-                                    })
-                                }
+                                invalid={!!errors.name}
+                                {...register('name')}
                             />
-                        </div>
-
-                        {/* Role */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Cargo
-                            </label>
+                        </FormItem>
+                        <FormItem
+                            label="Cargo"
+                            invalid={!!errors.role}
+                            errorMessage={errors.role?.message}
+                        >
                             <Input
-                                type="text"
                                 placeholder="Ej: Gerente de Compras"
-                                value={formData.role}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        role: e.target.value,
-                                    })
-                                }
+                                {...register('role')}
                             />
-                        </div>
-
-                        {/* Email */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Email
-                            </label>
+                        </FormItem>
+                        <FormItem
+                            label="Email"
+                            invalid={!!errors.email}
+                            errorMessage={errors.email?.message}
+                        >
                             <Input
                                 type="email"
                                 placeholder="email@ejemplo.com"
-                                value={formData.email}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        email: e.target.value,
-                                    })
-                                }
+                                invalid={!!errors.email}
+                                {...register('email')}
                             />
-                        </div>
-
-                        {/* Phone */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Teléfono
-                            </label>
+                        </FormItem>
+                        <FormItem
+                            label="Teléfono"
+                            invalid={!!errors.phone}
+                            errorMessage={errors.phone?.message}
+                        >
                             <Input
-                                type="text"
                                 placeholder="0987654321"
-                                value={formData.phone}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        phone: e.target.value,
-                                    })
-                                }
+                                {...register('phone')}
                             />
-                        </div>
+                        </FormItem>
                     </div>
-
-                    {/* Buttons */}
                     <div className="flex justify-end gap-2 mt-6">
                         <Button
                             type="button"
                             variant="plain"
-                            disabled={
-                                createContact.isPending ||
-                                updateContact.isPending
-                            }
+                            disabled={isSubmitting}
                             onClick={handleClose}
                         >
                             Cancelar
@@ -212,10 +161,7 @@ const ContactForm = ({
                         <Button
                             type="submit"
                             variant="solid"
-                            loading={
-                                createContact.isPending ||
-                                updateContact.isPending
-                            }
+                            loading={isSubmitting}
                         >
                             {isEdit ? 'Actualizar' : 'Crear'}
                         </Button>

--- a/src/views/inventory/SupplierDetailView/ContactForm.tsx
+++ b/src/views/inventory/SupplierDetailView/ContactForm.tsx
@@ -1,18 +1,19 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import Dialog from '@/components/ui/Dialog'
 import Button from '@/components/ui/Button'
 import Input from '@/components/ui/Input'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
+import { FormItem } from '@/components/ui/Form'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import {
     useCreateSupplierContact,
     useUpdateSupplierContact,
 } from '@/hooks/useSupplierContacts'
 import { getErrorMessage } from '@/utils/getErrorMessage'
-import type {
-    SupplierContact,
-    SupplierContactInput,
-} from '@/services/SupplierContactService'
+import { contactSchema, type ContactFormValues } from '@/schemas'
+import type { SupplierContact } from '@/services/SupplierContactService'
 
 interface ContactFormProps {
     open: boolean
@@ -27,85 +28,67 @@ const ContactForm = ({
     supplierId,
     contact,
 }: ContactFormProps) => {
-    const [formData, setFormData] = useState<SupplierContactInput>({
-        name: '',
-        role: '',
-        email: '',
-        phone: '',
-    })
-
     const createContact = useCreateSupplierContact()
     const updateContact = useUpdateSupplierContact()
-
     const isEdit = !!contact
 
+    const {
+        register,
+        handleSubmit,
+        reset,
+        formState: { errors, isSubmitting },
+    } = useForm<ContactFormValues>({
+        resolver: zodResolver(contactSchema),
+        defaultValues: { name: '', role: '', email: '', phone: '' },
+    })
+
     useEffect(() => {
-        if (contact) {
-            setFormData({
-                name: contact.name,
-                role: contact.role || '',
-                email: contact.email || '',
-                phone: contact.phone || '',
-            })
-        } else {
-            setFormData({
-                name: '',
-                role: '',
-                email: '',
-                phone: '',
-            })
+        if (open) {
+            reset(
+                contact
+                    ? {
+                          name: contact.name,
+                          role: contact.role ?? '',
+                          email: contact.email ?? '',
+                          phone: contact.phone ?? '',
+                      }
+                    : { name: '', role: '', email: '', phone: '' }
+            )
         }
-    }, [contact, open])
+    }, [contact, open, reset])
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
+    const handleClose = () => {
+        if (!isSubmitting) {
+            reset()
+            onClose()
+        }
+    }
 
+    const onSubmit = async (values: ContactFormValues) => {
         try {
             if (isEdit && contact) {
                 await updateContact.mutateAsync({
                     id: contact.id,
-                    contact: formData,
+                    contact: values,
                 })
             } else {
-                await createContact.mutateAsync({
-                    supplierId,
-                    contact: formData,
-                })
+                await createContact.mutateAsync({ supplierId, contact: values })
             }
-
             toast.push(
                 <Notification
                     title={isEdit ? 'Contacto actualizado' : 'Contacto creado'}
                     type="success"
-                >
-                    {isEdit
-                        ? 'El contacto se actualizó correctamente'
-                        : 'El contacto se creó correctamente'}
-                </Notification>,
+                />,
                 { placement: 'top-center' }
             )
-
             onClose()
         } catch (error: unknown) {
-            const errorMessage = getErrorMessage(
-                error,
-                'Error al guardar el contacto'
-            )
-
             toast.push(
                 <Notification title="Error" type="danger">
-                    {errorMessage}
+                    {getErrorMessage(error, 'Error al guardar el contacto')}
                 </Notification>,
                 { placement: 'top-center' }
             )
-
-            console.error('Error saving contact:', error)
-        }
-    }
-
-    const handleClose = () => {
-        if (!createContact.isPending && !updateContact.isPending) {
-            onClose()
         }
     }
 
@@ -119,92 +102,58 @@ const ContactForm = ({
                 <h5 className="mb-4">
                     {isEdit ? 'Editar Contacto' : 'Nuevo Contacto'}
                 </h5>
-
-                <form className="flex-1" onSubmit={handleSubmit}>
+                <form className="flex-1" onSubmit={handleSubmit(onSubmit)}>
                     <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        {/* Name */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Nombre <span className="text-red-500">*</span>
-                            </label>
+                        <FormItem
+                            asterisk
+                            label="Nombre"
+                            invalid={!!errors.name}
+                            errorMessage={errors.name?.message}
+                        >
                             <Input
-                                required
-                                type="text"
                                 placeholder="Nombre del contacto"
-                                value={formData.name}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        name: e.target.value,
-                                    })
-                                }
+                                invalid={!!errors.name}
+                                {...register('name')}
                             />
-                        </div>
-
-                        {/* Role */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Cargo
-                            </label>
+                        </FormItem>
+                        <FormItem
+                            label="Cargo"
+                            invalid={!!errors.role}
+                            errorMessage={errors.role?.message}
+                        >
                             <Input
-                                type="text"
                                 placeholder="Ej: Gerente de Ventas"
-                                value={formData.role}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        role: e.target.value,
-                                    })
-                                }
+                                {...register('role')}
                             />
-                        </div>
-
-                        {/* Email */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Email
-                            </label>
+                        </FormItem>
+                        <FormItem
+                            label="Email"
+                            invalid={!!errors.email}
+                            errorMessage={errors.email?.message}
+                        >
                             <Input
                                 type="email"
                                 placeholder="email@ejemplo.com"
-                                value={formData.email}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        email: e.target.value,
-                                    })
-                                }
+                                invalid={!!errors.email}
+                                {...register('email')}
                             />
-                        </div>
-
-                        {/* Phone */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Teléfono
-                            </label>
+                        </FormItem>
+                        <FormItem
+                            label="Teléfono"
+                            invalid={!!errors.phone}
+                            errorMessage={errors.phone?.message}
+                        >
                             <Input
-                                type="text"
                                 placeholder="0987654321"
-                                value={formData.phone}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        phone: e.target.value,
-                                    })
-                                }
+                                {...register('phone')}
                             />
-                        </div>
+                        </FormItem>
                     </div>
-
-                    {/* Buttons */}
                     <div className="flex justify-end gap-2 mt-6">
                         <Button
                             type="button"
                             variant="plain"
-                            disabled={
-                                createContact.isPending ||
-                                updateContact.isPending
-                            }
+                            disabled={isSubmitting}
                             onClick={handleClose}
                         >
                             Cancelar
@@ -212,10 +161,7 @@ const ContactForm = ({
                         <Button
                             type="submit"
                             variant="solid"
-                            loading={
-                                createContact.isPending ||
-                                updateContact.isPending
-                            }
+                            loading={isSubmitting}
                         >
                             {isEdit ? 'Actualizar' : 'Crear'}
                         </Button>


### PR DESCRIPTION
## Descripción

  - Add contact.schema.ts with contactSchema (name required, optionalEmail, role/phone optional); shared between both domains
  - Replace useState + manual useEffect sync with useForm + zodResolver in CustomerDetailView/ContactForm and SupplierDetailView/ContactForm
  - Replace raw <div>/<label> with <FormItem> for inline field-level validation; remove toast-based validation errors
  - Re-export contactSchema / ContactFormValues from schemas/index.ts

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
