### PR TITLE
feat(forms): migrate TransferItemForm and AdjustmentItemForm to RHF+Zod

### DIFF
--- a/src/schemas/adjustmentItem.schema.ts
+++ b/src/schemas/adjustmentItem.schema.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+export const adjustmentItemCreateSchema = z.object({
+    productId: z
+        .number({ error: 'Debe seleccionar un producto' })
+        .int()
+        .min(1, 'Debe seleccionar un producto'),
+    locationId: z
+        .number({ error: 'Debe seleccionar una ubicación' })
+        .int()
+        .min(1, 'Debe seleccionar una ubicación'),
+    actualQuantity: z.number().int().min(0),
+    lotId: z.number().int().positive().nullable().optional(),
+    notes: z.string().optional(),
+})
+
+export const adjustmentItemUpdateSchema = z.object({
+    actualQuantity: z.number().int().min(0),
+    notes: z.string().optional(),
+})
+
+export type AdjustmentItemCreateFormValues = z.infer<
+    typeof adjustmentItemCreateSchema
+>
+export type AdjustmentItemUpdateFormValues = z.infer<
+    typeof adjustmentItemUpdateSchema
+>

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -31,3 +31,15 @@ export {
     type PurchaseOrderItemCreateFormValues,
     type PurchaseOrderItemUpdateFormValues,
 } from './purchaseOrderItem.schema'
+export {
+    transferItemCreateSchema,
+    transferItemUpdateSchema,
+    type TransferItemCreateFormValues,
+    type TransferItemUpdateFormValues,
+} from './transferItem.schema'
+export {
+    adjustmentItemCreateSchema,
+    adjustmentItemUpdateSchema,
+    type AdjustmentItemCreateFormValues,
+    type AdjustmentItemUpdateFormValues,
+} from './adjustmentItem.schema'

--- a/src/schemas/transferItem.schema.ts
+++ b/src/schemas/transferItem.schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+export const transferItemCreateSchema = z.object({
+    productId: z
+        .number({ error: 'Debe seleccionar un producto' })
+        .int()
+        .min(1, 'Debe seleccionar un producto'),
+    quantity: z.number().int().min(1),
+    lotId: z.number().int().positive().nullable().optional(),
+    notes: z.string().optional(),
+})
+
+export const transferItemUpdateSchema = z.object({
+    quantity: z.number().int().min(1),
+    notes: z.string().optional(),
+})
+
+export type TransferItemCreateFormValues = z.infer<
+    typeof transferItemCreateSchema
+>
+export type TransferItemUpdateFormValues = z.infer<
+    typeof transferItemUpdateSchema
+>

--- a/src/views/inventory/AdjustmentDetailView/AdjustmentItemForm.tsx
+++ b/src/views/inventory/AdjustmentDetailView/AdjustmentItemForm.tsx
@@ -1,10 +1,14 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import Dialog from '@/components/ui/Dialog'
 import Input from '@/components/ui/Input'
 import Button from '@/components/ui/Button'
