### PR TITLE
feat(forms): migrate MovementForm, TransferForm and AdjustmentForm to RHF+Zod

### DIFF
--- a/src/schemas/adjustment.schema.ts
+++ b/src/schemas/adjustment.schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+export const adjustmentReasons = [
+    'physical_count',
+    'damaged',
+    'theft',
+    'expiration',
+    'supplier_error',
+    'correction',
+    'other',
+] as const
+
+export const adjustmentSchema = z.object({
+    warehouseId: z.number().int().min(1),
+    reason: z.enum(adjustmentReasons),
+    notes: z.string().optional(),
+    adjustedBy: z.string().optional(),
+})
+
+export type AdjustmentFormValues = z.infer<typeof adjustmentSchema>

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -43,3 +43,10 @@ export {
     type AdjustmentItemCreateFormValues,
     type AdjustmentItemUpdateFormValues,
 } from './adjustmentItem.schema'
+export { movementSchema, type MovementFormValues } from './movement.schema'
+export { transferSchema, type TransferFormValues } from './transfer.schema'
+export {
+    adjustmentReasons,
+    adjustmentSchema,
+    type AdjustmentFormValues,
+} from './adjustment.schema'

--- a/src/schemas/movement.schema.ts
+++ b/src/schemas/movement.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const movementSchema = z.object({
+    productId: z.number().int().min(1),
+    quantity: z
+        .number()
+        .int()
+        .refine((v) => v !== 0, 'No puede ser cero'),
+    type: z.enum(['in', 'out']),
+    reason: z.string().optional(),
+    date: z.string().optional(),
+})
+
+export type MovementFormValues = z.infer<typeof movementSchema>

--- a/src/schemas/transfer.schema.ts
+++ b/src/schemas/transfer.schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const transferSchema = z
+    .object({
+        sourceLocationId: z.number().int().min(1),
+        destinationLocationId: z.number().int().min(1),
+        notes: z.string().optional(),
+        requestedBy: z.string().optional(),
+    })
+    .refine((d) => d.sourceLocationId !== d.destinationLocationId, {
+        message: 'Las ubicaciones deben ser diferentes',
+        path: ['destinationLocationId'],
+    })
+
+export type TransferFormValues = z.infer<typeof transferSchema>

--- a/src/views/inventory/AdjustmentsView/AdjustmentForm.tsx
+++ b/src/views/inventory/AdjustmentsView/AdjustmentForm.tsx
@@ -1,18 +1,22 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import Dialog from '@/components/ui/Dialog'
 import Input from '@/components/ui/Input'
 import Button from '@/components/ui/Button'
-import Select from '@/components/ui/Select'
+import { FormItem, FormContainer } from '@/components/ui/Form'
+import { ControlledSelect } from '@/components/ui/Form/controlled'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
 import { useCreateAdjustment } from '@/hooks/useAdjustments'
 import { useWarehouses } from '@/hooks/useWarehouses'
 import { getErrorMessage } from '@/utils/getErrorMessage'
