### PR TITLE
feat(forms): migrate SupplierProductForm and PurchaseOrderItemForm to RHF+Zod

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -21,3 +21,13 @@ export {
 } from './serialNumber.schema'
 export { locationSchema, type LocationFormValues } from './location.schema'
 export { contactSchema, type ContactFormValues } from './contact.schema'
+export {
+    supplierProductSchema,
+    type SupplierProductFormValues,
+} from './supplierProduct.schema'
+export {
+    purchaseOrderItemCreateSchema,
+    purchaseOrderItemUpdateSchema,
+    type PurchaseOrderItemCreateFormValues,
+    type PurchaseOrderItemUpdateFormValues,
+} from './purchaseOrderItem.schema'

--- a/src/schemas/purchaseOrderItem.schema.ts
+++ b/src/schemas/purchaseOrderItem.schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+export const purchaseOrderItemCreateSchema = z.object({
+    productId: z
+        .number({ error: 'Debe seleccionar un producto' })
+        .int()
+        .min(1, 'Debe seleccionar un producto'),
+    quantityOrdered: z.number().int().min(1),
+    unitCost: z.number().min(0),
+})
+
+export const purchaseOrderItemUpdateSchema = z.object({
+    quantityOrdered: z.number().int().min(1),
+    unitCost: z.number().min(0),
+})
+
+export type PurchaseOrderItemCreateFormValues = z.infer<
+    typeof purchaseOrderItemCreateSchema
+>
+export type PurchaseOrderItemUpdateFormValues = z.infer<
+    typeof purchaseOrderItemUpdateSchema
+>

--- a/src/schemas/supplierProduct.schema.ts
+++ b/src/schemas/supplierProduct.schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const supplierProductSchema = z.object({
+    productId: z
+        .number({ error: 'Debe seleccionar un producto' })
+        .int()
+        .min(1, 'Debe seleccionar un producto'),
+    purchasePrice: z.number().min(0),
+    supplierSku: z.string().optional(),
+    minOrderQuantity: z.number().int().min(1).optional(),
+    leadTimeDays: z.number().int().min(0).optional(),
+    isPreferred: z.boolean().optional(),
+})
+
+export type SupplierProductFormValues = z.infer<typeof supplierProductSchema>

--- a/src/views/inventory/SupplierDetailView/SupplierProductForm.tsx
+++ b/src/views/inventory/SupplierDetailView/SupplierProductForm.tsx
@@ -1,17 +1,27 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import Dialog from '@/components/ui/Dialog'
 import Button from '@/components/ui/Button'
 import Input from '@/components/ui/Input'
-import Select from '@/components/ui/Select'
-import Switcher from '@/components/ui/Switcher'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
+import { FormItem } from '@/components/ui/Form'
+import { makeNumberRegister } from '@/components/ui/Form/utils'
+import {
+    ControlledSelect,
+    ControlledSwitcher,
+} from '@/components/ui/Form/controlled'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import {
     useCreateSupplierProduct,
     useUpdateSupplierProduct,
 } from '@/hooks/useSupplierProducts'
 import { useProducts } from '@/hooks/useProducts'
 import { getErrorMessage } from '@/utils/getErrorMessage'