-import Select from '@/components/ui/Select'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
+import { FormItem } from '@/components/ui/Form'
+import { makeNumberRegister } from '@/components/ui/Form/utils'
+import { ControlledSelect } from '@/components/ui/Form/controlled'
+import { useForm, useWatch } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import {
     useAddAdjustmentItem,
     useUpdateAdjustmentItem,
@@ -13,11 +17,376 @@ import { useProducts } from '@/hooks/useProducts'
 import { useLocations } from '@/hooks/useLocations'
 import { useLots } from '@/hooks/useLots'
 import { getErrorMessage } from '@/utils/getErrorMessage'
-import type {
-    AdjustmentItem,
-    AdjustmentItemInput,
-    AdjustmentItemUpdateInput,
-} from '@/services/AdjustmentService'
+import {
+    adjustmentItemCreateSchema,
+    adjustmentItemUpdateSchema,
+    type AdjustmentItemCreateFormValues,
+    type AdjustmentItemUpdateFormValues,
+} from '@/schemas'
+import type { AdjustmentItem } from '@/services/AdjustmentService'
+
+// ─── Create ───────────────────────────────────────────────────────────────────
+
+interface CreateFormProps {
+    open: boolean
+    onClose: () => void
+    adjustmentId: number
+    warehouseId: number
+}
+
+const AdjustmentItemCreateForm = ({
+    open,
+    onClose,
+    adjustmentId,
+    warehouseId,
+}: CreateFormProps) => {
+    const addItem = useAddAdjustmentItem()
+    const { data: productsData } = useProducts()
+    const products = productsData?.items ?? []
+
+    const { data: locationsData } = useLocations({ warehouseId, limit: 100 })
+    const locations = locationsData?.items ?? []
+
+    const {
+        register,
+        handleSubmit,
+        control,
+        reset,
+        setValue,
+        formState: { errors, isSubmitting },
+    } = useForm<AdjustmentItemCreateFormValues>({
+        resolver: zodResolver(adjustmentItemCreateSchema),
+        defaultValues: {
+            productId: undefined,
+            locationId: undefined,
+            actualQuantity: 0,
+            lotId: null,
+            notes: '',
+        },
+    })
+
+    const numberRegister = makeNumberRegister(register)
+    const selectedProductId = useWatch({ control, name: 'productId' })
+
+    const { data: lotsData } = useLots(
+        selectedProductId
+            ? { productId: selectedProductId, limit: 100 }
+            : undefined
+    )
+    const lots = lotsData?.items ?? []
+
+    useEffect(() => {
+        if (open) {
+            reset({
+                productId: undefined,
+                locationId: undefined,
+                actualQuantity: 0,
+                lotId: null,
+                notes: '',
+            })
+        }
+    }, [open, adjustmentId, reset])
+
+    useEffect(() => {
+        setValue('lotId', null)
+    }, [selectedProductId, setValue])
+
+    const handleClose = () => {
+        if (!isSubmitting) onClose()
+    }
+
+    const productOptions = products.map((p) => ({
+        value: p.id,
+        label: `${p.name} (${p.sku})`,
+    }))
+
+    const locationOptions = locations.map((l) => ({
+        value: l.id,
+        label: `${l.name} (${l.code})`,
+    }))
+
+    const lotOptions: { value: number | null; label: string }[] = [
+        { value: null, label: 'Sin lote' },
+        ...lots.map((l) => ({ value: l.id, label: l.lotNumber })),
+    ]
+
+    const onSubmit = async (values: AdjustmentItemCreateFormValues) => {
+        try {
+            await addItem.mutateAsync({
+                adjustmentId,
+                data: {
+                    productId: values.productId,
+                    locationId: values.locationId,
+                    actualQuantity: values.actualQuantity,
+                    lotId: values.lotId,
+                    notes: values.notes || undefined,
+                },
+            })
+            toast.push(<Notification title="Item agregado" type="success" />, {
+                placement: 'top-center',
+            })
+            onClose()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al agregar el item')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
+    }
+
+    return (
+        <Dialog
+            isOpen={open}
+            width={600}
+            onClose={handleClose}
+            onRequestClose={handleClose}
+        >
+            <div className="flex flex-col h-full justify-between">
+                <h5 className="mb-4">Agregar Item</h5>
+                <form className="flex-1" onSubmit={handleSubmit(onSubmit)}>
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
+                        <FormItem
+                            asterisk
+                            label="Producto"
+                            invalid={!!errors.productId}
+                            errorMessage={errors.productId?.message}
+                        >
+                            <ControlledSelect
+                                name="productId"
+                                control={control}
+                                options={productOptions}
+                                placeholder="Seleccionar producto"
+                                isDisabled={isSubmitting}
+                            />
+                        </FormItem>
+
+                        <FormItem
+                            asterisk
+                            label="Ubicación"
+                            invalid={!!errors.locationId}
+                            errorMessage={errors.locationId?.message}
+                        >
+                            <ControlledSelect
+                                name="locationId"
+                                control={control}
+                                options={locationOptions}
+                                placeholder="Seleccionar ubicación"
+                                isDisabled={isSubmitting}
+                            />
+                        </FormItem>
+
+                        <FormItem
+                            asterisk
+                            label="Cantidad Actual"
+                            invalid={!!errors.actualQuantity}
+                            errorMessage={errors.actualQuantity?.message}
+                        >
+                            <Input
+                                type="number"
+                                min={0}
+                                placeholder="0"
+                                disabled={isSubmitting}
+                                invalid={!!errors.actualQuantity}
+                                {...numberRegister('actualQuantity', {
+                                    integer: true,
+                                    emptyValue: 0,
+                                })}
+                            />
+                        </FormItem>
+
+                        <FormItem
+                            label="Lote (opcional)"
+                            invalid={!!errors.lotId}
+                            errorMessage={errors.lotId?.message}
+                        >
+                            <ControlledSelect
+                                name="lotId"
+                                control={control}
+                                options={lotOptions}
+                                placeholder="Seleccionar lote"
+                                isDisabled={isSubmitting || !selectedProductId}
+                            />
+                        </FormItem>
+
+                        <FormItem
+                            label="Notas"
+                            invalid={!!errors.notes}
+                            errorMessage={errors.notes?.message}
+                        >
+                            <Input
+                                textArea
+                                placeholder="Observaciones del item"
+                                disabled={isSubmitting}
+                                invalid={!!errors.notes}
+                                {...register('notes')}
+                            />
+                        </FormItem>
+                    </div>
+
+                    <div className="flex justify-end gap-2 mt-6">
+                        <Button
+                            type="button"
+                            variant="plain"
+                            disabled={isSubmitting}
+                            onClick={handleClose}
+                        >
+                            Cancelar
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            loading={isSubmitting}
+                        >
+                            Agregar
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </Dialog>
+    )
+}
+
+// ─── Update ───────────────────────────────────────────────────────────────────
+
+interface UpdateFormProps {
+    open: boolean
+    onClose: () => void
+    adjustmentId: number
+    item: AdjustmentItem
+}
+
+const AdjustmentItemUpdateForm = ({
+    open,
+    onClose,
+    adjustmentId,
+    item,
+}: UpdateFormProps) => {
+    const updateItem = useUpdateAdjustmentItem()
+
+    const {
+        register,
+        handleSubmit,
+        reset,
+        formState: { errors, isSubmitting },
+    } = useForm<AdjustmentItemUpdateFormValues>({
+        resolver: zodResolver(adjustmentItemUpdateSchema),
+        defaultValues: {
+            actualQuantity: item.actualQuantity,
+            notes: item.notes ?? '',
+        },
+    })
+
+    const numberRegister = makeNumberRegister(register)
+
+    useEffect(() => {
+        if (open) {
+            reset({
+                actualQuantity: item.actualQuantity,
+                notes: item.notes ?? '',
+            })
+        }
+    }, [open, item, reset])
+
+    const handleClose = () => {
+        if (!isSubmitting) onClose()
+    }
+
+    const onSubmit = async (values: AdjustmentItemUpdateFormValues) => {
+        try {
+            await updateItem.mutateAsync({
+                itemId: item.id,
+                adjustmentId,
+                data: {
+                    actualQuantity: values.actualQuantity,
+                    notes: values.notes || undefined,
+                },
+            })
+            toast.push(
+                <Notification title="Item actualizado" type="success" />,
+                { placement: 'top-center' }
+            )
+            onClose()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al actualizar el item')}
+                </Notification>,
+                { placement: 'top-center' }
+            )
+        }
+    }
+
+    return (
+        <Dialog
+            isOpen={open}
+            width={600}
+            onClose={handleClose}
+            onRequestClose={handleClose}
+        >
+            <div className="flex flex-col h-full justify-between">
+                <h5 className="mb-4">Editar Item</h5>
+                <form className="flex-1" onSubmit={handleSubmit(onSubmit)}>
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
+                        <FormItem
+                            asterisk
+                            label="Cantidad Actual"
+                            invalid={!!errors.actualQuantity}
+                            errorMessage={errors.actualQuantity?.message}
+                        >
+                            <Input
+                                type="number"
+                                min={0}
+                                placeholder="0"
+                                disabled={isSubmitting}
+                                invalid={!!errors.actualQuantity}
+                                {...numberRegister('actualQuantity', {
+                                    integer: true,
+                                    emptyValue: 0,
+                                })}
+                            />
+                        </FormItem>
+
+                        <FormItem
+                            label="Notas"
+                            invalid={!!errors.notes}
+                            errorMessage={errors.notes?.message}
+                        >
+                            <Input
+                                textArea
+                                placeholder="Observaciones del item"
+                                disabled={isSubmitting}
+                                invalid={!!errors.notes}
+                                {...register('notes')}
+                            />
+                        </FormItem>
+                    </div>
+
+                    <div className="flex justify-end gap-2 mt-6">
+                        <Button
+                            type="button"
+                            variant="plain"
+                            disabled={isSubmitting}
+                            onClick={handleClose}
+                        >
+                            Cancelar
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            loading={isSubmitting}
+                        >
+                            Actualizar
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </Dialog>
+    )
+}
+
+// ─── Wrapper ──────────────────────────────────────────────────────────────────
 
 interface AdjustmentItemFormProps {
     open: boolean
@@ -33,328 +402,21 @@ const AdjustmentItemForm = ({
     adjustmentId,
     warehouseId,
     item,
-}: AdjustmentItemFormProps) => {
-    const [formData, setFormData] = useState<AdjustmentItemInput>({
-        productId: 0,
-        locationId: 0,
-        actualQuantity: 0,
-        lotId: null,
-        notes: '',
-    })
-
-    const [editData, setEditData] = useState<AdjustmentItemUpdateInput>({
-        actualQuantity: 0,
-        notes: '',
-    })
-
-    const addItem = useAddAdjustmentItem()
-    const updateItem = useUpdateAdjustmentItem()
-
-    const { data: productsData } = useProducts()
-    const products = productsData?.items ?? []
-
-    const { data: locationsData } = useLocations({
-        warehouseId,
-        limit: 100,
-    })
-    const locations = locationsData?.items ?? []
-
-    const selectedProductId = item ? item.productId : formData.productId
-    const { data: lotsData } = useLots(
-        selectedProductId
-            ? { productId: selectedProductId, limit: 100 }
-            : undefined
+}: AdjustmentItemFormProps) =>
+    item ? (
+        <AdjustmentItemUpdateForm
+            open={open}
+            adjustmentId={adjustmentId}
+            item={item}
+            onClose={onClose}
+        />
+    ) : (
+        <AdjustmentItemCreateForm
+            open={open}
+            adjustmentId={adjustmentId}
+            warehouseId={warehouseId}
+            onClose={onClose}
+        />
     )
-    const lots = lotsData?.items ?? []
-
-    const isEdit = !!item
-
-    const productOptions = products.map((p) => ({
-        value: p.id.toString(),
-        label: `${p.name} (${p.sku})`,
-    }))
-
-    const locationOptions = locations.map((l) => ({
-        value: l.id.toString(),
-        label: `${l.name} (${l.code})`,
-    }))
-
-    const lotOptions = [
-        { value: '', label: 'Sin lote' },
-        ...lots.map((l) => ({
-            value: l.id.toString(),
-            label: `${l.lotNumber}`,
-        })),
-    ]
-
-    useEffect(() => {
-        if (item) {
-            setEditData({
-                actualQuantity: item.actualQuantity,
-                notes: item.notes || '',
-            })
-        } else {
-            setFormData({
-                productId: 0,
-                locationId: 0,
-                actualQuantity: 0,
-                lotId: null,
-                notes: '',
-            })
-        }
-    }, [item, open])
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-
-        try {
-            if (isEdit && item) {
-                await updateItem.mutateAsync({
-                    itemId: item.id,
-                    adjustmentId,
-                    data: {
-                        actualQuantity: editData.actualQuantity,
-                        notes: editData.notes || undefined,
-                    },
-                })
-            } else {
-                await addItem.mutateAsync({
-                    adjustmentId,
-                    data: {
-                        productId: formData.productId,
-                        locationId: formData.locationId,
-                        actualQuantity: formData.actualQuantity,
-                        lotId: formData.lotId || undefined,
-                        notes: formData.notes || undefined,
-                    },
-                })
-            }
-
-            toast.push(
-                <Notification
-                    title={isEdit ? 'Item actualizado' : 'Item agregado'}
-                    type="success"
-                >
-                    {isEdit
-                        ? 'El item se actualizó correctamente'
-                        : 'El item se agregó correctamente'}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-
-            onClose()
-        } catch (error: unknown) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al guardar el item')}
-                </Notification>,
-                { placement: 'top-center' }
-            )
-        }
-    }
-
-    const isPending = addItem.isPending || updateItem.isPending
-
-    const handleClose = () => {
-        if (!isPending) {
-            onClose()
-        }
-    }
-
-    return (
-        <Dialog
-            isOpen={open}
-            width={600}
-            onClose={handleClose}
-            onRequestClose={handleClose}
-        >
-            <div className="flex flex-col h-full justify-between">
-                <h5 className="mb-4">
-                    {isEdit ? 'Editar Item' : 'Agregar Item'}
-                </h5>
-
-                <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        {isEdit ? (
-                            <>
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Cantidad Actual{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Input
-                                        required
-                                        type="number"
-                                        min={0}
-                                        placeholder="0"
-                                        value={editData.actualQuantity ?? ''}
-                                        onChange={(e) =>
-                                            setEditData({
-                                                ...editData,
-                                                actualQuantity:
-                                                    parseInt(e.target.value) ||
-                                                    0,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Notas
-                                    </label>
-                                    <Input
-                                        textArea
-                                        placeholder="Observaciones del item"
-                                        value={editData.notes || ''}
-                                        onChange={(e) =>
-                                            setEditData({
-                                                ...editData,
-                                                notes: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-                            </>
-                        ) : (
-                            <>
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Producto{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Select
-                                        placeholder="Seleccionar producto"
-                                        options={productOptions}
-                                        value={productOptions.find(
-                                            (o) =>
-                                                o.value ===
-                                                formData.productId.toString()
-                                        )}
-                                        onChange={(option) =>
-                                            setFormData({
-                                                ...formData,
-                                                productId: option
-                                                    ? parseInt(option.value)
-                                                    : 0,
-                                                lotId: null,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Ubicación{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Select
-                                        placeholder="Seleccionar ubicación"
-                                        options={locationOptions}
-                                        value={locationOptions.find(
-                                            (o) =>
-                                                o.value ===
-                                                formData.locationId.toString()
-                                        )}
-                                        onChange={(option) =>
-                                            setFormData({
-                                                ...formData,
-                                                locationId: option
-                                                    ? parseInt(option.value)
-                                                    : 0,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Cantidad Actual{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Input
-                                        required
-                                        type="number"
-                                        min={0}
-                                        placeholder="0"
-                                        value={formData.actualQuantity || ''}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                actualQuantity:
-                                                    parseInt(e.target.value) ||
-                                                    0,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Lote (opcional)
-                                    </label>
-                                    <Select
-                                        placeholder="Seleccionar lote"
-                                        options={lotOptions}
-                                        value={lotOptions.find(
-                                            (o) =>
-                                                o.value ===
-                                                (formData.lotId?.toString() ||
-                                                    '')
-                                        )}
-                                        onChange={(option) =>
-                                            setFormData({
-                                                ...formData,
-                                                lotId:
-                                                    option && option.value
-                                                        ? parseInt(option.value)
-                                                        : null,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Notas
-                                    </label>
-                                    <Input
-                                        textArea
-                                        placeholder="Observaciones del item"
-                                        value={formData.notes || ''}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                notes: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-                            </>
-                        )}
-                    </div>
-
-                    <div className="flex justify-end gap-2 mt-6">
-                        <Button
-                            type="button"
-                            variant="plain"
-                            disabled={isPending}
-                            onClick={handleClose}
-                        >
-                            Cancelar
-                        </Button>
-                        <Button
-                            type="submit"
-                            variant="solid"
-                            loading={isPending}
-                        >
-                            {isEdit ? 'Actualizar' : 'Agregar'}
-                        </Button>
-                    </div>
-                </form>
-            </div>
-        </Dialog>
-    )
-}
 
 export default AdjustmentItemForm

--- a/src/views/inventory/TransferDetailView/TransferItemForm.tsx
+++ b/src/views/inventory/TransferDetailView/TransferItemForm.tsx
@@ -1,19 +1,360 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import Dialog from '@/components/ui/Dialog'
 import Input from '@/components/ui/Input'
 import Button from '@/components/ui/Button'
-import Select from '@/components/ui/Select'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
+import { FormItem } from '@/components/ui/Form'
+import { makeNumberRegister } from '@/components/ui/Form/utils'
+import { ControlledSelect } from '@/components/ui/Form/controlled'
+import { useForm, useWatch } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { useAddTransferItem, useUpdateTransferItem } from '@/hooks/useTransfers'
 import { useProducts } from '@/hooks/useProducts'
 import { useLots } from '@/hooks/useLots'
 import { getErrorMessage } from '@/utils/getErrorMessage'
-import type {
-    TransferItem,
-    TransferItemInput,
-    TransferItemUpdateInput,
-} from '@/services/TransferService'
+import {
+    transferItemCreateSchema,
+    transferItemUpdateSchema,
+    type TransferItemCreateFormValues,
+    type TransferItemUpdateFormValues,
+} from '@/schemas'
+import type { TransferItem } from '@/services/TransferService'
+
+// ─── Create ───────────────────────────────────────────────────────────────────
+
+interface CreateFormProps {
+    open: boolean
+    onClose: () => void
+    transferId: number
+}
+
+const TransferItemCreateForm = ({
+    open,
+    onClose,
+    transferId,
+}: CreateFormProps) => {
+    const addItem = useAddTransferItem()
+    const { data: productsData } = useProducts()
+    const products = productsData?.items ?? []
+
+    const {
+        register,
+        handleSubmit,
+        control,
+        reset,
+        setValue,
+        formState: { errors, isSubmitting },
+    } = useForm<TransferItemCreateFormValues>({
+        resolver: zodResolver(transferItemCreateSchema),
+        defaultValues: {
+            productId: undefined,
+            quantity: 1,
+            lotId: null,
+            notes: '',
+        },
+    })
+
+    const numberRegister = makeNumberRegister(register)
+    const selectedProductId = useWatch({ control, name: 'productId' })
+
+    const { data: lotsData } = useLots(
+        selectedProductId
+            ? { productId: selectedProductId, limit: 100 }
+            : undefined
+    )
+    const lots = lotsData?.items ?? []
+
+    useEffect(() => {
+        if (open) {
+            reset({
+                productId: undefined,
+                quantity: 1,
+                lotId: null,
+                notes: '',
+            })
+        }
+    }, [open, transferId, reset])
+
+    useEffect(() => {
+        setValue('lotId', null)
+    }, [selectedProductId, setValue])
+
+    const handleClose = () => {
+        if (!isSubmitting) onClose()
+    }
+
+    const productOptions = products.map((p) => ({
+        value: p.id,
+        label: `${p.name} (${p.sku})`,
+    }))
+
+    const lotOptions: { value: number | null; label: string }[] = [
+        { value: null, label: 'Sin lote' },
+        ...lots.map((l) => ({ value: l.id, label: l.lotNumber })),
+    ]
+
+    const onSubmit = async (values: TransferItemCreateFormValues) => {
+        try {
+            await addItem.mutateAsync({
+                transferId,
+                data: {
+                    productId: values.productId,
+                    quantity: values.quantity,
+                    lotId: values.lotId,
+                    notes: values.notes || undefined,
+                },
+            })
+            toast.push(<Notification title="Item agregado" type="success" />, {
+                placement: 'top-end',
+            })
+            onClose()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al agregar el item')}
+                </Notification>,
+                { placement: 'top-end' }
+            )
+        }
+    }
+
+    return (
+        <Dialog
+            isOpen={open}
+            width={600}
+            onClose={handleClose}
+            onRequestClose={handleClose}
+        >
+            <div className="flex flex-col h-full justify-between">
+                <h5 className="mb-4">Agregar Item</h5>
+                <form className="flex-1" onSubmit={handleSubmit(onSubmit)}>
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
+                        <FormItem
+                            asterisk
+                            label="Producto"
+                            invalid={!!errors.productId}
+                            errorMessage={errors.productId?.message}
+                        >
+                            <ControlledSelect
+                                name="productId"
+                                control={control}
+                                options={productOptions}
+                                placeholder="Seleccionar producto"
+                                isDisabled={isSubmitting}
+                            />
+                        </FormItem>
+
+                        <FormItem
+                            asterisk
+                            label="Cantidad"
+                            invalid={!!errors.quantity}
+                            errorMessage={errors.quantity?.message}
+                        >
+                            <Input
+                                type="number"
+                                min={1}
+                                placeholder="1"
+                                disabled={isSubmitting}
+                                invalid={!!errors.quantity}
+                                {...numberRegister('quantity', {
+                                    integer: true,
+                                    emptyValue: 1,
+                                })}
+                            />
+                        </FormItem>
+
+                        <FormItem
+                            label="Lote (opcional)"
+                            invalid={!!errors.lotId}
+                            errorMessage={errors.lotId?.message}
+                        >
+                            <ControlledSelect
+                                name="lotId"
+                                control={control}
+                                options={lotOptions}
+                                placeholder="Seleccionar lote"
+                                isDisabled={isSubmitting || !selectedProductId}
+                            />
+                        </FormItem>
+
+                        <FormItem
+                            label="Notas"
+                            invalid={!!errors.notes}
+                            errorMessage={errors.notes?.message}
+                        >
+                            <Input
+                                textArea
+                                placeholder="Observaciones del item"
+                                disabled={isSubmitting}
+                                invalid={!!errors.notes}
+                                {...register('notes')}
+                            />
+                        </FormItem>
+                    </div>
+
+                    <div className="flex justify-end gap-2 mt-6">
+                        <Button
+                            type="button"
+                            variant="plain"
+                            disabled={isSubmitting}
+                            onClick={handleClose}
+                        >
+                            Cancelar
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            loading={isSubmitting}
+                        >
+                            Agregar
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </Dialog>
+    )
+}
+
+// ─── Update ───────────────────────────────────────────────────────────────────
+
+interface UpdateFormProps {
+    open: boolean
+    onClose: () => void
+    transferId: number
+    item: TransferItem
+}
+
+const TransferItemUpdateForm = ({
+    open,
+    onClose,
+    transferId,
+    item,
+}: UpdateFormProps) => {
+    const updateItem = useUpdateTransferItem()
+
+    const {
+        register,
+        handleSubmit,
+        reset,
+        formState: { errors, isSubmitting },
+    } = useForm<TransferItemUpdateFormValues>({
+        resolver: zodResolver(transferItemUpdateSchema),
+        defaultValues: {
+            quantity: item.quantity,
+            notes: item.notes ?? '',
+        },
+    })
+
+    const numberRegister = makeNumberRegister(register)
+
+    useEffect(() => {
+        if (open) {
+            reset({
+                quantity: item.quantity,
+                notes: item.notes ?? '',
+            })
+        }
+    }, [open, item, reset])
+
+    const handleClose = () => {
+        if (!isSubmitting) onClose()
+    }
+
+    const onSubmit = async (values: TransferItemUpdateFormValues) => {
+        try {
+            await updateItem.mutateAsync({
+                itemId: item.id,
+                transferId,
+                data: {
+                    quantity: values.quantity,
+                    notes: values.notes || undefined,
+                },
+            })
+            toast.push(
+                <Notification title="Item actualizado" type="success" />,
+                { placement: 'top-end' }
+            )
+            onClose()
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al actualizar el item')}
+                </Notification>,
+                { placement: 'top-end' }
+            )
+        }
+    }
+
+    return (
+        <Dialog
+            isOpen={open}
+            width={600}
+            onClose={handleClose}
+            onRequestClose={handleClose}
+        >
+            <div className="flex flex-col h-full justify-between">
+                <h5 className="mb-4">Editar Item</h5>
+                <form className="flex-1" onSubmit={handleSubmit(onSubmit)}>
+                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
+                        <FormItem
+                            asterisk
+                            label="Cantidad"
+                            invalid={!!errors.quantity}
+                            errorMessage={errors.quantity?.message}
+                        >
+                            <Input
+                                type="number"
+                                min={1}
+                                placeholder="1"
+                                disabled={isSubmitting}
+                                invalid={!!errors.quantity}
+                                {...numberRegister('quantity', {
+                                    integer: true,
+                                    emptyValue: 1,
+                                })}
+                            />
+                        </FormItem>
+
+                        <FormItem
+                            label="Notas"
+                            invalid={!!errors.notes}
+                            errorMessage={errors.notes?.message}
+                        >
+                            <Input
+                                textArea
+                                placeholder="Observaciones del item"
+                                disabled={isSubmitting}
+                                invalid={!!errors.notes}
+                                {...register('notes')}
+                            />
+                        </FormItem>
+                    </div>
+
+                    <div className="flex justify-end gap-2 mt-6">
+                        <Button
+                            type="button"
+                            variant="plain"
+                            disabled={isSubmitting}
+                            onClick={handleClose}
+                        >
+                            Cancelar
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            loading={isSubmitting}
+                        >
+                            Actualizar
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </Dialog>
+    )
+}
+
+// ─── Wrapper ──────────────────────────────────────────────────────────────────
 
 interface TransferItemFormProps {
     open: boolean
@@ -27,290 +368,20 @@ const TransferItemForm = ({
     onClose,
     transferId,
     item,
-}: TransferItemFormProps) => {
-    const [formData, setFormData] = useState<TransferItemInput>({
-        productId: 0,
-        quantity: 1,
-        lotId: null,
-        notes: '',
-    })
-
-    const [editData, setEditData] = useState<TransferItemUpdateInput>({
-        quantity: 1,
-        notes: '',
-    })
-
-    const addItem = useAddTransferItem()
-    const updateItem = useUpdateTransferItem()
-
-    const { data: productsData } = useProducts()
-    const products = productsData?.items ?? []
-
-    const selectedProductId = item ? item.productId : formData.productId
-    const { data: lotsData } = useLots(
-        selectedProductId
-            ? { productId: selectedProductId, limit: 100 }
-            : undefined
+}: TransferItemFormProps) =>
+    item ? (
+        <TransferItemUpdateForm
+            open={open}
+            transferId={transferId}
+            item={item}
+            onClose={onClose}
+        />
+    ) : (
+        <TransferItemCreateForm
+            open={open}
+            transferId={transferId}
+            onClose={onClose}
+        />
     )
-    const lots = lotsData?.items ?? []
-
-    const isEdit = !!item
-
-    const productOptions = products.map((p) => ({
-        value: p.id.toString(),
-        label: `${p.name} (${p.sku})`,
-    }))
-
-    const lotOptions = [
-        { value: '', label: 'Sin lote' },
-        ...lots.map((l) => ({
-            value: l.id.toString(),
-            label: `${l.lotNumber}`,
-        })),
-    ]
-
-    useEffect(() => {
-        if (item) {
-            setEditData({
-                quantity: item.quantity,
-                notes: item.notes || '',
-            })
-        } else {
-            setFormData({
-                productId: 0,
-                quantity: 1,
-                lotId: null,
-                notes: '',
-            })
-        }
-    }, [item, open])
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-
-        try {
-            if (isEdit && item) {
-                await updateItem.mutateAsync({
-                    itemId: item.id,
-                    transferId,
-                    data: {
-                        quantity: editData.quantity,
-                        notes: editData.notes || undefined,
-                    },
-                })
-            } else {
-                await addItem.mutateAsync({
-                    transferId,
-                    data: {
-                        productId: formData.productId,
-                        quantity: formData.quantity,
-                        lotId: formData.lotId || undefined,
-                        notes: formData.notes || undefined,
-                    },
-                })
-            }
-
-            toast.push(
-                <Notification
-                    title={isEdit ? 'Item actualizado' : 'Item agregado'}
-                    type="success"
-                >
-                    {isEdit
-                        ? 'El item se actualizó correctamente'
-                        : 'El item se agregó correctamente'}
-                </Notification>,
-                { placement: 'top-end' }
-            )
-
-            onClose()
-        } catch (error: unknown) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al guardar el item')}
-                </Notification>,
-                { placement: 'top-end' }
-            )
-        }
-    }
-
-    const isPending = addItem.isPending || updateItem.isPending
-
-    const handleClose = () => {
-        if (!isPending) {
-            onClose()
-        }
-    }
-
-    return (
-        <Dialog
-            isOpen={open}
-            width={600}
-            onClose={handleClose}
-            onRequestClose={handleClose}
-        >
-            <div className="flex flex-col h-full justify-between">
-                <h5 className="mb-4">
-                    {isEdit ? 'Editar Item' : 'Agregar Item'}
-                </h5>
-
-                <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        {isEdit ? (
-                            <>
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Cantidad{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Input
-                                        required
-                                        type="number"
-                                        min={1}
-                                        placeholder="1"
-                                        value={editData.quantity ?? ''}
-                                        onChange={(e) =>
-                                            setEditData({
-                                                ...editData,
-                                                quantity:
-                                                    parseInt(e.target.value) ||
-                                                    1,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Notas
-                                    </label>
-                                    <Input
-                                        textArea
-                                        placeholder="Observaciones del item"
-                                        value={editData.notes || ''}
-                                        onChange={(e) =>
-                                            setEditData({
-                                                ...editData,
-                                                notes: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-                            </>
-                        ) : (
-                            <>
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Producto{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Select
-                                        placeholder="Seleccionar producto"
-                                        options={productOptions}
-                                        value={productOptions.find(
-                                            (o) =>
-                                                o.value ===
-                                                formData.productId.toString()
-                                        )}
-                                        onChange={(option) =>
-                                            setFormData({
-                                                ...formData,
-                                                productId: option
-                                                    ? parseInt(option.value)
-                                                    : 0,
-                                                lotId: null,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Cantidad{' '}
-                                        <span className="text-red-500">*</span>
-                                    </label>
-                                    <Input
-                                        required
-                                        type="number"
-                                        min={1}
-                                        placeholder="1"
-                                        value={formData.quantity || ''}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                quantity:
-                                                    parseInt(e.target.value) ||
-                                                    1,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Lote (opcional)
-                                    </label>
-                                    <Select
-                                        placeholder="Seleccionar lote"
-                                        options={lotOptions}
-                                        value={lotOptions.find(
-                                            (o) =>
-                                                o.value ===
-                                                (formData.lotId?.toString() ||
-                                                    '')
-                                        )}
-                                        onChange={(option) =>
-                                            setFormData({
-                                                ...formData,
-                                                lotId:
-                                                    option && option.value
-                                                        ? parseInt(option.value)
-                                                        : null,
-                                            })
-                                        }
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium mb-2">
-                                        Notas
-                                    </label>
-                                    <Input
-                                        textArea
-                                        placeholder="Observaciones del item"
-                                        value={formData.notes || ''}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                notes: e.target.value,
-                                            })
-                                        }
-                                    />
-                                </div>
-                            </>
-                        )}
-                    </div>
-
-                    <div className="flex justify-end gap-2 mt-6">
-                        <Button
-                            type="button"
-                            variant="plain"
-                            disabled={isPending}
-                            onClick={handleClose}
-                        >
-                            Cancelar
-                        </Button>
-                        <Button
-                            type="submit"
-                            variant="solid"
-                            loading={isPending}
-                        >
-                            {isEdit ? 'Actualizar' : 'Agregar'}
-                        </Button>
-                    </div>
-                </form>
-            </div>
-        </Dialog>
-    )
-}
 
 export default TransferItemForm


### PR DESCRIPTION

## Descripción

  - Add transferItem.schema.ts and adjustmentItem.schema.ts with dual create/update schemas
  - Split both forms into Create/Update sub-components with a wrapper parent (no shared useForm with dynamic resolver)
  - Replace useState+manual validation with useForm+zodResolver
  - Replace <Select> with <ControlledSelect> in all item forms
  - Drive product→lot cascade via useWatch instead of duplicated useState
  - Move toast errors to field-level validation; server errors remain as toast

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
