### PR TITLE
feat(forms): migrate ShiftOpenDialog, CashMovementDialog and StatusChangeDialog to RHF+Zod

### DIFF
--- a/src/schemas/cashMovement.schema.ts
+++ b/src/schemas/cashMovement.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const cashMovementSchema = z.object({
+    type: z.enum(['IN', 'OUT']),
+    amount: z.number().positive('El monto debe ser mayor a cero'),
+    reason: z.string().optional(),
+})
+
+export type CashMovementFormValues = z.infer<typeof cashMovementSchema>

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -50,3 +50,12 @@ export {
     adjustmentSchema,
     type AdjustmentFormValues,
 } from './adjustment.schema'
+export { shiftOpenSchema, type ShiftOpenFormValues } from './shiftOpen.schema'
+export {
+    cashMovementSchema,
+    type CashMovementFormValues,
+} from './cashMovement.schema'
+export {
+    serialStatusChangeSchema,
+    type SerialStatusChangeFormValues,
+} from './serialStatusChange.schema'

--- a/src/schemas/serialStatusChange.schema.ts
+++ b/src/schemas/serialStatusChange.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const serialStatusChangeSchema = z.object({
+    status: z.string().min(1, 'Debe seleccionar un estado'),
+})
+
+export type SerialStatusChangeFormValues = z.infer<
+    typeof serialStatusChangeSchema
+>

--- a/src/schemas/shiftOpen.schema.ts
+++ b/src/schemas/shiftOpen.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const shiftOpenSchema = z.object({
+    cashierName: z.string().min(1, 'Nombre del cajero requerido'),
+    openingBalance: z.number().min(0, 'El saldo inicial no puede ser negativo'),
+    notes: z.string().optional(),
+})
+
+export type ShiftOpenFormValues = z.infer<typeof shiftOpenSchema>

--- a/src/views/inventory/SerialNumbersView/StatusChangeDialog.tsx
+++ b/src/views/inventory/SerialNumbersView/StatusChangeDialog.tsx
@@ -1,16 +1,23 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import Dialog from '@/components/ui/Dialog'
 import Button from '@/components/ui/Button'
-import Select from '@/components/ui/Select'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
+import { FormItem } from '@/components/ui/Form'
+import { ControlledSelect } from '@/components/ui/Form/controlled'
 import { useChangeSerialNumberStatus } from '@/hooks/useSerialNumbers'
 import { getErrorMessage } from '@/utils/getErrorMessage'
-import type { SerialNumber, SerialStatus } from '@/services/SerialNumberService'
 import {
     SERIAL_STATUS_LABELS,
     VALID_TRANSITIONS,
 } from '@/services/SerialNumberService'
+import type { SerialNumber, SerialStatus } from '@/services/SerialNumberService'
+import {
+    serialStatusChangeSchema,
+    type SerialStatusChangeFormValues,
+} from '@/schemas'
 
 interface StatusChangeDialogProps {
     open: boolean
@@ -23,7 +30,6 @@ const StatusChangeDialog = ({
     onClose,
     serialNumber,
 }: StatusChangeDialogProps) => {
-    const [newStatus, setNewStatus] = useState<SerialStatus | ''>('')
     const changeStatus = useChangeSerialNumberStatus()
 
     const validTargets = serialNumber
@@ -35,27 +41,40 @@ const StatusChangeDialog = ({
         label: SERIAL_STATUS_LABELS[s],
     }))
 
+    const noTransitions = validTargets.length === 0
+
+    const {
+        handleSubmit,
+        control,
+        reset,
+        formState: { errors, isSubmitting },
+    } = useForm<SerialStatusChangeFormValues>({
+        resolver: zodResolver(serialStatusChangeSchema),
+        defaultValues: { status: validTargets[0] ?? '' },
+    })
+
     useEffect(() => {
         if (serialNumber) {
             const targets = VALID_TRANSITIONS[serialNumber.status]
-            setNewStatus(targets.length > 0 ? targets[0] : '')
+            reset({ status: targets[0] ?? '' })
         } else {
-            setNewStatus('')
+            reset({ status: '' })
         }
-    }, [serialNumber, open])
+    }, [serialNumber, open, reset])
 
