### PR TITLE
feat(forms): centralize remaining inline schemas to /src/schemas/

### DIFF
--- a/src/schemas/auth.schema.ts
+++ b/src/schemas/auth.schema.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+
+export const signInSchema = z.object({
+    username: z
+        .string()
+        .min(1, 'Ingresa tu usuario')
+        .max(64, 'El usuario es demasiado largo'),
+    password: z
+        .string()
+        .min(1, 'Ingresa tu contraseña')
+        .max(128, 'La contraseña es demasiado larga'),
+})
+
+export type SignInFormValues = z.infer<typeof signInSchema>
+
+export const changePasswordSchema = z
+    .object({
+        currentPassword: z.string().min(1, 'Ingresa tu contraseña actual'),
+        newPassword: z
+            .string()
+            .min(8, 'La nueva contraseña debe tener al menos 8 caracteres')
+            .max(128, 'La contraseña es demasiado larga'),
+        confirmNewPassword: z.string().min(1, 'Confirma tu nueva contraseña'),
+    })
+    .refine((data) => data.confirmNewPassword === data.newPassword, {
+        message: 'Las contraseñas no coinciden',
+        path: ['confirmNewPassword'],
+    })
+
+export type ChangePasswordFormValues = z.infer<typeof changePasswordSchema>
+
+export const resetPasswordSchema = z.object({
+    password: z.string().min(8, 'Mínimo 8 caracteres'),
+})
+
+export type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,4 +1,22 @@
 export { optionalEmail, taxTypeSchema } from './common'
+export {
+    signInSchema,
+    changePasswordSchema,
+    resetPasswordSchema,
+    type SignInFormValues,
+    type ChangePasswordFormValues,
+    type ResetPasswordFormValues,
+} from './auth.schema'
+export {
+    purchaseOrderSchema,
+    type PurchaseOrderFormValues,
+} from './purchaseOrder.schema'
+export {
+    receiveItemSchema,
+    receiveFormSchema,
+    type ReceiveItemFormValues,
+    type ReceiveFormValues,
+} from './receivePurchaseOrder.schema'
 export { categorySchema, type CategoryFormValues } from './category.schema'
 export { productSchema, type ProductFormValues } from './product.schema'
 export { supplierSchema, type SupplierFormValues } from './supplier.schema'

--- a/src/schemas/purchaseOrder.schema.ts
+++ b/src/schemas/purchaseOrder.schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export const purchaseOrderSchema = z.object({
+    supplierId: z
+        .number({ error: 'Selecciona un proveedor' })
+        .int()
+        .positive('Selecciona un proveedor'),
+    notes: z.string().optional(),
+    expectedDate: z.string().optional(),
+})
+
+export type PurchaseOrderFormValues = z.infer<typeof purchaseOrderSchema>

--- a/src/schemas/receivePurchaseOrder.schema.ts
+++ b/src/schemas/receivePurchaseOrder.schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+export const receiveItemSchema = z
+    .object({
+        purchaseOrderItemId: z.number(),
+        productId: z.number(),
+        quantityOrdered: z.number(),
+        quantityReceived: z.number(),
+        quantityPending: z.number(),
+        quantityToReceive: z.number().min(0, 'Mínimo 0'),
+        locationId: z.number().nullable(),
+        lotNumber: z.string(),
+        serialNumbers: z.string(),
+    })
+    .refine((d) => d.quantityToReceive <= d.quantityPending, {
+        message: 'Excede pendiente',
+        path: ['quantityToReceive'],
+    })
+
+export const receiveFormSchema = z
+    .object({
+        items: z.array(receiveItemSchema),
+        notes: z.string(),
+        receivedAt: z.string(),
+    })
+    .refine((d) => d.items.some((i) => i.quantityToReceive > 0), {
+        message: 'Debe recibir al menos un item',
+        path: ['items'],
+    })
+
+export type ReceiveItemFormValues = z.infer<typeof receiveItemSchema>
+export type ReceiveFormValues = z.infer<typeof receiveFormSchema>

--- a/src/views/auth/ChangePassword/ChangePasswordForm.tsx
+++ b/src/views/auth/ChangePassword/ChangePasswordForm.tsx
@@ -9,25 +9,9 @@ import { isApiError } from '@/utils/errors/ApiError'
 import { ROLE } from '@/constants/roles.constant'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
+import { changePasswordSchema, type ChangePasswordFormValues } from '@/schemas'
 import { useNavigate } from 'react-router-dom'
 import appConfig from '@/configs/app.config'
