### PR TITLE
fix(lint): eliminate set-state-in-effect warnings in UI primitives

### DIFF
--- a/src/components/ui/Checkbox/Checkbox.tsx
+++ b/src/components/ui/Checkbox/Checkbox.tsx
@@ -17,8 +17,6 @@ export interface CheckboxProps extends CommonProps {
     readOnly?: boolean
     ref?: Ref<HTMLInputElement>
     value?: CheckboxValue
-    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-    field?: any
 }
 
 const Checkbox = (props: CheckboxProps) => {
@@ -42,7 +40,6 @@ const Checkbox = (props: CheckboxProps) => {
         checked: controlledChecked,
         labelRef,
         ref,
-        field,
         ...rest
     } = props
 
@@ -58,28 +55,14 @@ const Checkbox = (props: CheckboxProps) => {
     const [checkboxChecked, setCheckboxChecked] = useState(isChecked())
 
     const getControlProps = () => {
-        let checkedValue = checkboxChecked
-
-        let groupChecked = { checked: checkedValue }
-        let singleChecked: {
-            value: boolean
+        let groupChecked = { checked: checkboxChecked }
+        const singleChecked: {
             defaultChecked?: boolean
             checked?: boolean
-        } = {
-            value: checkedValue as boolean,
-        }
+        } = {}
 
         if (typeof controlledChecked !== 'undefined') {
             singleChecked.checked = controlledChecked
-        }
-
-        if (field) {
-            checkedValue =
-                typeof field.value === 'boolean' ? field.value : defaultChecked
-            singleChecked = {
-                value: checkedValue as boolean,
-                checked: checkedValue,
-            }
         }
 
         if (typeof groupValue !== 'undefined') {
@@ -149,7 +132,6 @@ const Checkbox = (props: CheckboxProps) => {
                 name={name}
                 onChange={onCheckboxChange}
                 {...controlProps}
-                {...field}
                 {...rest}
             />
             {children ? (

--- a/src/components/ui/Checkbox/Group.tsx
+++ b/src/components/ui/Checkbox/Group.tsx
@@ -1,9 +1,10 @@
-import { useState, useCallback, useMemo, useEffect } from 'react'
+import { useCallback, useMemo } from 'react'
 import classNames from 'classnames'
 import { CheckboxGroupContextProvider } from './context'
 import cloneDeep from 'lodash/cloneDeep'
 import remove from 'lodash/remove'
 import shallowEqual from '../utils/shallowEqual'
+import useControllableState from '../hooks/useControllableState'
 import type { CommonProps } from '../@types/common'
 import type { CheckboxGroupValue, CheckboxValue } from './context'
 import type { Ref, SyntheticEvent } from 'react'
@@ -30,7 +31,10 @@ const Group = (props: CheckboxGroupProps) => {
         ...rest
     } = props
 
-    const [value, setValue] = useState(valueProp)
+    const [value, setValue] = useControllableState<CheckboxGroupValue>({
+        prop: valueProp,
+        defaultProp: [],
+    })
 
     const onCheckboxGroupChange = useCallback(
         (
@@ -50,10 +54,6 @@ const Group = (props: CheckboxGroupProps) => {
         },
         [onChange, setValue, value]
     )
-
-    useEffect(() => {
-        setValue(valueProp)
-    }, [valueProp])
 
     const checkboxGroupDefaultClass = `inline-flex ${
         vertical ? 'flex-col gap-y-2' : ''

--- a/src/components/ui/Radio/Radio.tsx
+++ b/src/components/ui/Radio/Radio.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useContext, useCallback, useEffect } from 'react'
+import { useMemo, useContext, useCallback } from 'react'
 import classNames from 'classnames'
 import RadioGroupContext from './context'
 import { useConfig } from '../ConfigProvider'
@@ -21,8 +21,6 @@ export interface RadioProps
     value?: any
     vertical?: boolean
     readOnly?: boolean
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    field?: any
 }
 
 const Radio = (props: RadioProps) => {
@@ -43,7 +41,6 @@ const Radio = (props: RadioProps) => {
         color,
         defaultChecked,
         disabled = disabledContext,
-        field,
         labelRef,
         name = nameContext,
         onChange,
@@ -62,7 +59,7 @@ const Radio = (props: RadioProps) => {
             : checkedProp
     }
 
-    const [radioChecked, setRadioChecked] = useState(getChecked())
+    const radioChecked = getChecked()
 
     const radioColor =
         color || colorContext || `${themeColor}-${primaryColorLevel}`
@@ -83,25 +80,8 @@ const Radio = (props: RadioProps) => {
             onGroupChange?.(value, e)
             onChange?.(value, e)
         },
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [
-            disabled,
-            setRadioChecked,
-            onChange,
-            value,
-            onGroupChange,
-            groupValue,
-            readOnly,
-        ]
+        [disabled, onChange, value, onGroupChange, readOnly]
     )
-
-    useEffect(() => {
-        const propChecked = getChecked()
-        if (radioChecked !== propChecked) {
-            setRadioChecked(propChecked)
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [value, checkedProp, groupValue])
 
     const radioDefaultClass = `radio text-${radioColor}`
     const radioColorClass = disabled && 'disabled'
@@ -128,7 +108,6 @@ const Radio = (props: RadioProps) => {
                 readOnly={readOnly}
                 onChange={onRadioChange}
                 {...controlProps}
-                {...field}
                 {...rest}
             />
             {children ? (

--- a/src/components/ui/Switcher/Switcher.tsx
+++ b/src/components/ui/Switcher/Switcher.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react'
 import classNames from 'classnames'
 import { Spinner } from '../Spinner'
 import { useConfig } from '../ConfigProvider'
+import useControllableState from '../hooks/useControllableState'
 import type { CommonProps } from '../@types/common'
 import type { ReactNode, ChangeEvent, Ref } from 'react'
 
@@ -18,8 +18,6 @@ export interface SwitcherProps extends CommonProps {
     readOnly?: boolean
     ref?: Ref<HTMLInputElement>
     unCheckedContent?: string | ReactNode
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    field?: any
 }
 
 const Switcher = (props: SwitcherProps) => {
@@ -37,67 +35,30 @@ const Switcher = (props: SwitcherProps) => {
         readOnly,
         ref,
         unCheckedContent,
-        field,
         ...rest
     } = props
 
     const { themeColor, primaryColorLevel } = useConfig()
 
-    const [switcherChecked, setSwitcherChecked] = useState(
-        defaultChecked || checked
+    const [switcherChecked, setSwitcherChecked] = useControllableState<boolean>(
+        {
+            prop: checked,
+            defaultProp: defaultChecked ?? false,
+        }
     )
 
-    useEffect(() => {
-        if (typeof checked !== 'undefined') {
-            setSwitcherChecked(checked)
-        }
-    }, [checked])
-
-    const getControlProps = () => {
-        let checkedValue = switcherChecked
-
-        let checked: {
-            value?: boolean
-            defaultChecked?: boolean
-            checked?: boolean
-        } = {
-            value: checkedValue,
-        }
-
-        if (field) {
-            checkedValue =
-                typeof field.value === 'boolean' ? field.value : defaultChecked
-            checked = { value: checkedValue, checked: checkedValue }
-        }
-
-        if (defaultChecked) {
-            checked.defaultChecked = defaultChecked
-        }
-        return checked
-    }
-
-    const controlProps = getControlProps()
-
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        if (disabled || readOnly || isLoading) return
         const nextChecked = !switcherChecked
-
-        if (disabled || readOnly || isLoading) {
-            return
-        }
-
-        if (typeof checked === 'undefined') {
-            setSwitcherChecked(nextChecked)
-            onChange?.(nextChecked, e)
-        } else {
-            onChange?.(nextChecked, e)
-        }
+        setSwitcherChecked(nextChecked)
+        onChange?.(nextChecked, e)
     }
 
     const switcherColor = color || `${themeColor}-${primaryColorLevel}`
 
     const switcherClass = classNames(
         'switcher',
-        (switcherChecked || controlProps.checked) &&
+        switcherChecked &&
             `switcher-checked bg-${switcherColor} dark:bg-${switcherColor}`,
         disabled && 'switcher-disabled',
         className
@@ -111,9 +72,8 @@ const Switcher = (props: SwitcherProps) => {
                 disabled={disabled}
                 readOnly={readOnly}
                 name={name}
+                checked={switcherChecked ?? false}
                 onChange={handleChange}
-                {...controlProps}
-                {...field}
                 {...rest}
             />
             {isLoading ? (

--- a/src/components/ui/Upload/Upload.tsx
+++ b/src/components/ui/Upload/Upload.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useEffect } from 'react'
+import { useRef, useState, useCallback } from 'react'
 import classNames from 'classnames'
 import { useConfig } from '../ConfigProvider'
 import cloneDeep from 'lodash/cloneDeep'
@@ -7,6 +7,7 @@ import Button from '../Button/Button'
 import CloseButton from '../CloseButton'
 import Notification from '../Notification/Notification'
 import toast from '../toast/toast'
+import useControllableState from '../hooks/useControllableState'
 import type { CommonProps } from '../@types/common'
 import type { ReactNode, ChangeEvent, MouseEvent, Ref } from 'react'
 
@@ -23,8 +24,6 @@ export interface UploadProps extends CommonProps {
     showList?: boolean
     tip?: string | ReactNode
     uploadLimit?: number
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    field?: any
 }
 
 const filesToArray = (files: File[]) =>
@@ -37,7 +36,7 @@ const Upload = (props: UploadProps) => {
         beforeUpload,
         disabled = false,
         draggable = false,
-        fileList = [],
+        fileList,
         multiple,
         onChange,
         onFileRemove,
@@ -47,22 +46,19 @@ const Upload = (props: UploadProps) => {
         uploadLimit,
         children,
         className,
-        field,
         ...rest
     } = props
 
     const fileInputField = useRef<HTMLInputElement>(null)
-    const [files, setFiles] = useState(fileList)
+    const [files, setFiles] = useControllableState<File[]>({
+        prop: fileList,
+        defaultProp: [],
+    })
     const [dragOver, setDragOver] = useState(false)
 
     const { themeColor, primaryColorLevel } = useConfig()
 
-    useEffect(() => {
-        if (JSON.stringify(files) !== JSON.stringify(fileList)) {
-            setFiles(fileList)
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [fileList])
+    const safeFiles = files ?? []
 
     const triggerMessage = (msg: string | ReactNode = '') => {
         toast.push(
@@ -86,7 +82,7 @@ const Upload = (props: UploadProps) => {
     }
 
     const addNewFiles = (newFiles: FileList | null) => {
-        let file = cloneDeep(files)
+        let file = cloneDeep(safeFiles)
         if (typeof uploadLimit === 'number' && uploadLimit !== 0) {
             if (Object.keys(file).length >= uploadLimit) {
                 if (uploadLimit === 1) {
@@ -106,7 +102,7 @@ const Upload = (props: UploadProps) => {
         let result: boolean | string = true
 
         if (beforeUpload) {
-            result = beforeUpload(newFiles, files)
+            result = beforeUpload(newFiles, safeFiles)
 
             if (result === false) {
                 triggerMessage()
@@ -122,12 +118,14 @@ const Upload = (props: UploadProps) => {
         if (result) {
             const updatedFiles = addNewFiles(newFiles)
             setFiles(updatedFiles)
-            onChange?.(updatedFiles, files)
+            onChange?.(updatedFiles, safeFiles)
         }
     }
 
     const removeFile = (fileIndex: number) => {
-        const deletedFileList = files.filter((_, index) => index !== fileIndex)
+        const deletedFileList = safeFiles.filter(
+            (_, index) => index !== fileIndex
+        )
         setFiles(deletedFileList)
         onFileRemove?.(deletedFileList)
     }
@@ -213,7 +211,6 @@ const Upload = (props: UploadProps) => {
                     title=""
                     value=""
                     onChange={onNewFileUpload}
-                    {...field}
                     {...rest}
                 ></input>
                 {renderChildren()}
@@ -221,7 +218,7 @@ const Upload = (props: UploadProps) => {
             {tip}
             {showList && (
                 <div className="upload-file-list">
-                    {files.map((file, index) => (
+                    {safeFiles.map((file, index) => (
                         <FileItem key={file.name + index} file={file}>
                             <CloseButton
                                 className="upload-file-remove"


### PR DESCRIPTION
## Descripción

  Remove legacy  prop from Switcher, Checkbox, Radio and Upload
  (zero consumers in views). Migrate state sync patterns: Switcher and
  Upload use useControllableState, CheckboxGroup replaces its useEffect
  with useControllableState, Radio becomes stateless (radioChecked
  computed each render instead of stored in useState)

## Tipo de cambio

- [x] 🐛 Bug fix
- [ ] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