+import {
+    supplierProductSchema,
+    type SupplierProductFormValues,
+} from '@/schemas'
 import type {
     SupplierProduct,
     SupplierProductInput,
@@ -30,101 +40,103 @@ const SupplierProductForm = ({
     supplierId,
     supplierProduct,
 }: SupplierProductFormProps) => {
-    const [formData, setFormData] = useState<SupplierProductInput>({
-        productId: 0,
-        purchasePrice: 0,
-        supplierSku: '',
-        minOrderQuantity: undefined,
-        leadTimeDays: undefined,
-        isPreferred: false,
-    })
-
     const createSupplierProduct = useCreateSupplierProduct()
     const updateSupplierProduct = useUpdateSupplierProduct()
     const { data: productsData } = useProducts()
     const products = productsData?.items ?? []
-
     const isEdit = !!supplierProduct
 
+    const {
+        register,
+        handleSubmit,
+        control,
+        reset,
+        formState: { errors, isSubmitting },
+    } = useForm<SupplierProductFormValues>({
+        resolver: zodResolver(supplierProductSchema),
+        defaultValues: {
+            productId: undefined,
+            purchasePrice: undefined,
+            supplierSku: '',
+            minOrderQuantity: undefined,
+            leadTimeDays: undefined,
+            isPreferred: false,
+        },
+    })
+
+    const numberRegister = makeNumberRegister(register)
+
     useEffect(() => {
-        if (supplierProduct) {
-            setFormData({
-                productId: supplierProduct.productId,
-                purchasePrice: supplierProduct.purchasePrice,
-                supplierSku: supplierProduct.supplierSku || '',
-                minOrderQuantity: supplierProduct.minOrderQuantity ?? undefined,
-                leadTimeDays: supplierProduct.leadTimeDays ?? undefined,
-                isPreferred: supplierProduct.isPreferred,
-            })
-        } else {
-            setFormData({
-                productId: 0,
-                purchasePrice: 0,
-                supplierSku: '',
-                minOrderQuantity: undefined,
-                leadTimeDays: undefined,
-                isPreferred: false,
-            })
+        if (open) {
+            reset(
+                supplierProduct
+                    ? {
+                          productId: supplierProduct.productId,
+                          purchasePrice: supplierProduct.purchasePrice,
+                          supplierSku: supplierProduct.supplierSku ?? '',
+                          minOrderQuantity:
+                              supplierProduct.minOrderQuantity ?? undefined,
+                          leadTimeDays:
+                              supplierProduct.leadTimeDays ?? undefined,
+                          isPreferred: supplierProduct.isPreferred,
+                      }
+                    : {
+                          productId: undefined,
+                          purchasePrice: undefined,
+                          supplierSku: '',
+                          minOrderQuantity: undefined,
+                          leadTimeDays: undefined,
+                          isPreferred: false,
+                      }
+            )
         }
-    }, [supplierProduct, open])
+    }, [supplierProduct, open, reset])
+
+    const handleClose = () => {
+        if (!isSubmitting) {
+            reset()
+            onClose()
+        }
+    }
 
     const productOptions = products.map((p) => ({
         value: p.id,
         label: `${p.name} (${p.sku})`,
     }))
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-
+    const onSubmit = async (values: SupplierProductFormValues) => {
         try {
             if (isEdit && supplierProduct) {
                 await updateSupplierProduct.mutateAsync({
                     id: supplierProduct.id,
-                    product: formData,
+                    product: values as SupplierProductInput,
                 })
             } else {
                 await createSupplierProduct.mutateAsync({
                     supplierId,
-                    product: formData,
+                    product: values as SupplierProductInput,
                 })
             }
-
             toast.push(
                 <Notification
                     title={
                         isEdit ? 'Producto actualizado' : 'Producto agregado'
                     }
                     type="success"
-                >
-                    {isEdit
-                        ? 'El producto se actualizó correctamente'
-                        : 'El producto se agregó correctamente'}
-                </Notification>,
+                />,
                 { placement: 'top-center' }
             )
-
             onClose()
         } catch (error: unknown) {
-            const errorMessage = getErrorMessage(
-                error,
-                'Error al guardar el producto del proveedor'
-            )
-
             toast.push(
                 <Notification title="Error" type="danger">
-                    {errorMessage}
+                    {getErrorMessage(
+                        error,
+                        'Error al guardar el producto del proveedor'
+                    )}
                 </Notification>,
                 { placement: 'top-center' }
             )
-        }
-    }
-
-    const handleClose = () => {
-        if (
-            !createSupplierProduct.isPending &&
-            !updateSupplierProduct.isPending
-        ) {
-            onClose()
         }
     }
 
@@ -140,131 +152,92 @@ const SupplierProductForm = ({
                         ? 'Editar Producto del Proveedor'
                         : 'Agregar Producto al Proveedor'}
                 </h5>
-
-                <form className="flex-1" onSubmit={handleSubmit}>
+                <form className="flex-1" onSubmit={handleSubmit(onSubmit)}>
                     <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        {/* Product */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Producto <span className="text-red-500">*</span>
-                            </label>
-                            <Select
+                        <FormItem
+                            asterisk
+                            label="Producto"
+                            invalid={!!errors.productId}
+                            errorMessage={errors.productId?.message}
+                        >
+                            <ControlledSelect
+                                name="productId"
+                                control={control}
                                 options={productOptions}
-                                value={
-                                    productOptions.find(
-                                        (p) => p.value === formData.productId
-                                    ) || null
-                                }
                                 placeholder="Seleccionar producto..."
-                                isDisabled={isEdit}
-                                onChange={(option) =>
-                                    setFormData({
-                                        ...formData,
-                                        productId:
-                                            (
-                                                option as {
-                                                    value: number
-                                                    label: string
-                                                }
-                                            )?.value || 0,
-                                    })
-                                }
+                                isDisabled={isEdit || isSubmitting}
                             />
-                        </div>
+                        </FormItem>
 
-                        {/* Purchase Price */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Precio de Compra{' '}
-                                <span className="text-red-500">*</span>
-                            </label>
+                        <FormItem
+                            asterisk
+                            label="Precio de Compra"
+                            invalid={!!errors.purchasePrice}
+                            errorMessage={errors.purchasePrice?.message}
+                        >
                             <Input
-                                required
                                 type="number"
                                 step="0.01"
-                                min="0"
                                 placeholder="0.00"
-                                value={formData.purchasePrice || ''}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        purchasePrice:
-                                            parseFloat(e.target.value) || 0,
-                                    })
-                                }
+                                disabled={isSubmitting}
+                                invalid={!!errors.purchasePrice}
+                                {...numberRegister('purchasePrice', {
+                                    emptyValue: 0,
+                                })}
                             />
-                        </div>
+                        </FormItem>
 
-                        {/* Supplier SKU */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                SKU del Proveedor
-                            </label>
+                        <FormItem
+                            label="SKU del Proveedor"
+                            invalid={!!errors.supplierSku}
+                            errorMessage={errors.supplierSku?.message}
+                        >
                             <Input
                                 type="text"
                                 placeholder="Código del proveedor"
-                                value={formData.supplierSku}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        supplierSku: e.target.value,
-                                    })
-                                }
+                                disabled={isSubmitting}
+                                {...register('supplierSku')}
                             />