-
-const changePasswordSchema = z
-    .object({
-        currentPassword: z.string().min(1, 'Ingresa tu contraseña actual'),
-        newPassword: z
-            .string()
-            .min(8, 'La nueva contraseña debe tener al menos 8 caracteres')
-            .max(128, 'La contraseña es demasiado larga'),
-        confirmNewPassword: z.string().min(1, 'Confirma tu nueva contraseña'),
-    })
-    .refine((data) => data.confirmNewPassword === data.newPassword, {
-        message: 'Las contraseñas no coinciden',
-        path: ['confirmNewPassword'],
-    })
-
-type ChangePasswordFormValues = z.infer<typeof changePasswordSchema>
 
 const ChangePasswordForm = () => {
     const navigate = useNavigate()

--- a/src/views/auth/SignIn/SignInForm.tsx
+++ b/src/views/auth/SignIn/SignInForm.tsx
@@ -7,25 +7,12 @@ import useTimeOutMessage from '@/utils/hooks/useTimeOutMessage'
 import useAuth from '@/utils/hooks/useAuth'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
+import { signInSchema, type SignInFormValues } from '@/schemas'
 import type { CommonProps } from '@/@types/common'
 
 interface SignInFormProps extends CommonProps {
     disableSubmit?: boolean
 }
-
-const signInSchema = z.object({
-    username: z
-        .string()
-        .min(1, 'Ingresa tu usuario')
-        .max(64, 'El usuario es demasiado largo'),
-    password: z
-        .string()
-        .min(1, 'Ingresa tu contraseña')
-        .max(128, 'La contraseña es demasiado larga'),
-})
-
-type SignInFormValues = z.infer<typeof signInSchema>
 
 const SignInForm = (props: SignInFormProps) => {
     const { disableSubmit = false, className } = props

--- a/src/views/purchases/PurchaseOrderDetailView/ReceiveForm.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/ReceiveForm.tsx
@@ -12,7 +12,7 @@ import { getErrorMessage } from '@/utils/getErrorMessage'
 import { dateToIsoStartOfDay } from '@/utils/dateToIsoStartOfDay'
 import { useForm, useFieldArray, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
+import { receiveFormSchema, type ReceiveFormValues } from '@/schemas'
 import type { PurchaseOrderItem } from '@/services/PurchaseOrderService'
 
 const { Tr, Th, Td, THead, TBody } = Table
@@ -24,36 +24,6 @@ interface ReceiveFormProps {
     items: PurchaseOrderItem[]
     getProductName: (productId: number) => string
 }
-
-const receiveItemSchema = z
-    .object({
-        purchaseOrderItemId: z.number(),
-        productId: z.number(),
-        quantityOrdered: z.number(),
-        quantityReceived: z.number(),
-        quantityPending: z.number(),
-        quantityToReceive: z.number().min(0, 'Mínimo 0'),
-        locationId: z.number().nullable(),
-        lotNumber: z.string(),
-        serialNumbers: z.string(),
-    })
-    .refine((d) => d.quantityToReceive <= d.quantityPending, {
-        message: 'Excede pendiente',
-        path: ['quantityToReceive'],
-    })
-
-const receiveFormSchema = z
-    .object({
-        items: z.array(receiveItemSchema),
-        notes: z.string(),
-        receivedAt: z.string(),
-    })
-    .refine((d) => d.items.some((i) => i.quantityToReceive > 0), {
-        message: 'Debe recibir al menos un item',
-        path: ['items'],
-    })
-
-type ReceiveFormValues = z.infer<typeof receiveFormSchema>
 
 const ReceiveForm = ({
     open,

--- a/src/views/purchases/PurchaseOrdersView/PurchaseOrderForm.tsx
+++ b/src/views/purchases/PurchaseOrdersView/PurchaseOrderForm.tsx
@@ -12,24 +12,13 @@ import { getErrorMessage } from '@/utils/getErrorMessage'
 import { dateToIsoStartOfDay } from '@/utils/dateToIsoStartOfDay'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
+import { purchaseOrderSchema, type PurchaseOrderFormValues } from '@/schemas'
 
 interface PurchaseOrderFormProps {
     open: boolean
     onClose: () => void
     onCreated?: (id: number) => void
 }
-
-const purchaseOrderFormSchema = z.object({
-    supplierId: z
-        .number({ error: 'Selecciona un proveedor' })
-        .int()
-        .positive('Selecciona un proveedor'),
-    notes: z.string().optional(),
-    expectedDate: z.string().optional(),
-})
-
-type PurchaseOrderFormValues = z.infer<typeof purchaseOrderFormSchema>
 
 const PurchaseOrderForm = ({
     open,
@@ -51,7 +40,7 @@ const PurchaseOrderForm = ({
         reset,
         formState: { errors, isSubmitting },
     } = useForm<PurchaseOrderFormValues>({
-        resolver: zodResolver(purchaseOrderFormSchema),
+        resolver: zodResolver(purchaseOrderSchema),
         defaultValues: {
             supplierId: 0,
             notes: '',

--- a/src/views/settings/UsersView/ResetPasswordModal.tsx
+++ b/src/views/settings/UsersView/ResetPasswordModal.tsx
@@ -8,7 +8,7 @@ import { useResetUserPassword } from '@/hooks/useAdminUsers'
 import { getErrorMessage } from '@/utils/getErrorMessage'
 import { useForm, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
+import { resetPasswordSchema, type ResetPasswordFormValues } from '@/schemas'
 import type { AdminUserResponse } from '@/@types/auth'
 
 interface ResetPasswordModalProps {
@@ -23,12 +23,6 @@ const generatePassword = () =>
     Array.from(crypto.getRandomValues(new Uint8Array(12)))
         .map((b) => CHARS[b % CHARS.length])
         .join('')
-
-const resetPasswordSchema = z.object({
-    password: z.string().min(8, 'Mínimo 8 caracteres'),
-})
-
-type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>
 
 const ResetPasswordModal = ({
     open,


### PR DESCRIPTION
## Descripción

  Extract auth, purchaseOrder and receivePurchaseOrder schemas from their view files into /src/schemas/. All forms now import schemas from the central index; zero
   z.object() declarations remain inline in views.

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
