### PR TITLE
fix(lint): eliminate set-state-in-effect warnings in DatePicker and view components

### DIFF
--- a/src/components/ui/DatePicker/DatePicker.tsx
+++ b/src/components/ui/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef } from 'react'
 import dayjs from 'dayjs'
 import useControllableState from '../hooks/useControllableState'
 import useMergedRef from '../hooks/useMergeRef'
@@ -118,6 +118,12 @@ const DatePicker = (props: DatePickerProps) => {
             : ''
     )
 
+    const displayValue = focused
+        ? inputState
+        : _value instanceof Date
+        ? capitalize(dayjs(_value).locale(finalLocale).format(dateFormat))
+        : ''
+
     const closeDropdown = () => {
         setDropdownOpened(false)
         onDropdownClose?.()
@@ -127,28 +133,6 @@ const DatePicker = (props: DatePickerProps) => {
         setDropdownOpened(true)
         onDropdownOpen?.()
     }
-
-    useEffect(() => {
-        if (value === null && !focused) {
-            setInputState('')
-        }
-
-        if (value instanceof Date && !focused) {
-            setInputState(
-                capitalize(dayjs(value).locale(finalLocale).format(dateFormat))
-            )
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [value, focused, themeLocale])
-
-    useEffect(() => {
-        if (defaultValue instanceof Date && inputState && !focused) {
-            setInputState(
-                capitalize(dayjs(_value).locale(finalLocale).format(dateFormat))
-            )
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [themeLocale])
 
     const handleValueChange = (date: Date | null) => {
         setValue(date)
@@ -238,7 +222,7 @@ const DatePicker = (props: DatePickerProps) => {
             style={style}
             className={className}
             name={name}
-            inputLabel={inputState}
+            inputLabel={displayValue}
             clearable={
                 type === 'date' ? false : clearable && !!_value && !disabled
             }

--- a/src/components/ui/DatePicker/DateTimepicker.tsx
+++ b/src/components/ui/DatePicker/DateTimepicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import dayjs from 'dayjs'
 import useControllableState from '../hooks/useControllableState'
 import useMergedRef from '../hooks/useMergeRef'
@@ -115,6 +115,12 @@ const DateTimepicker = (props: DateTimepickerProps) => {
             : ''
     )
 
+    const displayValue = focused
+        ? inputState
+        : _value instanceof Date
+        ? dayjs(_value).locale(finalLocale).format(dateFormat)
+        : ''
+
     const closeDropdown = () => {
         setDropdownOpened(false)
         onDropdownClose?.()
@@ -124,17 +130,6 @@ const DateTimepicker = (props: DateTimepickerProps) => {
         setDropdownOpened(true)
         onDropdownOpen?.()
     }
-
-    useEffect(() => {
-        if (value === null && !focused) {
-            setInputState('')
-        }
-
-        if (value instanceof Date && !focused) {
-            setInputState(dayjs(value).locale(finalLocale).format(dateFormat))
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [value, focused])
 
     const handleValueChange = (date: Date) => {
         if (_value) {
@@ -244,7 +239,7 @@ const DateTimepicker = (props: DateTimepickerProps) => {
             setDropdownOpened={setDropdownOpened}
             className={className}
             name={name}
-            inputLabel={inputState}
+            inputLabel={displayValue}
             clearable={clearable && !!_value && !disabled}
             disabled={disabled}
             size={size}

--- a/src/utils/generatePassword.ts
+++ b/src/utils/generatePassword.ts
@@ -1,0 +1,8 @@
+const CHARS = 'ABCDEFGHJKMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#%'
+
+const generatePassword = () =>
+    Array.from(crypto.getRandomValues(new Uint8Array(12)))
+        .map((b) => CHARS[b % CHARS.length])
+        .join('')
+
+export default generatePassword

--- a/src/views/pos/components/DiscountDialog.tsx
+++ b/src/views/pos/components/DiscountDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import Dialog from '@/components/ui/Dialog'
 import Button from '@/components/ui/Button'
 import Input from '@/components/ui/Input'
@@ -24,20 +24,23 @@ const DiscountDialog = ({ isOpen, onClose }: DiscountDialogProps) => {
         clearDiscount,
     } = usePOSStore()
 
-    const [type, setType] = useState<DiscountType>('PERCENTAGE')
-    const [value, setValue] = useState<string>('')
-
     const hasExistingDiscount = currentType !== null && currentValue > 0
 
-    useEffect(() => {
-        if (isOpen && currentType !== null && currentValue > 0) {
-            setType(currentType)
-            setValue(currentValue.toString())
-        } else if (isOpen) {
-            setType('PERCENTAGE')
-            setValue('')
+    const [type, setType] = useState<DiscountType>(() =>
+        isOpen && hasExistingDiscount ? currentType! : 'PERCENTAGE'
+    )
+    const [value, setValue] = useState<string>(() =>
+        isOpen && hasExistingDiscount ? currentValue.toString() : ''
+    )
+
+    const [prevIsOpen, setPrevIsOpen] = useState(isOpen)
+    if (prevIsOpen !== isOpen) {
+        setPrevIsOpen(isOpen)
+        if (isOpen) {
+            setType(hasExistingDiscount ? currentType! : 'PERCENTAGE')
+            setValue(hasExistingDiscount ? currentValue.toString() : '')
         }
-    }, [isOpen, currentType, currentValue])
+    }
 
     const numValue = Number(value) || 0
 

--- a/src/views/pos/components/SearchBar.tsx
+++ b/src/views/pos/components/SearchBar.tsx
@@ -16,6 +16,7 @@ const SearchBar = () => {
     }, [localTerm, setSearchTerm])
 
     useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setLocalTerm(searchTerm)
     }, [searchTerm])
 

--- a/src/views/settings/UsersView/ResetPasswordModal.tsx
+++ b/src/views/settings/UsersView/ResetPasswordModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import Dialog from '@/components/ui/Dialog'
 import Button from '@/components/ui/Button'
 import Input from '@/components/ui/Input'
@@ -6,6 +6,7 @@ import Notification from '@/components/ui/Notification'
 import toast from '@/components/ui/toast'
 import { useResetUserPassword } from '@/hooks/useAdminUsers'
 import { getErrorMessage } from '@/utils/getErrorMessage'
+import generatePassword from '@/utils/generatePassword'
 import { useForm, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { resetPasswordSchema, type ResetPasswordFormValues } from '@/schemas'
@@ -15,19 +16,14 @@ interface ResetPasswordModalProps {
     open: boolean
     onClose: () => void
     user: AdminUserResponse | null
+    defaultPassword: string
 }
-
-const CHARS = 'ABCDEFGHJKMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#%'
-
-const generatePassword = () =>
-    Array.from(crypto.getRandomValues(new Uint8Array(12)))
-        .map((b) => CHARS[b % CHARS.length])
-        .join('')
 
 const ResetPasswordModal = ({
     open,
     user,
     onClose,
+    defaultPassword,
 }: ResetPasswordModalProps) => {
     const [done, setDone] = useState(false)
     const resetPassword = useResetUserPassword()
@@ -37,21 +33,13 @@ const ResetPasswordModal = ({
         handleSubmit,
         control,
         setValue,
-        reset,
         formState: { errors },
     } = useForm<ResetPasswordFormValues>({
         resolver: zodResolver(resetPasswordSchema),
-        defaultValues: { password: '' },
+        defaultValues: { password: defaultPassword },
     })
 
     const password = useWatch({ control, name: 'password' })
-
-    useEffect(() => {
-        if (open) {
-            reset({ password: generatePassword() })
-            setDone(false)
-        }
-    }, [open, reset])
 
     const handleClose = () => {
         if (!resetPassword.isPending) {

--- a/src/views/settings/UsersView/index.tsx
+++ b/src/views/settings/UsersView/index.tsx
@@ -20,6 +20,7 @@ import { HiPlus } from 'react-icons/hi'
 import { useCrudOperations } from '@/hooks'
 import CreateUserModal from './CreateUserModal'
 import ResetPasswordModal from './ResetPasswordModal'
+import generatePassword from '@/utils/generatePassword'
 
 const roleOptions = ALL_ROLES.map((role) => ({
     value: role,
@@ -52,9 +53,11 @@ const UsersView = () => {
     const [resetDialog, setResetDialog] = useState<{
         open: boolean
         user: AdminUserResponse | null
+        defaultPassword: string
     }>({
         open: false,
         user: null,
+        defaultPassword: '',
     })
     const [deactivateDialog, setDeactivateDialog] = useState<{
         open: boolean
@@ -236,7 +239,13 @@ const UsersView = () => {
                         <Button
                             size="xs"
                             variant="plain"
-                            onClick={() => setResetDialog({ open: true, user })}
+                            onClick={() =>
+                                setResetDialog({
+                                    open: true,
+                                    user,
+                                    defaultPassword: generatePassword(),
+                                })
+                            }
                         >
                             Resetear
                         </Button>
@@ -345,11 +354,20 @@ const UsersView = () => {
 
             <CreateUserModal open={crud.isCreateOpen} onClose={crud.closeAll} />
 
-            <ResetPasswordModal
-                open={resetDialog.open}
-                user={resetDialog.user}
-                onClose={() => setResetDialog({ open: false, user: null })}
-            />
+            {resetDialog.open && (
+                <ResetPasswordModal
+                    open={resetDialog.open}
+                    user={resetDialog.user}
+                    defaultPassword={resetDialog.defaultPassword}
+                    onClose={() =>
+                        setResetDialog({
+                            open: false,
+                            user: null,
+                            defaultPassword: '',
+                        })
+                    }
+                />
+            )}
 
             <ConfirmDialog
                 isOpen={deactivateDialog.open}


### PR DESCRIPTION
## Descripción

  DatePicker / DateTimepicker: replace two useEffect blocks that synced
  inputState ← value with a computed displayValue (focused ? inputState :
  derivedFromValue), eliminating the anti-pattern without changing UX.

  DiscountDialog: drop useEffect in favor of setState during render
  pattern (prevIsOpen guard) to re-initialize local state on each open, preserving
  Dialog animations. SearchBar: add eslint-disable for the intentional
  reverse-sync effect (debounce + store reset are both legitimate). ResetPasswordModal:
  extract generatePassword to src/utils/, accept defaultPassword as prop initialised
  by the parent at open-time, use mount-conditional rendering so useState(false)
  replaces the setDone effect on its own.

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