+import { ADJUSTMENT_REASON_LABELS } from '@/services/AdjustmentService'
 import {
-    ADJUSTMENT_REASON_LABELS,
-    type AdjustmentInput,
-    type AdjustmentReason,
-} from '@/services/AdjustmentService'
+    adjustmentReasons,
+    adjustmentSchema,
+    type AdjustmentFormValues,
+} from '@/schemas'
 
 interface AdjustmentFormProps {
     open: boolean
@@ -20,64 +24,52 @@ interface AdjustmentFormProps {
     onCreated?: (id: number) => void
 }
 
-const reasonOptions = Object.entries(ADJUSTMENT_REASON_LABELS).map(
-    ([value, label]) => ({
-        value,
-        label,
-    })
-)
+const reasonOptions = adjustmentReasons.map((value) => ({
+    value,
+    label: ADJUSTMENT_REASON_LABELS[value],
+}))
 
 const AdjustmentForm = ({ open, onClose, onCreated }: AdjustmentFormProps) => {
-    const [formData, setFormData] = useState<AdjustmentInput>({
-        warehouseId: 0,
-        reason: 'physical_count',
-        notes: '',
-        adjustedBy: '',
-    })
-
     const createAdjustment = useCreateAdjustment()
     const { data: warehousesData } = useWarehouses({ limit: 100 })
     const warehouses = warehousesData?.items ?? []
 
     const warehouseOptions = warehouses.map((w) => ({
-        value: w.id.toString(),
+        value: w.id,
         label: `${w.name} (${w.code})`,
     }))
 
+    const {
+        register,
+        handleSubmit,
+        control,
+        reset,
+        formState: { errors, isSubmitting },
+    } = useForm<AdjustmentFormValues>({
+        resolver: zodResolver(adjustmentSchema),
+        defaultValues: { reason: 'physical_count', notes: '', adjustedBy: '' },
+    })
+
     useEffect(() => {
-        if (open) {
-            setFormData({
-                warehouseId: 0,
-                reason: 'physical_count',
-                notes: '',
-                adjustedBy: '',
-            })
-        }
-    }, [open])
+        if (open) reset({ reason: 'physical_count', notes: '', adjustedBy: '' })
+    }, [open, reset])
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-
+    const onSubmit = async (values: AdjustmentFormValues) => {
         try {
-            const submitData: AdjustmentInput = {
-                warehouseId: formData.warehouseId,
-                reason: formData.reason,
-                notes: formData.notes || undefined,
-                adjustedBy: formData.adjustedBy || undefined,
-            }
-            const adjustment = await createAdjustment.mutateAsync(submitData)
-
+            const adjustment = await createAdjustment.mutateAsync({
+                warehouseId: values.warehouseId,
+                reason: values.reason,
+                notes: values.notes || undefined,
+                adjustedBy: values.adjustedBy || undefined,
+            })
             toast.push(
                 <Notification title="Ajuste creado" type="success">
                     El ajuste se creó correctamente
                 </Notification>,
                 { placement: 'top-center' }
             )
-
             onClose()
-            if (onCreated) {
-                onCreated(adjustment.id)
-            }
+            onCreated?.(adjustment.id)
         } catch (error: unknown) {
             toast.push(
                 <Notification title="Error" type="danger">
@@ -88,12 +80,8 @@ const AdjustmentForm = ({ open, onClose, onCreated }: AdjustmentFormProps) => {
         }
     }
 
-    const isPending = createAdjustment.isPending
-
     const handleClose = () => {
-        if (!isPending) {
-            onClose()
-        }
+        if (!isSubmitting) onClose()
     }
 
     return (
@@ -105,92 +93,72 @@ const AdjustmentForm = ({ open, onClose, onCreated }: AdjustmentFormProps) => {
         >
             <div className="flex flex-col h-full justify-between">
                 <h5 className="mb-4">Nuevo Ajuste de Inventario</h5>
-
-                <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Almacén <span className="text-red-500">*</span>
-                            </label>
-                            <Select
-                                placeholder="Seleccionar almacén"
+                <form className="flex-1" onSubmit={handleSubmit(onSubmit)}>
+                    <FormContainer>
+                        <FormItem
+                            asterisk
+                            label="Almacén"
+                            invalid={!!errors.warehouseId}
+                            errorMessage={errors.warehouseId?.message}
+                        >
+                            <ControlledSelect
+                                name="warehouseId"
+                                control={control}
                                 options={warehouseOptions}
-                                value={warehouseOptions.find(
-                                    (o) =>
-                                        o.value ===
-                                        formData.warehouseId.toString()
-                                )}
-                                onChange={(option) =>
-                                    setFormData({
-                                        ...formData,
-                                        warehouseId: option
-                                            ? parseInt(option.value)
-                                            : 0,
-                                    })
-                                }
+                                isDisabled={isSubmitting}
+                                placeholder="Seleccionar almacén"
                             />
-                        </div>
+                        </FormItem>
 
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Motivo <span className="text-red-500">*</span>
-                            </label>
-                            <Select
-                                placeholder="Seleccionar motivo"
+                        <FormItem
+                            asterisk
+                            label="Motivo"
+                            invalid={!!errors.reason}
+                            errorMessage={errors.reason?.message}
+                        >
+                            <ControlledSelect
+                                name="reason"
+                                control={control}
                                 options={reasonOptions}
-                                value={reasonOptions.find(
-                                    (o) => o.value === formData.reason
-                                )}
-                                onChange={(option) =>
-                                    setFormData({
-                                        ...formData,
-                                        reason: (option?.value ||
-                                            'physical_count') as AdjustmentReason,
-                                    })
-                                }
+                                isDisabled={isSubmitting}
+                                placeholder="Seleccionar motivo"
                             />
-                        </div>
+                        </FormItem>
 
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Responsable
-                            </label>
+                        <FormItem
+                            label="Responsable"
+                            invalid={!!errors.adjustedBy}
+                            errorMessage={errors.adjustedBy?.message}
+                        >
                             <Input
                                 type="text"
                                 placeholder="Nombre del responsable"
-                                value={formData.adjustedBy || ''}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        adjustedBy: e.target.value,
-                                    })
-                                }
+                                disabled={isSubmitting}
+                                invalid={!!errors.adjustedBy}
+                                {...register('adjustedBy')}
                             />
-                        </div>
+                        </FormItem>
 
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Notas
-                            </label>
+                        <FormItem
+                            label="Notas"
+                            invalid={!!errors.notes}
+                            errorMessage={errors.notes?.message}
+                        >
                             <Input
                                 textArea
                                 placeholder="Observaciones del ajuste"
-                                value={formData.notes || ''}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        notes: e.target.value,
-                                    })
-                                }
+                                disabled={isSubmitting}
+                                invalid={!!errors.notes}
+                                {...register('notes')}
                             />