-    const handleSubmit = async () => {
-        if (!serialNumber || !newStatus) return
+    const onSubmit = async (data: SerialStatusChangeFormValues) => {
+        if (!serialNumber) return
 
         try {
             await changeStatus.mutateAsync({
                 id: serialNumber.id,
-                status: newStatus,
+                status: data.status as SerialStatus,
             })
 
             toast.push(
                 <Notification title="Estado actualizado" type="success">
-                    El estado se cambió a {SERIAL_STATUS_LABELS[newStatus]}
+                    El estado se cambió a{' '}
+                    {SERIAL_STATUS_LABELS[data.status as SerialStatus]}
                 </Notification>,
                 { placement: 'top-end' }
             )
@@ -82,8 +101,6 @@ const StatusChangeDialog = ({
         }
     }
 
-    const noTransitions = validTargets.length === 0
-
     return (
         <Dialog
             isOpen={open}
@@ -109,41 +126,40 @@ const StatusChangeDialog = ({
                     transiciones.
                 </p>
             ) : (
-                <div className="mb-6">
-                    <label className="block text-sm font-medium mb-2">
-                        Nuevo Estado
-                    </label>
-                    <Select
-                        options={statusOptions}
-                        value={statusOptions.find((o) => o.value === newStatus)}
-                        onChange={(option) =>
-                            setNewStatus(
-                                (option as { value: SerialStatus })?.value || ''
-                            )
-                        }
-                    />
-                </div>
-            )}
-
-            <div className="flex justify-end gap-2">
-                <Button
-                    variant="plain"
-                    disabled={changeStatus.isPending}
-                    onClick={handleClose}
-                >
-                    Cancelar
-                </Button>
-                {!noTransitions && (
-                    <Button
-                        variant="solid"
-                        loading={changeStatus.isPending}
-                        disabled={!newStatus}
-                        onClick={handleSubmit}
+                <form onSubmit={handleSubmit(onSubmit)}>
+                    <FormItem
+                        label="Nuevo Estado"
+                        invalid={!!errors.status}
+                        errorMessage={errors.status?.message}
                     >
-                        Cambiar Estado
-                    </Button>
-                )}
-            </div>
+                        <ControlledSelect
+                            name="status"
+                            control={control}
+                            options={statusOptions}
+                            isDisabled={isSubmitting}
+                            placeholder="Seleccione un estado"
+                        />
+                    </FormItem>
+
+                    <div className="flex justify-end gap-2 mt-6">
+                        <Button
+                            type="button"
+                            variant="plain"
+                            disabled={changeStatus.isPending}
+                            onClick={handleClose}
+                        >
+                            Cancelar
+                        </Button>
+                        <Button
+                            type="submit"
+                            variant="solid"
+                            loading={changeStatus.isPending}
+                        >
+                            Cambiar Estado
+                        </Button>
+                    </div>
+                </form>
+            )}
         </Dialog>
     )
 }

--- a/src/views/pos/components/CashMovementDialog.tsx
+++ b/src/views/pos/components/CashMovementDialog.tsx
@@ -1,12 +1,15 @@
-import { useState } from 'react'
+import { useForm, useWatch } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import Dialog from '@/components/ui/Dialog'
 import Button from '@/components/ui/Button'
 import Input from '@/components/ui/Input'
 import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
+import { FormItem } from '@/components/ui/Form'
+import { makeNumberRegister } from '@/components/ui/Form/utils'
 import { useAddCashMovement } from '@/hooks/usePOS'
 import { useShift } from './useShift'