-                        </div>
+                        </FormItem>
 
-                        {/* Min Order Quantity & Lead Time */}
                         <div className="grid grid-cols-2 gap-4">
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Cantidad Mín. de Pedido
-                                </label>
+                            <FormItem
+                                label="Cantidad Mín. de Pedido"
+                                invalid={!!errors.minOrderQuantity}
+                                errorMessage={errors.minOrderQuantity?.message}
+                            >
                                 <Input
                                     type="number"
-                                    min="1"
                                     placeholder="1"
-                                    value={formData.minOrderQuantity ?? ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            minOrderQuantity: e.target.value
-                                                ? parseInt(e.target.value)
-                                                : undefined,
-                                        })
-                                    }
+                                    disabled={isSubmitting}
+                                    invalid={!!errors.minOrderQuantity}
+                                    {...numberRegister('minOrderQuantity', {
+                                        integer: true,
+                                    })}
                                 />
-                            </div>
-                            <div>
-                                <label className="block text-sm font-medium mb-2">
-                                    Tiempo de Entrega (días)
-                                </label>
+                            </FormItem>
+
+                            <FormItem
+                                label="Tiempo de Entrega (días)"
+                                invalid={!!errors.leadTimeDays}
+                                errorMessage={errors.leadTimeDays?.message}
+                            >
                                 <Input
                                     type="number"
-                                    min="0"
                                     placeholder="0"
-                                    value={formData.leadTimeDays ?? ''}
-                                    onChange={(e) =>
-                                        setFormData({
-                                            ...formData,
-                                            leadTimeDays: e.target.value
-                                                ? parseInt(e.target.value)
-                                                : undefined,
-                                        })
-                                    }
+                                    disabled={isSubmitting}
+                                    invalid={!!errors.leadTimeDays}
+                                    {...numberRegister('leadTimeDays', {
+                                        integer: true,
+                                    })}
                                 />
-                            </div>
+                            </FormItem>
                         </div>
 
-                        {/* Is Preferred */}
                         <div className="flex items-center gap-3">
-                            <Switcher
-                                checked={formData.isPreferred}
-                                onChange={(checked) =>
-                                    setFormData({
-                                        ...formData,
-                                        isPreferred: !checked,
-                                    })
-                                }
+                            <ControlledSwitcher
+                                name="isPreferred"
+                                control={control}
                             />
                             <label className="text-sm font-medium">
                                 Proveedor preferido para este producto