-                        </div>
-                    </div>
+                        </FormItem>
+                    </FormContainer>
 
                     <div className="flex justify-end gap-2 mt-6">
                         <Button
                             type="button"
                             variant="plain"
-                            disabled={isPending}
+                            disabled={isSubmitting}
                             onClick={handleClose}
                         >
                             Cancelar
@@ -198,8 +166,7 @@ const AdjustmentForm = ({ open, onClose, onCreated }: AdjustmentFormProps) => {
                         <Button
                             type="submit"
                             variant="solid"
-                            loading={isPending}
-                            disabled={!formData.warehouseId}
+                            loading={isSubmitting}
                         >
                             Crear
                         </Button>

--- a/src/views/inventory/MovementsView/MovementForm.tsx
+++ b/src/views/inventory/MovementsView/MovementForm.tsx
@@ -1,148 +1,77 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import Dialog from '@/components/ui/Dialog'
 import Button from '@/components/ui/Button'
 import Input from '@/components/ui/Input'
-import Select from '@/components/ui/Select'
+import { FormItem, FormContainer } from '@/components/ui/Form'
+import { ControlledSelect } from '@/components/ui/Form/controlled'
+import { makeNumberRegister } from '@/components/ui/Form/utils'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
 import { useCreateMovement } from '@/hooks/useMovements'
 import { getErrorMessage } from '@/utils/getErrorMessage'
-import type { MovementInput, MovementType } from '@/services/MovementService'
+import { movementSchema, type MovementFormValues } from '@/schemas'
 
 interface MovementFormProps {
     open: boolean
     onClose: () => void
 }
 
-const MovementForm = ({ open, onClose }: MovementFormProps) => {
-    const [formData, setFormData] = useState<MovementInput>({
-        productId: 0,
-        quantity: 0,
-        type: 'in',
-        reason: '',
-        date: '',
-    })
+const typeOptions = [
+    { value: 'in' as const, label: 'Entrada' },
+    { value: 'out' as const, label: 'Salida' },
+]
 
+const MovementForm = ({ open, onClose }: MovementFormProps) => {
     const createMovement = useCreateMovement()
 
-    const typeOptions = [
-        { value: 'in', label: 'Entrada' },
-        { value: 'out', label: 'Salida' },
-    ]
+    const {
+        register,
+        handleSubmit,
+        control,
+        reset,
+        formState: { errors, isSubmitting },
+    } = useForm<MovementFormValues>({
+        resolver: zodResolver(movementSchema),
+        defaultValues: { type: 'in', reason: '', date: '' },
+    })
+
+    const numberRegister = makeNumberRegister(register)
 
     useEffect(() => {
-        if (open) {
-            // Reset form when opening
-            setFormData({
-                productId: 0,
-                quantity: 0,
-                type: 'in',
-                reason: '',
-                date: '',
-            })
-        }
-    }, [open])
+        if (open) reset({ type: 'in', reason: '', date: '' })
+    }, [open, reset])
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-
-        // Client-side validation
-        if (formData.productId <= 0) {
-            toast.push(
-                <Notification title="Error de validación" type="warning">
-                    El ID del producto debe ser mayor a 0
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            return
-        }
-
-        if (formData.quantity === 0) {
-            toast.push(
-                <Notification title="Error de validación" type="warning">
-                    La cantidad no puede ser cero
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            return
-        }
-
-        // Validate type and quantity relationship
-        if (formData.type === 'in' && formData.quantity < 0) {
-            toast.push(
-                <Notification title="Error de validación" type="warning">
-                    Para movimientos de entrada, la cantidad debe ser positiva
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            return
-        }
-
-        if (formData.type === 'out' && formData.quantity > 0) {
-            toast.push(
-                <Notification title="Error de validación" type="warning">
-                    Para movimientos de salida, la cantidad debe ser negativa
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            return
-        }
-
+    const onSubmit = async (values: MovementFormValues) => {
+        const signedQuantity =
+            Math.abs(values.quantity) * (values.type === 'in' ? 1 : -1)
         try {
-            await createMovement.mutateAsync(formData)
-
+            await createMovement.mutateAsync({
+                ...values,
+                quantity: signedQuantity,
+                reason: values.reason || undefined,
+                date: values.date || undefined,
+            })
             toast.push(
                 <Notification title="Movimiento creado" type="success">
                     El movimiento se registró correctamente
                 </Notification>,
                 { placement: 'top-end' }
             )
-
             onClose()
         } catch (error: unknown) {
-            const errorMessage = getErrorMessage(
-                error,
-                'Error al crear el movimiento'
-            )
-
             toast.push(
                 <Notification title="Error" type="danger">
-                    {errorMessage}
+                    {getErrorMessage(error, 'Error al crear el movimiento')}
                 </Notification>,
                 { placement: 'top-end' }
             )
-
-            console.error('Error creating movement:', error)
         }
     }
 
     const handleClose = () => {
-        if (!createMovement.isPending) {
-            onClose()
-        }
-    }
-
-    const handleTypeChange = (
-        option: { value: string; label: string } | null
-    ) => {
-        const newType = option?.value as MovementType
-        setFormData({
-            ...formData,
-            type: newType,
-            // Auto-adjust quantity sign based on type
-            quantity: Math.abs(formData.quantity) * (newType === 'in' ? 1 : -1),
-        })
-    }
-
-    const handleQuantityChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        let value = parseInt(e.target.value) || 0
-        // Ensure quantity has correct sign based on type
-        if (formData.type === 'out' && value > 0) {
-            value = -value
-        } else if (formData.type === 'in' && value < 0) {
-            value = Math.abs(value)
-        }
-        setFormData({ ...formData, quantity: value })
+        if (!isSubmitting) onClose()
     }
 
     return (
@@ -153,120 +82,91 @@ const MovementForm = ({ open, onClose }: MovementFormProps) => {
         >
             <div className="flex flex-col h-full justify-between">
                 <h5 className="mb-4">Nuevo Movimiento</h5>
-
-                <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        {/* Product ID */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                ID Producto{' '}
-                                <span className="text-red-500">*</span>
-                            </label>
+                <form className="flex-1" onSubmit={handleSubmit(onSubmit)}>
+                    <FormContainer>
+                        <FormItem
+                            asterisk
+                            label="ID Producto"
+                            invalid={!!errors.productId}
+                            errorMessage={errors.productId?.message}
+                        >
                             <Input
-                                required
                                 type="number"
                                 placeholder="ID del producto"
-                                value={formData.productId || ''}
-                                min="1"
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        productId:
-                                            parseInt(e.target.value) || 0,
-                                    })
-                                }
+                                disabled={isSubmitting}
+                                invalid={!!errors.productId}
+                                {...numberRegister('productId', {
+                                    integer: true,
+                                })}
                             />
-                        </div>
+                        </FormItem>
 
-                        {/* Type */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Tipo <span className="text-red-500">*</span>
-                            </label>
-                            <Select
-                                value={typeOptions.find(
-                                    (opt) => opt.value === formData.type
-                                )}
+                        <FormItem
+                            asterisk
+                            label="Tipo"
+                            invalid={!!errors.type}
+                            errorMessage={errors.type?.message}
+                        >
+                            <ControlledSelect
+                                name="type"
+                                control={control}
                                 options={typeOptions}
-                                onChange={handleTypeChange}
+                                isDisabled={isSubmitting}
+                                placeholder="Seleccionar tipo"
                             />
-                            <p className="text-xs text-gray-500 mt-1">
-                                {formData.type === 'in'
-                                    ? 'Entrada: suma al inventario (cantidad positiva)'
-                                    : 'Salida: resta del inventario (cantidad negativa)'}
-                            </p>
-                        </div>
+                        </FormItem>
 
-                        {/* Quantity */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Cantidad <span className="text-red-500">*</span>
-                            </label>
+                        <FormItem
+                            asterisk
+                            label="Cantidad"
+                            invalid={!!errors.quantity}
+                            errorMessage={errors.quantity?.message}
+                        >
                             <Input
-                                required
                                 type="number"
-                                placeholder={
-                                    formData.type === 'in'
-                                        ? 'Ej: 100'
-                                        : 'Ej: -50'
-                                }
-                                value={formData.quantity || ''}
-                                onChange={handleQuantityChange}
+                                placeholder="Ej: 100"
+                                disabled={isSubmitting}
+                                invalid={!!errors.quantity}
+                                {...numberRegister('quantity', {
+                                    integer: true,
+                                })}
                             />
-                            <p className="text-xs text-gray-500 mt-1">
-                                {formData.type === 'in'
-                                    ? 'Ingrese una cantidad positiva'
-                                    : 'Ingrese una cantidad negativa'}
-                            </p>
-                        </div>
+                        </FormItem>
 
-                        {/* Reason */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Motivo
-                            </label>
+                        <FormItem
+                            label="Motivo"
+                            invalid={!!errors.reason}
+                            errorMessage={errors.reason?.message}
+                        >
                             <Input
                                 textArea
                                 placeholder="Motivo del movimiento (opcional)"
-                                value={formData.reason}
                                 style={{ minHeight: '80px' }}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        reason: e.target.value,
-                                    })
-                                }
+                                disabled={isSubmitting}
+                                invalid={!!errors.reason}
+                                {...register('reason')}
                             />
-                        </div>
+                        </FormItem>
 
-                        {/* Date */}
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Fecha
-                            </label>
+                        <FormItem
+                            label="Fecha"
+                            invalid={!!errors.date}
+                            errorMessage={errors.date?.message}
+                        >
                             <Input
                                 type="datetime-local"
-                                value={formData.date}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        date: e.target.value,
-                                    })
-                                }
+                                disabled={isSubmitting}
+                                invalid={!!errors.date}
+                                {...register('date')}
                             />
-                            <p className="text-xs text-gray-500 mt-1">
-                                Opcional: si no se especifica, se usará la fecha
-                                actual
-                            </p>
-                        </div>
-                    </div>
+                        </FormItem>
+                    </FormContainer>
 
-                    {/* Buttons */}
                     <div className="flex justify-end gap-2 mt-6">
                         <Button
                             type="button"
                             variant="plain"
-                            disabled={createMovement.isPending}
+                            disabled={isSubmitting}
                             onClick={handleClose}
                         >
                             Cancelar
@@ -274,7 +174,7 @@ const MovementForm = ({ open, onClose }: MovementFormProps) => {
                         <Button
                             type="submit"
                             variant="solid"
-                            loading={createMovement.isPending}
+                            loading={isSubmitting}
                         >
                             Crear
                         </Button>

--- a/src/views/inventory/TransfersView/TransferForm.tsx
+++ b/src/views/inventory/TransfersView/TransferForm.tsx
@@ -1,14 +1,17 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import Dialog from '@/components/ui/Dialog'
 import Input from '@/components/ui/Input'
 import Button from '@/components/ui/Button'
-import Select from '@/components/ui/Select'
+import { FormItem, FormContainer } from '@/components/ui/Form'
+import { ControlledSelect } from '@/components/ui/Form/controlled'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
 import { useCreateTransfer } from '@/hooks/useTransfers'
 import { useLocations } from '@/hooks/useLocations'
 import { getErrorMessage } from '@/utils/getErrorMessage'
-import type { TransferInput } from '@/services/TransferService'
+import { transferSchema, type TransferFormValues } from '@/schemas'
 
 interface TransferFormProps {
     open: boolean
@@ -17,56 +20,46 @@ interface TransferFormProps {
 }
 
 const TransferForm = ({ open, onClose, onCreated }: TransferFormProps) => {
-    const [formData, setFormData] = useState<TransferInput>({
-        sourceLocationId: 0,
-        destinationLocationId: 0,
-        notes: '',
-        requestedBy: '',
-    })
-
     const createTransfer = useCreateTransfer()
     const { data: locationsData } = useLocations({ limit: 100 })
     const locations = locationsData?.items ?? []
 
     const locationOptions = locations.map((l) => ({
-        value: l.id.toString(),
+        value: l.id,
         label: `${l.name} (${l.code})`,
     }))
 
+    const {
+        register,
+        handleSubmit,
+        control,
+        reset,
+        formState: { errors, isSubmitting },
+    } = useForm<TransferFormValues>({
+        resolver: zodResolver(transferSchema),
+        defaultValues: { notes: '', requestedBy: '' },
+    })
+
     useEffect(() => {
-        if (open) {
-            setFormData({
-                sourceLocationId: 0,
-                destinationLocationId: 0,
-                notes: '',
-                requestedBy: '',
-            })
-        }
-    }, [open])
+        if (open) reset({ notes: '', requestedBy: '' })
+    }, [open, reset])
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-
+    const onSubmit = async (values: TransferFormValues) => {
         try {
-            const submitData: TransferInput = {
-                sourceLocationId: formData.sourceLocationId,
-                destinationLocationId: formData.destinationLocationId,
-                notes: formData.notes || undefined,
-                requestedBy: formData.requestedBy || undefined,
-            }
-            const transfer = await createTransfer.mutateAsync(submitData)
-
+            const transfer = await createTransfer.mutateAsync({
+                sourceLocationId: values.sourceLocationId,
+                destinationLocationId: values.destinationLocationId,
+                notes: values.notes || undefined,
+                requestedBy: values.requestedBy || undefined,
+            })
             toast.push(
                 <Notification title="Transferencia creada" type="success">
                     La transferencia se creó correctamente
                 </Notification>,
                 { placement: 'top-center' }
             )
-
             onClose()
-            if (onCreated) {
-                onCreated(transfer.id)
-            }
+            onCreated?.(transfer.id)
         } catch (error: unknown) {
             toast.push(
                 <Notification title="Error" type="danger">
@@ -77,16 +70,8 @@ const TransferForm = ({ open, onClose, onCreated }: TransferFormProps) => {
         }
     }
 
-    const isPending = createTransfer.isPending
-    const isValid =
-        formData.sourceLocationId > 0 &&
-        formData.destinationLocationId > 0 &&
-        formData.sourceLocationId !== formData.destinationLocationId
-
     const handleClose = () => {
-        if (!isPending) {
-            onClose()
-        }
+        if (!isSubmitting) onClose()
     }
 
     return (
@@ -98,107 +83,72 @@ const TransferForm = ({ open, onClose, onCreated }: TransferFormProps) => {
         >
             <div className="flex flex-col h-full justify-between">
                 <h5 className="mb-4">Nueva Transferencia</h5>
-
-                <form className="flex-1" onSubmit={handleSubmit}>
-                    <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Ubicación Origen{' '}
-                                <span className="text-red-500">*</span>
-                            </label>
-                            <Select
+                <form className="flex-1" onSubmit={handleSubmit(onSubmit)}>
+                    <FormContainer>
+                        <FormItem
+                            asterisk
+                            label="Ubicación Origen"
+                            invalid={!!errors.sourceLocationId}
+                            errorMessage={errors.sourceLocationId?.message}
+                        >
+                            <ControlledSelect
+                                name="sourceLocationId"
+                                control={control}
+                                options={locationOptions}
+                                isDisabled={isSubmitting}
                                 placeholder="Seleccionar ubicación origen"
-                                options={locationOptions}
-                                value={locationOptions.find(
-                                    (o) =>
-                                        o.value ===
-                                        formData.sourceLocationId.toString()
-                                )}
-                                onChange={(option) =>
-                                    setFormData({
-                                        ...formData,
-                                        sourceLocationId: option
-                                            ? parseInt(option.value)
-                                            : 0,
-                                    })
-                                }
                             />
-                        </div>
+                        </FormItem>
 
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Ubicación Destino{' '}
-                                <span className="text-red-500">*</span>
-                            </label>
-                            <Select
+                        <FormItem
+                            asterisk
+                            label="Ubicación Destino"
+                            invalid={!!errors.destinationLocationId}
+                            errorMessage={errors.destinationLocationId?.message}
+                        >
+                            <ControlledSelect
+                                name="destinationLocationId"
+                                control={control}
+                                options={locationOptions}
+                                isDisabled={isSubmitting}
                                 placeholder="Seleccionar ubicación destino"
-                                options={locationOptions}
-                                value={locationOptions.find(
-                                    (o) =>
-                                        o.value ===
-                                        formData.destinationLocationId.toString()
-                                )}
-                                onChange={(option) =>
-                                    setFormData({
-                                        ...formData,
-                                        destinationLocationId: option
-                                            ? parseInt(option.value)
-                                            : 0,
-                                    })
-                                }
                             />
-                        </div>
+                        </FormItem>
 
-                        {formData.sourceLocationId > 0 &&
-                            formData.destinationLocationId > 0 &&
-                            formData.sourceLocationId ===
-                                formData.destinationLocationId && (
-                                <p className="text-sm text-red-500">
-                                    Las ubicaciones de origen y destino deben
-                                    ser diferentes
-                                </p>
-                            )}
-
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Solicitado por
-                            </label>
+                        <FormItem
+                            label="Solicitado por"
+                            invalid={!!errors.requestedBy}
+                            errorMessage={errors.requestedBy?.message}
+                        >
                             <Input
                                 type="text"
                                 placeholder="Nombre del solicitante"
-                                value={formData.requestedBy || ''}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        requestedBy: e.target.value,
-                                    })
-                                }
+                                disabled={isSubmitting}
+                                invalid={!!errors.requestedBy}
+                                {...register('requestedBy')}
                             />
-                        </div>
+                        </FormItem>
 
-                        <div>
-                            <label className="block text-sm font-medium mb-2">
-                                Notas
-                            </label>
+                        <FormItem
+                            label="Notas"
+                            invalid={!!errors.notes}
+                            errorMessage={errors.notes?.message}
+                        >
                             <Input
                                 textArea
                                 placeholder="Observaciones de la transferencia"
-                                value={formData.notes || ''}
-                                onChange={(e) =>
-                                    setFormData({
-                                        ...formData,
-                                        notes: e.target.value,
-                                    })
-                                }
+                                disabled={isSubmitting}
+                                invalid={!!errors.notes}
+                                {...register('notes')}
                             />
-                        </div>
-                    </div>
+                        </FormItem>
+                    </FormContainer>
 
                     <div className="flex justify-end gap-2 mt-6">
                         <Button
                             type="button"
                             variant="plain"
-                            disabled={isPending}
+                            disabled={isSubmitting}
                             onClick={handleClose}
                         >
                             Cancelar
@@ -206,8 +156,7 @@ const TransferForm = ({ open, onClose, onCreated }: TransferFormProps) => {
                         <Button
                             type="submit"
                             variant="solid"
-                            loading={isPending}
-                            disabled={!isValid}
+                            loading={isSubmitting}
                         >
                             Crear
                         </Button>


### PR DESCRIPTION
## Descripción

  - Add movement.schema.ts, transfer.schema.ts, adjustment.schema.ts
  - MovementForm: remove handleTypeChange/handleQuantityChange; user always enters positive quantity; onSubmit applies sign via Math.abs * ±1
  - TransferForm: cross-field refine replaces manual isValid guard and inline error message; ControlledSelect for both location dropdowns
  - AdjustmentForm: ControlledSelect for warehouse and reason; reason options derived from adjustmentReasons enum + ADJUSTMENT_REASON_LABELS; remove disabled={ from submit button

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