-import type { CashMovementType } from '@/services/pos/POSTypes'
+import { cashMovementSchema, type CashMovementFormValues } from '@/schemas'
 
 interface CashMovementDialogProps {
     isOpen: boolean
@@ -17,28 +20,40 @@ const CashMovementDialog = ({ isOpen, onClose }: CashMovementDialogProps) => {
     const shift = useShift()
     const addCashMovement = useAddCashMovement()
 
-    const [type, setType] = useState<CashMovementType>('IN')
-    const [amount, setAmount] = useState<string>('')
-    const [reason, setReason] = useState('')
+    const {
+        register,
+        handleSubmit,
+        control,
+        setValue,
+        reset,
+        formState: { errors, isSubmitting },
+    } = useForm<CashMovementFormValues>({
+        resolver: zodResolver(cashMovementSchema),
+        defaultValues: {
+            type: 'IN',
+            amount: undefined,
+            reason: '',
+        },
+    })
 
-    const handleSubmit = async () => {
-        const numAmount = Number(amount)
-        if (numAmount <= 0) return
+    const numberRegister = makeNumberRegister(register)
+    const type = useWatch({ control, name: 'type' })
 
+    const onSubmit = async (data: CashMovementFormValues) => {
         try {
             await addCashMovement.mutateAsync({
                 shiftId: shift.id,
                 data: {
-                    type,
-                    amount: numAmount,
-                    reason: reason || undefined,
+                    type: data.type,
+                    amount: data.amount,
+                    reason: data.reason || undefined,
                 },
             })
             toast.push(
                 <Notification type="success" title="Movimiento registrado" />,
                 { placement: 'top-end' }
             )
-            resetForm()
+            reset()
             onClose()
         } catch {
             toast.push(
@@ -51,14 +66,8 @@ const CashMovementDialog = ({ isOpen, onClose }: CashMovementDialogProps) => {
         }
     }
 
-    const resetForm = () => {
-        setType('IN')
-        setAmount('')
-        setReason('')
-    }
-
     const handleClose = () => {
-        resetForm()
+        reset()
         onClose()
     }
 
@@ -71,79 +80,86 @@ const CashMovementDialog = ({ isOpen, onClose }: CashMovementDialogProps) => {
         >
             <h4 className="text-lg font-bold mb-4">Movimiento de Caja</h4>
 
-            <div className="flex gap-2 mb-4">
-                <Button
-                    block
-                    variant={type === 'IN' ? 'solid' : 'default'}
-                    className={
-                        type === 'IN'
-                            ? '!bg-emerald-500 !border-emerald-500 text-white'
-                            : ''
-                    }
-                    onClick={() => setType('IN')}
-                >
-                    Entrada
-                </Button>
-                <Button
-                    block
-                    variant={type === 'OUT' ? 'solid' : 'default'}
-                    className={
-                        type === 'OUT'
-                            ? '!bg-red-500 !border-red-500 text-white'
-                            : ''
-                    }
-                    onClick={() => setType('OUT')}
-                >
-                    Salida
-                </Button>
-            </div>
+            <form onSubmit={handleSubmit(onSubmit)}>
+                <div className="flex gap-2 mb-4">
+                    <Button
+                        block
+                        type="button"
+                        variant={type === 'IN' ? 'solid' : 'default'}
+                        className={
+                            type === 'IN'
+                                ? '!bg-emerald-500 !border-emerald-500 text-white'
+                                : ''
+                        }
+                        onClick={() => setValue('type', 'IN')}
+                    >
+                        Entrada
+                    </Button>
+                    <Button
+                        block
+                        type="button"
+                        variant={type === 'OUT' ? 'solid' : 'default'}
+                        className={
+                            type === 'OUT'
+                                ? '!bg-red-500 !border-red-500 text-white'
+                                : ''
+                        }
+                        onClick={() => setValue('type', 'OUT')}
+                    >
+                        Salida
+                    </Button>
+                </div>
 
-            <div>
-                <label
-                    htmlFor="cash-amount"
-                    className="block text-sm font-medium mb-1"
+                <FormItem
+                    asterisk
+                    label="Monto"
+                    invalid={!!errors.amount}
+                    errorMessage={errors.amount?.message}
                 >
-                    Monto
-                </label>
-                <Input
-                    id="cash-amount"
-                    type="number"
-                    prefix="$"
-                    value={amount}
-                    placeholder="0.00"
-                    onChange={(e) => setAmount(e.target.value)}
-                />
-            </div>
+                    <Input
+                        type="number"
+                        prefix="$"
+                        placeholder="0.00"
+                        disabled={isSubmitting}
+                        invalid={!!errors.amount}
+                        {...numberRegister('amount')}
+                    />
+                </FormItem>
 
-            <div className="mt-3">
-                <label
-                    htmlFor="cash-reason"
-                    className="block text-sm font-medium mb-1"
-                >
-                    Razon (opcional)
-                </label>
-                <Input
-                    id="cash-reason"
-                    value={reason}
-                    placeholder="Razon del movimiento"
-                    onChange={(e) => setReason(e.target.value)}
-                />
-            </div>
+                <div className="mt-3">
+                    <FormItem
+                        label="Razón (opcional)"
+                        invalid={!!errors.reason}
+                        errorMessage={errors.reason?.message}
+                    >
+                        <Input
+                            placeholder="Razón del movimiento"
+                            disabled={isSubmitting}
+                            invalid={!!errors.reason}
+                            {...register('reason')}
+                        />
+                    </FormItem>
+                </div>
 
-            <div className="flex gap-2 mt-6">
-                <Button block variant="default" onClick={handleClose}>
-                    Cancelar
-                </Button>
-                <Button
-                    block
-                    variant="solid"
-                    loading={addCashMovement.isPending}
-                    disabled={!amount || Number(amount) <= 0}
-                    onClick={handleSubmit}
-                >
-                    Registrar
-                </Button>
-            </div>
+                <div className="flex gap-2 mt-6">
+                    <Button
+                        block
+                        type="button"
+                        variant="default"
+                        onClick={handleClose}
+                    >
+                        Cancelar
+                    </Button>
+                    <Button
+                        block
+                        type="submit"
+                        variant="solid"
+                        loading={addCashMovement.isPending}
+                    >
+                        Registrar
+                    </Button>
+                </div>
+            </form>
         </Dialog>
     )
 }

--- a/src/views/pos/components/ShiftOpenDialog.tsx
+++ b/src/views/pos/components/ShiftOpenDialog.tsx
@@ -1,24 +1,39 @@
-import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import Input from '@/components/ui/Input'
 import Button from '@/components/ui/Button'
+import { FormItem, FormContainer } from '@/components/ui/Form'
+import { makeNumberRegister } from '@/components/ui/Form/utils'
 import { useOpenShift } from '@/hooks/usePOS'
 import { useSession } from '@/stores/useAuthStore'
+import { shiftOpenSchema, type ShiftOpenFormValues } from '@/schemas'
 
 const ShiftOpenDialog = () => {
     const navigate = useNavigate()
     const session = useSession()
     const openShift = useOpenShift()
 
-    const [cashierName, setCashierName] = useState(session?.username || '')
-    const [openingBalance, setOpeningBalance] = useState<string>('0')
-    const [notes, setNotes] = useState('')
+    const {
+        register,
+        handleSubmit,
+        formState: { errors, isSubmitting },
+    } = useForm<ShiftOpenFormValues>({
+        resolver: zodResolver(shiftOpenSchema),
+        defaultValues: {
+            cashierName: session?.username || '',
+            openingBalance: 0,
+            notes: '',
+        },
+    })
 
-    const handleSubmit = async () => {
+    const numberRegister = makeNumberRegister(register)
+
+    const onSubmit = async (data: ShiftOpenFormValues) => {
         await openShift.mutateAsync({
-            cashierName,
-            openingBalance: Number(openingBalance),
-            notes: notes || undefined,
+            cashierName: data.cashierName,
+            openingBalance: data.openingBalance,
+            notes: data.notes || undefined,
         })
     }
 
@@ -32,60 +47,72 @@ const ShiftOpenDialog = () => {
                     Debe abrir un turno para usar el POS
                 </p>
 
-                <div className="space-y-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-1">
-                            Nombre del cajero
-                        </label>
-                        <Input
-                            value={cashierName}
-                            placeholder="Nombre del cajero"
-                            onChange={(e) => setCashierName(e.target.value)}
-                        />
-                    </div>
+                <form onSubmit={handleSubmit(onSubmit)}>
+                    <FormContainer>
+                        <FormItem
+                            asterisk
+                            label="Nombre del cajero"
+                            invalid={!!errors.cashierName}
+                            errorMessage={errors.cashierName?.message}
+                        >
+                            <Input
+                                placeholder="Nombre del cajero"
+                                disabled={isSubmitting}
+                                invalid={!!errors.cashierName}
+                                {...register('cashierName')}
+                            />
+                        </FormItem>
 
-                    <div>
-                        <label className="block text-sm font-medium mb-1">
-                            Saldo inicial
-                        </label>
-                        <Input
-                            type="number"
-                            value={openingBalance}
-                            prefix="$"
-                            onChange={(e) => setOpeningBalance(e.target.value)}
-                        />
-                    </div>
+                        <FormItem
+                            asterisk
+                            label="Saldo inicial"
+                            invalid={!!errors.openingBalance}
+                            errorMessage={errors.openingBalance?.message}
+                        >
+                            <Input
+                                type="number"
+                                prefix="$"
+                                disabled={isSubmitting}
+                                invalid={!!errors.openingBalance}
+                                {...numberRegister('openingBalance', {
+                                    emptyValue: 0,
+                                })}
+                            />
+                        </FormItem>
 
-                    <div>
-                        <label className="block text-sm font-medium mb-1">
-                            Notas (opcional)
-                        </label>
-                        <Input
-                            value={notes}
-                            placeholder="Notas opcionales"
-                            onChange={(e) => setNotes(e.target.value)}
-                        />
-                    </div>
-                </div>
+                        <FormItem
+                            label="Notas (opcional)"
+                            invalid={!!errors.notes}
+                            errorMessage={errors.notes?.message}
+                        >
+                            <Input
+                                placeholder="Notas opcionales"
+                                disabled={isSubmitting}
+                                invalid={!!errors.notes}
+                                {...register('notes')}
+                            />
+                        </FormItem>
+                    </FormContainer>
 
-                <div className="flex gap-3 mt-8">
-                    <Button
-                        block
-                        variant="default"
-                        onClick={() => navigate('/home')}
-                    >
-                        Volver al Dashboard
-                    </Button>
-                    <Button
-                        block
-                        variant="solid"
-                        loading={openShift.isPending}
-                        disabled={!cashierName}
-                        onClick={handleSubmit}
-                    >
-                        Abrir Turno
-                    </Button>
-                </div>
+                    <div className="flex gap-3 mt-8">
+                        <Button
+                            block
+                            type="button"
+                            variant="default"
+                            onClick={() => navigate('/home')}
+                        >
+                            Volver al Dashboard
+                        </Button>
+                        <Button
+                            block
+                            type="submit"
+                            variant="solid"
+                            loading={openShift.isPending}
+                        >
+                            Abrir Turno
+                        </Button>
+                    </div>
+                </form>
             </div>
         </div>
     )


### PR DESCRIPTION
## Descripción

- Add shiftOpen, cashMovement and serialStatusChange schemas in /src/schemas/
  - Replace useState + manual validation with useForm + zodResolver in all three dialogs
  - Wrap dialog content in <form onSubmit={handleSubmit(...)}> with type=submit buttons
  - CashMovementDialog: keep IN/OUT toggle buttons calling setValue(); use useWatch to read type
  - StatusChangeDialog: replace bare <Select> with <ControlledSelect>; reset() on serialNumber/open change

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
