### PR TITLE
fix(lint): fix TS errors and eliminate set-state-in-effect warnings

### DIFF
--- a/src/components/template/VerticalMenuContent/VerticalMenuContent.tsx
+++ b/src/components/template/VerticalMenuContent/VerticalMenuContent.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import Menu from '@/components/ui/Menu'
 import AuthorityCheck from '@/components/shared/AuthorityCheck'
 import VerticalSingleMenuItem from './VerticalSingleMenuItem'
@@ -39,16 +39,11 @@ const VerticalMenuContent = (props: VerticalMenuContentProps) => {
 
     const { t } = useTranslation()
 
-    const [defaulExpandKey, setDefaulExpandKey] = useState<string[]>([])
-
     const { activedRoute } = useMenuActive(navigationTree, routeKey)
 
-    useEffect(() => {
-        if (defaulExpandKey.length === 0 && activedRoute?.parentKey) {
-            setDefaulExpandKey([activedRoute?.parentKey])
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [activedRoute?.parentKey])
+    const [defaulExpandKey] = useState<string[]>(() =>
+        activedRoute?.parentKey ? [activedRoute.parentKey] : []
+    )
 
     const handleLinkClick = () => {
         onMenuItemClick?.()

--- a/src/components/ui/Menu/MenuCollapse.tsx
+++ b/src/components/ui/Menu/MenuCollapse.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useContext } from 'react'
+import { useContext } from 'react'
 import { useConfig } from '../ConfigProvider'
+import useControllableState from '../hooks/useControllableState'
 import { CollapseContextProvider } from './context/collapseContext'
 import classNames from 'classnames'
 import { motion } from 'framer-motion'
@@ -20,27 +21,22 @@ const MenuCollapse = (props: MenuCollapseProps) => {
         children,
         className,
         eventKey,
-        expanded = false,
+        expanded,
         label = null,
         onToggle,
     } = props
-
-    const [isExpanded, setIsExpanded] = useState(expanded)
 
     const { variant, sideCollapsed, defaultExpandedKeys } =
         useContext(MenuContext)
 
     const { direction } = useConfig()
 
-    useEffect(() => {
-        if ((defaultExpandedKeys as string[]).includes(eventKey as string)) {
-            setIsExpanded(true)
-        }
-        if (expanded !== isExpanded) {
-            setIsExpanded(true)
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [expanded, onToggle, eventKey, defaultExpandedKeys])
+    const [isExpanded, setIsExpanded] = useControllableState({
+        prop: expanded,
+        defaultProp:
+            (defaultExpandedKeys as string[])?.includes(eventKey as string) ||
+            false,
+    })
 
     const toggleCollapse = (e: MouseEvent<HTMLDivElement>) => {
         if (typeof onToggle === 'function') {
@@ -76,7 +72,7 @@ const MenuCollapse = (props: MenuCollapseProps) => {
                     {sideCollapsed ? null : <HiChevronDown />}
                 </motion.span>
             </div>
-            <CollapseContextProvider value={isExpanded}>
+            <CollapseContextProvider value={isExpanded ?? false}>
                 <motion.ul
                     className={direction === 'rtl' ? 'mr-5' : 'ml-5'}
                     initial={{ opacity: 0, height: 0, overflow: 'hidden' }}

--- a/src/components/ui/Pagination/Pagers.tsx
+++ b/src/components/ui/Pagination/Pagers.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import classNames from 'classnames'
 import {
     HiOutlineChevronDoubleLeft,
@@ -78,28 +78,15 @@ type PagersProps = {
 const Pagers = (props: PagersProps) => {
     const { pageCount, currentPage, onChange, pagerClass } = props
 
-    const [showPrevMore, setShowPrevMore] = useState(false)
-    const [showNextMore, setShowNextMore] = useState(false)
-
-    useEffect(() => {
-        if (pageCount > PAGER_COUNT) {
-            if (currentPage > PAGER_COUNT - 2) {
-                setShowPrevMore(true)
-            }
-            if (currentPage < pageCount - 2) {
-                setShowNextMore(true)
-            }
-            if (currentPage >= pageCount - 3 && currentPage <= pageCount) {
-                setShowNextMore(false)
-            }
-            if (currentPage >= 1 && currentPage <= 4) {
-                setShowPrevMore(false)
-            }
-        } else {
-            setShowPrevMore(false)
-            setShowNextMore(false)
-        }
-    }, [currentPage, pageCount])
+    let showPrevMore = false
+    let showNextMore = false
+    if (pageCount > PAGER_COUNT) {
+        if (currentPage > PAGER_COUNT - 2) showPrevMore = true
+        if (currentPage < pageCount - 2) showNextMore = true
+        if (currentPage >= pageCount - 3 && currentPage <= pageCount)
+            showNextMore = false
+        if (currentPage >= 1 && currentPage <= 4) showPrevMore = false
+    }
 
     const onPagerClick = (
         value: number,

--- a/src/components/ui/Pagination/Pagination.tsx
+++ b/src/components/ui/Pagination/Pagination.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useMemo, useCallback } from 'react'
+import useControllableState from '../hooks/useControllableState'
 import Pager from './Pagers'
 import Prev from './Prev'
 import Next from './Next'
@@ -25,17 +26,14 @@ const Pagination = (props: PaginationProps) => {
         total = 5,
     } = props
 
-    const [paginationTotal, setPaginationTotal] = useState(total)
-    const [internalPageSize, setInternalPageSize] = useState(pageSize)
-
     const { themeColor, primaryColorLevel } = useConfig()
 
     const getInternalPageCount = useMemo(() => {
-        if (typeof paginationTotal === 'number') {
-            return Math.ceil(paginationTotal / internalPageSize)
+        if (typeof total === 'number') {
+            return Math.ceil(total / pageSize)
         }
         return null
-    }, [paginationTotal, internalPageSize])
+    }, [total, pageSize])
 
     const getValidCurrentPage = useCallback(
         (count: number | string) => {
@@ -67,41 +65,26 @@ const Pagination = (props: PaginationProps) => {
         [getInternalPageCount]
     )
 
-    const [internalCurrentPage, setInternalCurrentPage] = useState(
-        currentPage ? getValidCurrentPage(currentPage) : 1
-    )
-
-    useEffect(() => {
-        if (total !== paginationTotal) {
-            setPaginationTotal(total)
-        }
-
-        if (pageSize !== internalPageSize) {
-            setInternalPageSize(pageSize)
-        }
-
-        if (currentPage !== internalCurrentPage) {
-            setInternalCurrentPage(currentPage)
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [total, pageSize, currentPage])
+    const [internalCurrentPage, setInternalCurrentPage] =
+        useControllableState<number>({
+            prop: currentPage,
+            defaultProp: getValidCurrentPage(currentPage),
+            onChange,
+        })
 
     const onPaginationChange = (val: number) => {
         setInternalCurrentPage(getValidCurrentPage(val))
-        onChange?.(getValidCurrentPage(val))
     }
 
     const onPrev = useCallback(() => {
-        const newPage = internalCurrentPage - 1
+        const newPage = (internalCurrentPage ?? 1) - 1
         setInternalCurrentPage(getValidCurrentPage(newPage))
-        onChange?.(getValidCurrentPage(newPage))
-    }, [onChange, internalCurrentPage, getValidCurrentPage])
+    }, [internalCurrentPage, getValidCurrentPage, setInternalCurrentPage])
 
     const onNext = useCallback(() => {
-        const newPage = internalCurrentPage + 1
+        const newPage = (internalCurrentPage ?? 1) + 1
         setInternalCurrentPage(getValidCurrentPage(newPage))
-        onChange?.(getValidCurrentPage(newPage))
-    }, [onChange, internalCurrentPage, getValidCurrentPage])
+    }, [internalCurrentPage, getValidCurrentPage, setInternalCurrentPage])
 
     const pagerClass = {
         default: 'pagination-pager',
@@ -116,18 +99,18 @@ const Pagination = (props: PaginationProps) => {
         <div className={paginationClass}>
             {displayTotal && <Total total={total} />}
             <Prev
-                currentPage={internalCurrentPage}
+                currentPage={internalCurrentPage ?? 1}
                 pagerClass={pagerClass}
                 onPrev={onPrev}
             />
             <Pager
                 pageCount={getInternalPageCount as number}
-                currentPage={internalCurrentPage}
+                currentPage={internalCurrentPage ?? 1}
                 pagerClass={pagerClass}
                 onChange={onPaginationChange}
             />
             <Next
-                currentPage={internalCurrentPage}
+                currentPage={internalCurrentPage ?? 1}
                 pageCount={getInternalPageCount as number}
                 pagerClass={pagerClass}
                 onNext={onNext}

--- a/src/components/ui/hooks/useUncertainRef.ts
+++ b/src/components/ui/hooks/useUncertainRef.ts
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
-import type { ForwardedRef } from 'react'
+import type { Ref } from 'react'
 
-export default function useUncertainRef<T = unknown>(ref: ForwardedRef<T>) {
+export default function useUncertainRef<T = unknown>(ref: Ref<T> | undefined) {
     const newRef = useRef<T>(null)
 
     if (ref) {

--- a/src/utils/deepParseJson.ts
+++ b/src/utils/deepParseJson.ts
@@ -11,7 +11,7 @@ function deepParseJson(jsonString: Json): Json {
         }
         try {
             return deepParseJson(JSON.parse(jsonString))
-        } catch (err) {
+        } catch {
             return jsonString
         }
     } else if (Array.isArray(jsonString)) {

--- a/src/views/settings/CertificatesView/index.tsx
+++ b/src/views/settings/CertificatesView/index.tsx
@@ -237,7 +237,9 @@ const CertificatesView = () => {
                     <h5 className="mb-4">Subir Certificado Digital</h5>
                     <form
                         className="flex-1"
-                        onSubmit={handleSubmit(onUploadSubmit)}
+                        onSubmit={(e) => {
+                            void handleSubmit(onUploadSubmit)(e)
+                        }}
                     >
                         <div className="space-y-4">
                             <FormItem


### PR DESCRIPTION
## Descripción

  Fix ForwardedRef → Ref<T>|undefined in useUncertainRef (2 TS errors);
  optional catch binding in deepParseJson; defer handleSubmit call in
  CertificatesView to avoid ref-during-render warning. Convert useState+
  useEffect sync patterns to pure derived state (Pagers), lazy initializer
  (VerticalMenuContent), and useControllableState (MenuCollapse, Pagination)

## Tipo de cambio

- [x] 🐛 Bug fix
- [ ] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