@@ -272,15 +245,11 @@ const SupplierProductForm = ({
                         </div>
                     </div>
 
-                    {/* Buttons */}
                     <div className="flex justify-end gap-2 mt-6">
                         <Button
                             type="button"
                             variant="plain"
-                            disabled={
-                                createSupplierProduct.isPending ||
-                                updateSupplierProduct.isPending
-                            }
+                            disabled={isSubmitting}
                             onClick={handleClose}
                         >
                             Cancelar
@@ -288,10 +257,7 @@ const SupplierProductForm = ({
                         <Button
                             type="submit"
                             variant="solid"
-                            loading={
-                                createSupplierProduct.isPending ||
-                                updateSupplierProduct.isPending
-                            }
+                            loading={isSubmitting}
                         >
                             {isEdit ? 'Actualizar' : 'Agregar'}
                         </Button>

--- a/src/views/purchases/PurchaseOrderDetailView/PurchaseOrderItemForm.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/PurchaseOrderItemForm.tsx
@@ -1,138 +1,113 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import Dialog from '@/components/ui/Dialog'
 import Input from '@/components/ui/Input'
 import Button from '@/components/ui/Button'
-import Select from '@/components/ui/Select'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
+import { FormItem } from '@/components/ui/Form'
+import { makeNumberRegister } from '@/components/ui/Form/utils'
+import { ControlledSelect } from '@/components/ui/Form/controlled'
+import { useForm, useWatch } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import {
     useAddPurchaseOrderItem,
     useUpdatePurchaseOrderItem,
 } from '@/hooks/usePurchaseOrders'
 import { useProducts } from '@/hooks/useProducts'
 import { getErrorMessage } from '@/utils/getErrorMessage'
-import type {
-    PurchaseOrderItem,
-    PurchaseOrderItemInput,
-    PurchaseOrderItemUpdateInput,
-} from '@/services/PurchaseOrderService'
+import {
+    purchaseOrderItemCreateSchema,
+    purchaseOrderItemUpdateSchema,
+    type PurchaseOrderItemCreateFormValues,
+    type PurchaseOrderItemUpdateFormValues,
+} from '@/schemas'
+import type { PurchaseOrderItem } from '@/services/PurchaseOrderService'
 
-interface PurchaseOrderItemFormProps {
+const formatCurrency = (value: number) =>
+    new Intl.NumberFormat('es-EC', {
+        style: 'currency',
+        currency: 'USD',
+    }).format(value)
+
+// ─── Create ───────────────────────────────────────────────────────────────────
+
+interface CreateFormProps {
     open: boolean
     onClose: () => void
     orderId: number
-    item: PurchaseOrderItem | null
 }
 
-const PurchaseOrderItemForm = ({
+const PurchaseOrderItemCreateForm = ({
     open,
     onClose,
     orderId,
-    item,
-}: PurchaseOrderItemFormProps) => {
-    const [formData, setFormData] = useState<PurchaseOrderItemInput>({
-        purchaseOrderId: orderId,
-        productId: 0,
-        quantityOrdered: 1,
-        unitCost: 0,
-    })
-
-    const [editData, setEditData] = useState<PurchaseOrderItemUpdateInput>({
-        quantityOrdered: 1,
-        unitCost: 0,
-    })
-
+}: CreateFormProps) => {
     const addItem = useAddPurchaseOrderItem()
-    const updateItem = useUpdatePurchaseOrderItem()
-
     const { data: productsData } = useProducts()
     const products = productsData?.items ?? []
 
-    const isEdit = !!item
+    const {
+        register,
+        handleSubmit,
+        control,
+        reset,
+        formState: { errors, isSubmitting },
+    } = useForm<PurchaseOrderItemCreateFormValues>({
+        resolver: zodResolver(purchaseOrderItemCreateSchema),
+        defaultValues: {
+            productId: undefined,
+            quantityOrdered: 1,
+            unitCost: 0,
+        },
+    })
 
-    const productOptions = products.map((p) => ({
-        value: p.id.toString(),
-        label: `${p.name} (${p.sku})`,
-    }))
+    const numberRegister = makeNumberRegister(register)
+
+    const [quantityOrdered, unitCost] = useWatch({
+        control,
+        name: ['quantityOrdered', 'unitCost'],
+    })
+    const subtotal = (quantityOrdered ?? 0) * (unitCost ?? 0)
 
     useEffect(() => {
-        if (item) {
-            setEditData({
-                quantityOrdered: item.quantityOrdered,
-                unitCost: item.unitCost,
-            })
-        } else {
-            setFormData({
-                purchaseOrderId: orderId,
-                productId: 0,
+        if (open) {
+            reset({
+                productId: undefined,
                 quantityOrdered: 1,
                 unitCost: 0,
             })
         }
-    }, [item, open, orderId])
+    }, [open, orderId, reset])
 
-    const subtotal = isEdit
-        ? editData.quantityOrdered * editData.unitCost
-        : formData.quantityOrdered * formData.unitCost
+    const handleClose = () => {
+        if (!isSubmitting) onClose()
+    }
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
+    const productOptions = products.map((p) => ({
+        value: p.id,
+        label: `${p.name} (${p.sku})`,
+    }))
 
+    const onSubmit = async (values: PurchaseOrderItemCreateFormValues) => {
         try {
-            if (isEdit && item) {
-                await updateItem.mutateAsync({
-                    itemId: item.id,
-                    orderId,
-                    data: {
-                        quantityOrdered: editData.quantityOrdered,
-                        unitCost: editData.unitCost,
-                    },
-                })
-            } else {
-                await addItem.mutateAsync({
-                    purchaseOrderId: orderId,
-                    productId: formData.productId,
-                    quantityOrdered: formData.quantityOrdered,
-                    unitCost: formData.unitCost,
-                })
-            }
-
-            toast.push(
-                <Notification
-                    title={isEdit ? 'Item actualizado' : 'Item agregado'}
-                    type="success"
-                >
-                    {isEdit
-                        ? 'El item se actualizó correctamente'
-                        : 'El item se agregó correctamente'}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-
+            await addItem.mutateAsync({
+                purchaseOrderId: orderId,
+                productId: values.productId,
+                quantityOrdered: values.quantityOrdered,
+                unitCost: values.unitCost,
+            })
+            toast.push(<Notification title="Item agregado" type="success" />, {
+                placement: 'top-center',
+            })
             onClose()
         } catch (error: unknown) {
             toast.push(
                 <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al guardar el item')}
+                    {getErrorMessage(error, 'Error al agregar el item')}
                 </Notification>,
                 { placement: 'top-center' }
             )
         }
-    }
-
-    const isPending = addItem.isPending || updateItem.isPending
-
-    const handleClose = () => {
-        if (!isPending) {
-            onClose()
-        }
-    }
-
-    const formatCurrency = (value: number) => {
-        return new Intl.NumberFormat('es-EC', {
-            style: 'currency',
-            currency: 'USD',
-        }).format(value)
     }
 
     return (
@@ -143,133 +118,60 @@ const PurchaseOrderItemForm = ({
             onRequestClose={handleClose}
         >
             <div className="flex flex-col h-full justify-between">
-                <h5 className="mb-4">
-                    {isEdit ? 'Editar Item' : 'Agregar Item'}
-                </h5>
-
-                <form className="flex-1" onSubmit={handleSubmit}>
+                <h5 className="mb-4">Agregar Item</h5>
+                <form className="flex-1" onSubmit={handleSubmit(onSubmit)}>
                     <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        {isEdit ? (
-                            <>
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Cantidad{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Input
-                                        required
-                                        type="number"
-                                        min={1}
-                                        placeholder="1"
-                                        value={editData.quantityOrdered}
-                                        onChange={(e) =>
-                                            setEditData({
-                                                ...editData,
-                                                quantityOrdered:
-                                                    parseInt(e.target.value) ||
-                                                    1,
-                                            })
-                                        }
-                                    />
-                                </div>
+                        <FormItem
+                            asterisk
+                            label="Producto"
+                            invalid={!!errors.productId}
+                            errorMessage={errors.productId?.message}
+                        >
+                            <ControlledSelect
+                                name="productId"
+                                control={control}
+                                options={productOptions}
+                                placeholder="Seleccionar producto"
+                                isDisabled={isSubmitting}
+                            />
+                        </FormItem>
 
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Costo Unitario{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Input
-                                        required
-                                        type="number"
-                                        min={0}
-                                        step={0.01}
-                                        placeholder="0.00"
-                                        value={editData.unitCost}
-                                        onChange={(e) =>
-                                            setEditData({
-                                                ...editData,
-                                                unitCost:
-                                                    parseFloat(
-                                                        e.target.value
-                                                    ) || 0,
-                                            })
-                                        }
-                                    />
-                                </div>
-                            </>
-                        ) : (
-                            <>
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Producto{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Select
-                                        placeholder="Seleccionar producto"
-                                        options={productOptions}
-                                        value={productOptions.find(
-                                            (o) =>
-                                                o.value ===
-                                                formData.productId.toString()
-                                        )}
-                                        onChange={(option) =>
-                                            setFormData({
-                                                ...formData,
-                                                productId: option
-                                                    ? parseInt(option.value)
-                                                    : 0,
-                                            })
-                                        }
-                                    />
-                                </div>
+                        <FormItem
+                            asterisk
+                            label="Cantidad"
+                            invalid={!!errors.quantityOrdered}
+                            errorMessage={errors.quantityOrdered?.message}
+                        >
+                            <Input
+                                type="number"
+                                min={1}
+                                placeholder="1"
+                                disabled={isSubmitting}
+                                invalid={!!errors.quantityOrdered}
+                                {...numberRegister('quantityOrdered', {
+                                    integer: true,
+                                    emptyValue: 1,
+                                })}
+                            />
+                        </FormItem>
 
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Cantidad{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Input
-                                        required
-                                        type="number"
-                                        min={1}
-                                        placeholder="1"
-                                        value={formData.quantityOrdered || ''}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                quantityOrdered:
-                                                    parseInt(e.target.value) ||
-                                                    1,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Costo Unitario{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Input
-                                        required
-                                        type="number"
-                                        min={0}
-                                        step={0.01}
-                                        placeholder="0.00"
-                                        value={formData.unitCost || ''}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                unitCost:
-                                                    parseFloat(
-                                                        e.target.value
-                                                    ) || 0,
-                                            })
-                                        }
-                                    />
-                                </div>
-                            </>
-                        )}
+                        <FormItem
+                            asterisk
+                            label="Costo Unitario"
+                            invalid={!!errors.unitCost}
+                            errorMessage={errors.unitCost?.message}
+                        >
+                            <Input
+                                type="number"
+                                step="0.01"
+                                placeholder="0.00"
+                                disabled={isSubmitting}
+                                invalid={!!errors.unitCost}
+                                {...numberRegister('unitCost', {
+                                    emptyValue: 0,
+                                })}
+                            />
+                        </FormItem>
 
                         <div className="p-3 bg-gray-50 dark:bg-gray-700 rounded-lg">
                             <p className="text-sm text-gray-500">Subtotal</p>
@@ -283,7 +185,7 @@ const PurchaseOrderItemForm = ({
                         <Button
                             type="button"
                             variant="plain"
-                            disabled={isPending}
+                            disabled={isSubmitting}
                             onClick={handleClose}
                         >
                             Cancelar
@@ -291,9 +193,9 @@ const PurchaseOrderItemForm = ({
                         <Button
                             type="submit"
                             variant="solid"
-                            loading={isPending}
+                            loading={isSubmitting}
                         >
-                            {isEdit ? 'Actualizar' : 'Agregar'}
+                            Agregar
                         </Button>
                     </div>
                 </form>
@@ -301,5 +203,188 @@ const PurchaseOrderItemForm = ({
         </Dialog>
     )
 }
+
+// ─── Update ───────────────────────────────────────────────────────────────────
+
+interface UpdateFormProps {
+    open: boolean
+    onClose: () => void
+    orderId: number
+    item: PurchaseOrderItem
+}
+
+const PurchaseOrderItemUpdateForm = ({
+    open,
+    onClose,
+    orderId,
+    item,
+}: UpdateFormProps) => {
+    const updateItem = useUpdatePurchaseOrderItem()
+
+    const {
+        register,
+        handleSubmit,
+        control,
+        reset,
+        formState: { errors, isSubmitting },
+    } = useForm<PurchaseOrderItemUpdateFormValues>({
+        resolver: zodResolver(purchaseOrderItemUpdateSchema),
+        defaultValues: {
+            quantityOrdered: item.quantityOrdered,
+            unitCost: item.unitCost,
+        },
+    })
+
+    const numberRegister = makeNumberRegister(register)
+
+    const [quantityOrdered, unitCost] = useWatch({
+        control,
+        name: ['quantityOrdered', 'unitCost'],
+    })
+    const subtotal = (quantityOrdered ?? 0) * (unitCost ?? 0)
+
+    useEffect(() => {
+        if (open) {
+            reset({
+                quantityOrdered: item.quantityOrdered,
+                unitCost: item.unitCost,
+            })
+        }
+    }, [open, item, reset])
+
+    const handleClose = () => {
+        if (!isSubmitting) onClose()
+    }
+
+    const onSubmit = async (values: PurchaseOrderItemUpdateFormValues) => {
+        try {
+            await updateItem.mutateAsync({
+                itemId: item.id,
+                orderId,
+                data: values,
+            })
+            toast.push(
+                <Notification title="Item actualizado" type="success" />,
+                { placement: 'top-center' }
+            )
+            onClose()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al actualizar el item')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
+    }
+
+    return (
+        <Dialog
+            isOpen={open}
+            width={600}
+            onClose={handleClose}
+            onRequestClose={handleClose}
+        >
+            <div className="flex flex-col h-full justify-between">
+                <h5 className="mb-4">Editar Item</h5>
+                <form className="flex-1" onSubmit={handleSubmit(onSubmit)}>
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
+                        <FormItem
+                            asterisk
+                            label="Cantidad"
+                            invalid={!!errors.quantityOrdered}
+                            errorMessage={errors.quantityOrdered?.message}
+                        >
+                            <Input
+                                type="number"
+                                min={1}
+                                placeholder="1"
+                                disabled={isSubmitting}
+                                invalid={!!errors.quantityOrdered}
+                                {...numberRegister('quantityOrdered', {
+                                    integer: true,
+                                    emptyValue: 1,
+                                })}
+                            />
+                        </FormItem>
+
+                        <FormItem
+                            asterisk
+                            label="Costo Unitario"
+                            invalid={!!errors.unitCost}
+                            errorMessage={errors.unitCost?.message}
+                        >
+                            <Input
+                                type="number"
+                                step="0.01"
+                                placeholder="0.00"
+                                disabled={isSubmitting}
+                                invalid={!!errors.unitCost}
+                                {...numberRegister('unitCost', {
+                                    emptyValue: 0,
+                                })}
+                            />
+                        </FormItem>
+
+                        <div className="p-3 bg-gray-50 dark:bg-gray-700 rounded-lg">
+                            <p className="text-sm text-gray-500">Subtotal</p>
+                            <p className="text-lg font-semibold">
+                                {formatCurrency(subtotal)}
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="flex justify-end gap-2 mt-6">
+                        <Button
+                            type="button"
+                            variant="plain"
+                            disabled={isSubmitting}
+                            onClick={handleClose}
+                        >
+                            Cancelar
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            loading={isSubmitting}
+                        >
+                            Actualizar
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </Dialog>
+    )
+}
+
+// ─── Wrapper ──────────────────────────────────────────────────────────────────
+
+interface PurchaseOrderItemFormProps {
+    open: boolean
+    onClose: () => void
+    orderId: number
+    item: PurchaseOrderItem | null
+}
+
+const PurchaseOrderItemForm = ({
+    open,
+    onClose,
+    orderId,
+    item,
+}: PurchaseOrderItemFormProps) =>
+    item ? (
+        <PurchaseOrderItemUpdateForm
+            open={open}
+            orderId={orderId}
+            item={item}
+            onClose={onClose}
+        />
+    ) : (
+        <PurchaseOrderItemCreateForm
+            open={open}
+            orderId={orderId}
+            onClose={onClose}
+        />
+    )
 
 export default PurchaseOrderItemForm


### PR DESCRIPTION

## Descripción

- Add supplierProduct.schema.ts and purchaseOrderItem.schema.ts (create + update)
  - SupplierProductForm: replace useState/useEffect with useForm+zodResolver, fix bug by migrating Switcher → ControlledSwitcher, productId uses ControlledSelect with isDisabled in edit mode
  - PurchaseOrderItemForm: split into PurchaseOrderItemCreateForm and PurchaseOrderItemUpdateForm sub-components with a thin wrapper; subtotal derived from useWatch instead of duplicated state


## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
