### PR TITLE
feat(arch): split fat detail views into sub-components

### DIFF
--- a/src/views/inventory/AdjustmentDetailView/AdjustmentHeader.tsx
+++ b/src/views/inventory/AdjustmentDetailView/AdjustmentHeader.tsx
@@ -1,0 +1,86 @@
+import Button from '@/components/ui/Button'
+import Badge from '@/components/ui/Badge'
+import {
+    HiOutlineArrowLeft,
+    HiOutlinePencil,
+    HiOutlineTrash,
+    HiOutlineCheck,
+    HiOutlineX,
+} from 'react-icons/hi'
+import {
+    ADJUSTMENT_STATUS_LABELS,
+    ADJUSTMENT_STATUS_CLASSES,
+} from '@/services/AdjustmentService'
+import type { Adjustment } from '@/services/AdjustmentService'
+
+type Props = {
+    adjustment: Adjustment
+    isDraft: boolean
+    onBack: () => void
+    onEdit: () => void
+    onConfirm: () => void
+    onCancel: () => void
+    onDelete: () => void
+}
+
+export const AdjustmentHeader = ({
+    adjustment,
+    isDraft,
+    onBack,
+    onEdit,
+    onConfirm,
+    onCancel,
+    onDelete,
+}: Props) => (
+    <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+            <Button
+                variant="plain"
+                icon={<HiOutlineArrowLeft />}
+                onClick={onBack}
+            />
+            <h3>Ajuste #{adjustment.id}</h3>
+            <Badge
+                content={ADJUSTMENT_STATUS_LABELS[adjustment.status]}
+                className={ADJUSTMENT_STATUS_CLASSES[adjustment.status]}
+            />
+        </div>
+        {isDraft && (
+            <div className="flex gap-2">
+                <Button
+                    size="sm"
+                    variant="plain"
+                    icon={<HiOutlinePencil />}
+                    onClick={onEdit}
+                >
+                    Editar
+                </Button>
+                <Button
+                    size="sm"
+                    variant="solid"
+                    color="emerald-600"
+                    icon={<HiOutlineCheck />}
+                    onClick={onConfirm}
+                >
+                    Confirmar
+                </Button>
+                <Button
+                    size="sm"
+                    variant="plain"
+                    icon={<HiOutlineX />}
+                    onClick={onCancel}
+                >
+                    Cancelar
+                </Button>
+                <Button
+                    size="sm"
+                    variant="plain"
+                    icon={<HiOutlineTrash />}
+                    onClick={onDelete}
+                >
+                    Eliminar
+                </Button>
+            </div>
+        )}
+    </div>
+)

--- a/src/views/inventory/AdjustmentDetailView/AdjustmentInfo.tsx
+++ b/src/views/inventory/AdjustmentDetailView/AdjustmentInfo.tsx
@@ -1,0 +1,53 @@
+import Card from '@/components/ui/Card'
+import { formatDatetime } from '@shared/lib/format'
+import { ADJUSTMENT_REASON_LABELS } from '@/services/AdjustmentService'
+import type { Adjustment } from '@/services/AdjustmentService'
+
+type Props = {
+    adjustment: Adjustment
+    warehouseName: string
+}
+
+export const AdjustmentInfo = ({ adjustment, warehouseName }: Props) => (
+    <Card>
+        <h5 className="mb-4">Información del Ajuste</h5>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div>
+                <p className="text-sm text-gray-500">Almacén</p>
+                <p className="font-medium">{warehouseName}</p>
+            </div>
+            <div>
+                <p className="text-sm text-gray-500">Motivo</p>
+                <p className="font-medium">
+                    {ADJUSTMENT_REASON_LABELS[adjustment.reason]}
+                </p>
+            </div>
+            <div>
+                <p className="text-sm text-gray-500">Responsable</p>
+                <p className="font-medium">{adjustment.adjustedBy || '-'}</p>
+            </div>
+            <div>
+                <p className="text-sm text-gray-500">Fecha de Creación</p>
+                <p className="font-medium">
+                    {adjustment.createdAt
+                        ? formatDatetime(adjustment.createdAt)
+                        : '-'}
+                </p>
+            </div>
+            <div>
+                <p className="text-sm text-gray-500">Fecha de Ajuste</p>
+                <p className="font-medium">
+                    {adjustment.adjustmentDate
+                        ? formatDatetime(adjustment.adjustmentDate)
+                        : '-'}
+                </p>
+            </div>
+        </div>
+        {adjustment.notes && (
+            <div className="mt-4">
+                <p className="text-sm text-gray-500">Notas</p>
+                <p className="font-medium">{adjustment.notes}</p>
+            </div>
+        )}
+    </Card>
+)

--- a/src/views/inventory/AdjustmentDetailView/AdjustmentItems.tsx
+++ b/src/views/inventory/AdjustmentDetailView/AdjustmentItems.tsx
@@ -1,0 +1,114 @@
+import Card from '@/components/ui/Card'
+import Button from '@/components/ui/Button'
+import Table from '@/components/ui/Table'
+import { HiOutlinePlus, HiOutlinePencil, HiOutlineTrash } from 'react-icons/hi'
+import { getDifferenceColor, getDifferenceLabel } from './utils'
+import type { AdjustmentItem } from '@/services/AdjustmentService'
+
+const { Tr, Th, Td, THead, TBody } = Table
+
+type Props = {
+    items: AdjustmentItem[]
+    itemsLoading: boolean
+    isDraft: boolean
+    getProductName: (productId: number) => string
+    getLocationName: (locationId: number) => string
+    onAdd: () => void
+    onEdit: (item: AdjustmentItem) => void
+    onDeleteItem: (item: AdjustmentItem) => void
+}
+
+export const AdjustmentItems = ({
+    items,
+    itemsLoading,
+    isDraft,
+    getProductName,
+    getLocationName,
+    onAdd,
+    onEdit,
+    onDeleteItem,
+}: Props) => (
+    <Card>
+        <div className="flex items-center justify-between mb-4">
+            <h5>Items del Ajuste ({items.length})</h5>
+            {isDraft && (
+                <Button
+                    size="sm"
+                    variant="solid"
+                    icon={<HiOutlinePlus />}
+                    onClick={onAdd}
+                >
+                    Agregar Item
+                </Button>
+            )}
+        </div>
+
+        {itemsLoading ? (
+            <div className="flex justify-center items-center h-32">
+                <div>Cargando items...</div>
+            </div>
+        ) : items.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">
+                No hay items en este ajuste
+            </div>
+        ) : (
+            <Table>
+                <THead>
+                    <Tr>
+                        <Th>Producto</Th>
+                        <Th>Ubicación</Th>
+                        <Th>Esperado</Th>
+                        <Th>Actual</Th>
+                        <Th>Diferencia</Th>
+                        <Th>Lote</Th>
+                        <Th>Notas</Th>
+                        {isDraft && <Th>Acciones</Th>}
+                    </Tr>
+                </THead>
+                <TBody>
+                    {items.map((item) => (
+                        <Tr key={item.id}>
+                            <Td>{getProductName(item.productId)}</Td>
+                            <Td>{getLocationName(item.locationId)}</Td>
+                            <Td>{item.expectedQuantity}</Td>
+                            <Td>{item.actualQuantity}</Td>
+                            <Td>
+                                <span
+                                    className={`font-semibold ${getDifferenceColor(
+                                        item.difference
+                                    )}`}
+                                >
+                                    {getDifferenceLabel(item.difference)}
+                                </span>
+                            </Td>
+                            <Td>{item.lotId ? `#${item.lotId}` : '-'}</Td>
+                            <Td>
+                                <span className="text-sm text-gray-600 dark:text-gray-400">
+                                    {item.notes || '-'}
+                                </span>
+                            </Td>
+                            {isDraft && (
+                                <Td>
+                                    <div className="flex gap-2">
+                                        <Button
+                                            size="sm"
+                                            variant="plain"
+                                            icon={<HiOutlinePencil />}
+                                            onClick={() => onEdit(item)}
+                                        />
+                                        <Button
+                                            size="sm"
+                                            variant="plain"
+                                            icon={<HiOutlineTrash />}
+                                            onClick={() => onDeleteItem(item)}
+                                        />
+                                    </div>
+                                </Td>
+                            )}
+                        </Tr>
+                    ))}
+                </TBody>
+            </Table>
+        )}
+    </Card>
+)

--- a/src/views/inventory/AdjustmentDetailView/ConfirmAdjustmentDialog.tsx
+++ b/src/views/inventory/AdjustmentDetailView/ConfirmAdjustmentDialog.tsx
@@ -1,0 +1,66 @@
+import Button from '@/components/ui/Button'
+import Dialog from '@/components/ui/Dialog'
+import { getDifferenceColor } from './utils'
+import type { AdjustmentItem } from '@/services/AdjustmentService'
+
+type Props = {
+    open: boolean
+    itemsWithDifference: AdjustmentItem[]
+    getProductName: (productId: number) => string
+    isPending: boolean
+    onClose: () => void
+    onConfirm: () => void
+}
+
+export const ConfirmAdjustmentDialog = ({
+    open,
+    itemsWithDifference,
+    getProductName,
+    isPending,
+    onClose,
+    onConfirm,
+}: Props) => (
+    <Dialog isOpen={open} onClose={onClose} onRequestClose={onClose}>
+        <h5 className="mb-4">Confirmar Ajuste</h5>
+        <p className="mb-4">
+            ¿Está seguro que desea confirmar este ajuste? Se generarán
+            movimientos de inventario automáticos.
+        </p>
+        {itemsWithDifference.length > 0 ? (
+            <div className="mb-4 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg">
+                <p className="text-sm font-medium mb-2">
+                    Movimientos que se generarán:
+                </p>
+                <ul className="text-sm space-y-1">
+                    {itemsWithDifference.map((item) => (
+                        <li key={item.id}>
+                            <span className="font-medium">
+                                {getProductName(item.productId)}
+                            </span>
+                            :{' '}
+                            <span
+                                className={getDifferenceColor(item.difference)}
+                            >
+                                {item.difference > 0
+                                    ? `+${item.difference} (entrada)`
+                                    : `${item.difference} (salida)`}
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        ) : (
+            <p className="mb-4 text-sm text-gray-500">
+                No se generarán movimientos (todas las diferencias son 0).
+            </p>
+        )}
+        <div className="flex justify-end gap-2">
+            <Button variant="plain" onClick={onClose}>
+                Cancelar
+            </Button>
+            <Button variant="solid" loading={isPending} onClick={onConfirm}>
+                Confirmar
+            </Button>
+        </div>
+    </Dialog>
+)

--- a/src/views/inventory/AdjustmentDetailView/EditAdjustmentDialog.tsx
+++ b/src/views/inventory/AdjustmentDetailView/EditAdjustmentDialog.tsx
@@ -1,0 +1,65 @@
+import Button from '@/components/ui/Button'
+import Dialog from '@/components/ui/Dialog'
+import Input from '@/components/ui/Input'
+import type { AdjustmentUpdateInput } from '@/services/AdjustmentService'
+
+type Props = {
+    open: boolean
+    editData: AdjustmentUpdateInput
+    isPending: boolean
+    onClose: () => void
+    onChange: (data: AdjustmentUpdateInput) => void
+    onSave: () => void
+}
+
+export const EditAdjustmentDialog = ({
+    open,
+    editData,
+    isPending,
+    onClose,
+    onChange,
+    onSave,
+}: Props) => (
+    <Dialog
+        isOpen={open}
+        width={500}
+        onClose={onClose}
+        onRequestClose={onClose}
+    >
+        <h5 className="mb-4">Editar Ajuste</h5>
+        <div className="space-y-4">
+            <div>
+                <label className="block text-sm font-medium mb-2">
+                    Responsable
+                </label>
+                <Input
+                    type="text"
+                    placeholder="Nombre del responsable"
+                    value={editData.adjustedBy || ''}
+                    onChange={(e) =>
+                        onChange({ ...editData, adjustedBy: e.target.value })
+                    }
+                />
+            </div>
+            <div>
+                <label className="block text-sm font-medium mb-2">Notas</label>
+                <Input
+                    textArea
+                    placeholder="Observaciones"
+                    value={editData.notes || ''}
+                    onChange={(e) =>
+                        onChange({ ...editData, notes: e.target.value })
+                    }
+                />
+            </div>
+        </div>
+        <div className="flex justify-end gap-2 mt-6">
+            <Button variant="plain" onClick={onClose}>
+                Cancelar
+            </Button>
+            <Button variant="solid" loading={isPending} onClick={onSave}>
+                Guardar
+            </Button>
+        </div>
+    </Dialog>
+)

--- a/src/views/inventory/AdjustmentDetailView/index.tsx
+++ b/src/views/inventory/AdjustmentDetailView/index.tsx
@@ -1,44 +1,18 @@
-import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import {
-    useAdjustment,
-    useAdjustmentItems,
-    useUpdateAdjustment,
-    useDeleteAdjustment,
-    useConfirmAdjustment,
-    useCancelAdjustment,
-    useDeleteAdjustmentItem,
-} from '@/hooks/useAdjustments'
+import { useAdjustment, useAdjustmentItems } from '@/hooks/useAdjustments'
 import { useWarehouses } from '@/hooks/useWarehouses'
 import { useProducts } from '@/hooks/useProducts'
 import { useLocations } from '@/hooks/useLocations'
-import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
-import Badge from '@/components/ui/Badge'
-import Table from '@/components/ui/Table'
 import Dialog from '@/components/ui/Dialog'
-import Input from '@/components/ui/Input'
-import Notification from '@/components/ui/Notification'
-import toast from '@/components/ui/toast'
-import { getErrorMessage } from '@/utils/getErrorMessage'
-import {
-    ADJUSTMENT_STATUS_LABELS,
-    ADJUSTMENT_STATUS_CLASSES,
-    ADJUSTMENT_REASON_LABELS,
-    type AdjustmentItem,
-    type AdjustmentUpdateInput,
-} from '@/services/AdjustmentService'
+import { HiOutlineArrowLeft } from 'react-icons/hi'
+import { useAdjustmentActions } from './useAdjustmentActions'
+import { AdjustmentHeader } from './AdjustmentHeader'
+import { AdjustmentInfo } from './AdjustmentInfo'
+import { AdjustmentItems } from './AdjustmentItems'
+import { EditAdjustmentDialog } from './EditAdjustmentDialog'
+import { ConfirmAdjustmentDialog } from './ConfirmAdjustmentDialog'
 import AdjustmentItemForm from './AdjustmentItemForm'
-import {
-    HiOutlineArrowLeft,
-    HiOutlinePlus,
-    HiOutlinePencil,
-    HiOutlineTrash,
-    HiOutlineCheck,
-    HiOutlineX,
-} from 'react-icons/hi'
-
-const { Tr, Th, Td, THead, TBody } = Table
 
 const AdjustmentDetailView = () => {
     const { id } = useParams<{ id: string }>()
@@ -62,35 +36,10 @@ const AdjustmentDetailView = () => {
     )
     const locations = locationsData?.items ?? []
 
-    const updateAdjustment = useUpdateAdjustment()
-    const deleteAdjustment = useDeleteAdjustment()
-    const confirmAdjustment = useConfirmAdjustment()
-    const cancelAdjustment = useCancelAdjustment()
-    const deleteItem = useDeleteAdjustmentItem()
+    const actions = useAdjustmentActions(adjustmentId, adjustment)
 
     const isDraft = adjustment?.status === 'draft'
-
-    // Edit adjustment state
-    const [editDialogOpen, setEditDialogOpen] = useState(false)
-    const [editData, setEditData] = useState<AdjustmentUpdateInput>({
-        notes: '',
-        adjustedBy: '',
-    })
-
-    // Item form state
-    const [itemFormOpen, setItemFormOpen] = useState(false)
-    const [selectedItem, setSelectedItem] = useState<AdjustmentItem | null>(
-        null
-    )
-
-    // Confirm/Cancel/Delete dialogs
-    const [confirmDialogOpen, setConfirmDialogOpen] = useState(false)
-    const [cancelDialogOpen, setCancelDialogOpen] = useState(false)
-    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-    const [deleteItemDialog, setDeleteItemDialog] = useState<{
-        open: boolean
-        item: AdjustmentItem | null
-    }>({ open: false, item: null })
+    const itemsWithDifference = items.filter((i) => i.difference !== 0)
 
     const getWarehouseName = (wId: number) => {
         const w = warehouses.find((w) => w.id === wId)
@@ -106,157 +55,6 @@ const AdjustmentDetailView = () => {
         const l = locations.find((l) => l.id === locationId)
         return l ? `${l.name} (${l.code})` : `#${locationId}`
     }
-
-    const getDifferenceColor = (diff: number) => {
-        if (diff > 0) return 'text-emerald-600 dark:text-emerald-400'
-        if (diff < 0) return 'text-red-600 dark:text-red-400'
-        return 'text-gray-500'
-    }
-
-    const getDifferenceLabel = (diff: number) => {
-        if (diff > 0) return `+${diff}`
-        return diff.toString()
-    }
-
-    // Handlers
-    const handleEditAdjustment = () => {
-        if (adjustment) {
-            setEditData({
-                notes: adjustment.notes || '',
-                adjustedBy: adjustment.adjustedBy || '',
-            })
-            setEditDialogOpen(true)
-        }
-    }
-
-    const handleSaveEdit = async () => {
-        try {
-            await updateAdjustment.mutateAsync({
-                id: adjustmentId,
-                data: {
-                    notes: editData.notes || undefined,
-                    adjustedBy: editData.adjustedBy || undefined,
-                },
-            })
-            toast.push(
-                <Notification title="Ajuste actualizado" type="success">
-                    El ajuste se actualizó correctamente
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            setEditDialogOpen(false)
-        } catch (error: unknown) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al actualizar el ajuste')}
-                </Notification>,
-                { placement: 'top-end' }
-            )
-        }
-    }
-
-    const handleConfirm = async () => {
-        try {
-            await confirmAdjustment.mutateAsync(adjustmentId)
-            toast.push(
-                <Notification title="Ajuste confirmado" type="success">
-                    El ajuste se confirmó y los movimientos de inventario fueron
-                    generados
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            setConfirmDialogOpen(false)
-        } catch (error: unknown) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al confirmar el ajuste')}
-                </Notification>,
-                { placement: 'top-end' }
-            )
-        }
-    }
-
-    const handleCancel = async () => {
-        try {
-            await cancelAdjustment.mutateAsync(adjustmentId)
-            toast.push(
-                <Notification title="Ajuste cancelado" type="success">
-                    El ajuste fue cancelado
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            setCancelDialogOpen(false)
-        } catch (error: unknown) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al cancelar el ajuste')}
-                </Notification>,
-                { placement: 'top-end' }
-            )
-        }
-    }
-
-    const handleDelete = async () => {
-        try {
-            await deleteAdjustment.mutateAsync(adjustmentId)
-            toast.push(
-                <Notification title="Ajuste eliminado" type="success">
-                    El ajuste fue eliminado
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            navigate('/adjustments')
-        } catch (error: unknown) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al eliminar el ajuste')}
-                </Notification>,
-                { placement: 'top-end' }
-            )
-        }
-    }
-
-    const handleDeleteItemConfirm = async () => {
-        if (!deleteItemDialog.item) return
-        try {
-            await deleteItem.mutateAsync({
-                itemId: deleteItemDialog.item.id,
-                adjustmentId,
-            })
-            toast.push(
-                <Notification title="Item eliminado" type="success">
-                    El item fue eliminado
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            setDeleteItemDialog({ open: false, item: null })
-        } catch (error: unknown) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al eliminar el item')}
-                </Notification>,
-                { placement: 'top-end' }
-            )
-        }
-    }
-
-    const handleAddItem = () => {
-        setSelectedItem(null)
-        setItemFormOpen(true)
-    }
-
-    const handleEditItem = (item: AdjustmentItem) => {
-        setSelectedItem(item)
-        setItemFormOpen(true)
-    }
-
-    const handleCloseItemForm = () => {
-        setItemFormOpen(false)
-        setSelectedItem(null)
-    }
-
-    // Items with difference != 0 for confirm summary
-    const itemsWithDifference = items.filter((i) => i.difference !== 0)
 
     if (adjustmentLoading) {
         return (
@@ -283,340 +81,64 @@ const AdjustmentDetailView = () => {
 
     return (
         <div className="flex flex-col gap-4">
-            {/* Header */}
-            <div className="flex items-center justify-between">
-                <div className="flex items-center gap-4">
-                    <Button
-                        variant="plain"
-                        icon={<HiOutlineArrowLeft />}
-                        onClick={() => navigate('/adjustments')}
-                    />
-                    <h3>Ajuste #{adjustment.id}</h3>
-                    <Badge
-                        content={ADJUSTMENT_STATUS_LABELS[adjustment.status]}
-                        className={ADJUSTMENT_STATUS_CLASSES[adjustment.status]}
-                    />
-                </div>
-                {isDraft && (
-                    <div className="flex gap-2">
-                        <Button
-                            size="sm"
-                            variant="plain"
-                            icon={<HiOutlinePencil />}
-                            onClick={handleEditAdjustment}
-                        >
-                            Editar
-                        </Button>
-                        <Button
-                            size="sm"
-                            variant="solid"
-                            color="emerald-600"
-                            icon={<HiOutlineCheck />}
-                            onClick={() => setConfirmDialogOpen(true)}
-                        >
-                            Confirmar
-                        </Button>
-                        <Button
-                            size="sm"
-                            variant="plain"
-                            icon={<HiOutlineX />}
-                            onClick={() => setCancelDialogOpen(true)}
-                        >
-                            Cancelar
-                        </Button>
-                        <Button
-                            size="sm"
-                            variant="plain"
-                            icon={<HiOutlineTrash />}
-                            onClick={() => setDeleteDialogOpen(true)}
-                        >
-                            Eliminar
-                        </Button>
-                    </div>
-                )}
-            </div>
-
-            {/* Adjustment Info */}
-            <Card>
-                <h5 className="mb-4">Información del Ajuste</h5>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    <div>
-                        <p className="text-sm text-gray-500">Almacén</p>
-                        <p className="font-medium">
-                            {getWarehouseName(adjustment.warehouseId)}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-sm text-gray-500">Motivo</p>
-                        <p className="font-medium">
-                            {ADJUSTMENT_REASON_LABELS[adjustment.reason]}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-sm text-gray-500">Responsable</p>
-                        <p className="font-medium">
-                            {adjustment.adjustedBy || '-'}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-sm text-gray-500">
-                            Fecha de Creación
-                        </p>
-                        <p className="font-medium">
-                            {adjustment.createdAt
-                                ? new Date(adjustment.createdAt).toLocaleString(
-                                      'es-EC'
-                                  )
-                                : '-'}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-sm text-gray-500">Fecha de Ajuste</p>
-                        <p className="font-medium">
-                            {adjustment.adjustmentDate
-                                ? new Date(
-                                      adjustment.adjustmentDate
-                                  ).toLocaleString('es-EC')
-                                : '-'}
-                        </p>
-                    </div>
-                </div>
-                {adjustment.notes && (
-                    <div className="mt-4">
-                        <p className="text-sm text-gray-500">Notas</p>
-                        <p className="font-medium">{adjustment.notes}</p>
-                    </div>
-                )}
-            </Card>
-
-            {/* Items */}
-            <Card>
-                <div className="flex items-center justify-between mb-4">
-                    <h5>Items del Ajuste ({items.length})</h5>
-                    {isDraft && (
-                        <Button
-                            size="sm"
-                            variant="solid"
-                            icon={<HiOutlinePlus />}
-                            onClick={handleAddItem}
-                        >
-                            Agregar Item
-                        </Button>
-                    )}
-                </div>
-
-                {itemsLoading ? (
-                    <div className="flex justify-center items-center h-32">
-                        <div>Cargando items...</div>
-                    </div>
-                ) : items.length === 0 ? (
-                    <div className="text-center py-8 text-gray-500">
-                        No hay items en este ajuste
-                    </div>
-                ) : (
-                    <Table>
-                        <THead>
-                            <Tr>
-                                <Th>Producto</Th>
-                                <Th>Ubicación</Th>
-                                <Th>Esperado</Th>
-                                <Th>Actual</Th>
-                                <Th>Diferencia</Th>
-                                <Th>Lote</Th>
-                                <Th>Notas</Th>
-                                {isDraft && <Th>Acciones</Th>}
-                            </Tr>
-                        </THead>
-                        <TBody>
-                            {items.map((item) => (
-                                <Tr key={item.id}>
-                                    <Td>{getProductName(item.productId)}</Td>
-                                    <Td>{getLocationName(item.locationId)}</Td>
-                                    <Td>{item.expectedQuantity}</Td>
-                                    <Td>{item.actualQuantity}</Td>
-                                    <Td>
-                                        <span
-                                            className={`font-semibold ${getDifferenceColor(
-                                                item.difference
-                                            )}`}
-                                        >
-                                            {getDifferenceLabel(
-                                                item.difference
-                                            )}
-                                        </span>
-                                    </Td>
-                                    <Td>
-                                        {item.lotId ? `#${item.lotId}` : '-'}
-                                    </Td>
-                                    <Td>
-                                        <span className="text-sm text-gray-600 dark:text-gray-400">
-                                            {item.notes || '-'}
-                                        </span>
-                                    </Td>
-                                    {isDraft && (
-                                        <Td>
-                                            <div className="flex gap-2">
-                                                <Button
-                                                    size="sm"
-                                                    variant="plain"
-                                                    icon={<HiOutlinePencil />}
-                                                    onClick={() =>
-                                                        handleEditItem(item)
-                                                    }
-                                                />
-                                                <Button
-                                                    size="sm"
-                                                    variant="plain"
-                                                    icon={<HiOutlineTrash />}
-                                                    onClick={() =>
-                                                        setDeleteItemDialog({
-                                                            open: true,
-                                                            item,
-                                                        })
-                                                    }
-                                                />
-                                            </div>
-                                        </Td>
-                                    )}
-                                </Tr>
-                            ))}
-                        </TBody>
-                    </Table>
-                )}
-            </Card>
-
-            {/* Item Form Modal */}
-            <AdjustmentItemForm
-                adjustmentId={adjustmentId}
-                item={selectedItem}
-                open={itemFormOpen}
-                warehouseId={adjustment.warehouseId}
-                onClose={handleCloseItemForm}
+            <AdjustmentHeader
+                adjustment={adjustment}
+                isDraft={isDraft}
+                onBack={() => navigate('/adjustments')}
+                onEdit={actions.handleEditAdjustment}
+                onConfirm={() => actions.setConfirmDialogOpen(true)}
+                onCancel={() => actions.setCancelDialogOpen(true)}
+                onDelete={() => actions.setDeleteDialogOpen(true)}
             />
 
-            {/* Edit Adjustment Dialog */}
-            <Dialog
-                isOpen={editDialogOpen}
-                width={500}
-                onClose={() => setEditDialogOpen(false)}
-                onRequestClose={() => setEditDialogOpen(false)}
-            >
-                <h5 className="mb-4">Editar Ajuste</h5>
-                <div className="space-y-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Responsable
-                        </label>
-                        <Input
-                            type="text"
-                            placeholder="Nombre del responsable"
-                            value={editData.adjustedBy || ''}
-                            onChange={(e) =>
-                                setEditData({
-                                    ...editData,
-                                    adjustedBy: e.target.value,
-                                })
-                            }
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Notas
-                        </label>
-                        <Input
-                            textArea
-                            placeholder="Observaciones"
-                            value={editData.notes || ''}
-                            onChange={(e) =>
-                                setEditData({
-                                    ...editData,
-                                    notes: e.target.value,
-                                })
-                            }
-                        />
-                    </div>
-                </div>
-                <div className="flex justify-end gap-2 mt-6">
-                    <Button
-                        variant="plain"
-                        onClick={() => setEditDialogOpen(false)}
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        variant="solid"
-                        loading={updateAdjustment.isPending}
-                        onClick={handleSaveEdit}
-                    >
-                        Guardar
-                    </Button>
-                </div>
-            </Dialog>
+            <AdjustmentInfo
+                adjustment={adjustment}
+                warehouseName={getWarehouseName(adjustment.warehouseId)}
+            />
 
-            {/* Confirm Dialog */}
-            <Dialog
-                isOpen={confirmDialogOpen}
-                onClose={() => setConfirmDialogOpen(false)}
-                onRequestClose={() => setConfirmDialogOpen(false)}
-            >
-                <h5 className="mb-4">Confirmar Ajuste</h5>
-                <p className="mb-4">
-                    ¿Está seguro que desea confirmar este ajuste? Se generarán
-                    movimientos de inventario automáticos.
-                </p>
-                {itemsWithDifference.length > 0 ? (
-                    <div className="mb-4 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg">
-                        <p className="text-sm font-medium mb-2">
-                            Movimientos que se generarán:
-                        </p>
-                        <ul className="text-sm space-y-1">
-                            {itemsWithDifference.map((item) => (
-                                <li key={item.id}>
-                                    <span className="font-medium">
-                                        {getProductName(item.productId)}
-                                    </span>
-                                    :{' '}
-                                    <span
-                                        className={getDifferenceColor(
-                                            item.difference
-                                        )}
-                                    >
-                                        {item.difference > 0
-                                            ? `+${item.difference} (entrada)`
-                                            : `${item.difference} (salida)`}
-                                    </span>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                ) : (
-                    <p className="mb-4 text-sm text-gray-500">
-                        No se generarán movimientos (todas las diferencias son
-                        0).
-                    </p>
-                )}
-                <div className="flex justify-end gap-2">
-                    <Button
-                        variant="plain"
-                        onClick={() => setConfirmDialogOpen(false)}
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        variant="solid"
-                        loading={confirmAdjustment.isPending}
-                        onClick={handleConfirm}
-                    >
-                        Confirmar
-                    </Button>
-                </div>
-            </Dialog>
+            <AdjustmentItems
+                items={items}
+                itemsLoading={itemsLoading}
+                isDraft={isDraft}
+                getProductName={getProductName}
+                getLocationName={getLocationName}
+                onAdd={actions.handleAddItem}
+                onEdit={actions.handleEditItem}
+                onDeleteItem={(item) =>
+                    actions.setDeleteItemDialog({ open: true, item })
+                }
+            />
 
-            {/* Cancel Dialog */}
+            <AdjustmentItemForm
+                adjustmentId={adjustmentId}
+                item={actions.selectedItem}
+                open={actions.itemFormOpen}
+                warehouseId={adjustment.warehouseId}
+                onClose={actions.handleCloseItemForm}
+            />
+
+            <EditAdjustmentDialog
+                open={actions.editDialogOpen}
+                editData={actions.editData}
+                isPending={actions.updateAdjustment.isPending}
+                onClose={() => actions.setEditDialogOpen(false)}
+                onChange={actions.setEditData}
+                onSave={actions.handleSaveEdit}
+            />
+
+            <ConfirmAdjustmentDialog
+                open={actions.confirmDialogOpen}
+                itemsWithDifference={itemsWithDifference}
+                getProductName={getProductName}
+                isPending={actions.confirmAdjustment.isPending}
+                onClose={() => actions.setConfirmDialogOpen(false)}
+                onConfirm={actions.handleConfirm}
+            />
+
             <Dialog
-                isOpen={cancelDialogOpen}
-                onClose={() => setCancelDialogOpen(false)}
-                onRequestClose={() => setCancelDialogOpen(false)}
+                isOpen={actions.cancelDialogOpen}
+                onClose={() => actions.setCancelDialogOpen(false)}
+                onRequestClose={() => actions.setCancelDialogOpen(false)}
             >
                 <h5 className="mb-4">Cancelar Ajuste</h5>
                 <p className="mb-6">
@@ -626,25 +148,24 @@ const AdjustmentDetailView = () => {
                 <div className="flex justify-end gap-2">
                     <Button
                         variant="plain"
-                        onClick={() => setCancelDialogOpen(false)}
+                        onClick={() => actions.setCancelDialogOpen(false)}
                     >
                         Volver
                     </Button>
                     <Button
                         variant="solid"
-                        loading={cancelAdjustment.isPending}
-                        onClick={handleCancel}
+                        loading={actions.cancelAdjustment.isPending}
+                        onClick={actions.handleCancel}
                     >
                         Cancelar Ajuste
                     </Button>
                 </div>
             </Dialog>
 
-            {/* Delete Adjustment Dialog */}
             <Dialog
-                isOpen={deleteDialogOpen}
-                onClose={() => setDeleteDialogOpen(false)}
-                onRequestClose={() => setDeleteDialogOpen(false)}
+                isOpen={actions.deleteDialogOpen}
+                onClose={() => actions.setDeleteDialogOpen(false)}
+                onRequestClose={() => actions.setDeleteDialogOpen(false)}
             >
                 <h5 className="mb-4">Eliminar Ajuste</h5>
                 <p className="mb-6">
@@ -654,26 +175,27 @@ const AdjustmentDetailView = () => {
                 <div className="flex justify-end gap-2">
                     <Button
                         variant="plain"
-                        onClick={() => setDeleteDialogOpen(false)}
+                        onClick={() => actions.setDeleteDialogOpen(false)}
                     >
                         Cancelar
                     </Button>
                     <Button
                         variant="solid"
-                        loading={deleteAdjustment.isPending}
-                        onClick={handleDelete}
+                        loading={actions.deleteAdjustment.isPending}
+                        onClick={actions.handleDelete}
                     >
                         Eliminar
                     </Button>
                 </div>
             </Dialog>
 
-            {/* Delete Item Dialog */}
             <Dialog
-                isOpen={deleteItemDialog.open}
-                onClose={() => setDeleteItemDialog({ open: false, item: null })}
+                isOpen={actions.deleteItemDialog.open}
+                onClose={() =>
+                    actions.setDeleteItemDialog({ open: false, item: null })
+                }
                 onRequestClose={() =>
-                    setDeleteItemDialog({ open: false, item: null })
+                    actions.setDeleteItemDialog({ open: false, item: null })
                 }
             >
                 <h5 className="mb-4">Eliminar Item</h5>
@@ -685,15 +207,18 @@ const AdjustmentDetailView = () => {
                     <Button
                         variant="plain"
                         onClick={() =>
-                            setDeleteItemDialog({ open: false, item: null })
+                            actions.setDeleteItemDialog({
+                                open: false,
+                                item: null,
+                            })
                         }
                     >
                         Cancelar
                     </Button>
                     <Button
                         variant="solid"
-                        loading={deleteItem.isPending}
-                        onClick={handleDeleteItemConfirm}
+                        loading={actions.deleteItem.isPending}
+                        onClick={actions.handleDeleteItemConfirm}
                     >
                         Eliminar
                     </Button>

--- a/src/views/inventory/AdjustmentDetailView/useAdjustmentActions.tsx
+++ b/src/views/inventory/AdjustmentDetailView/useAdjustmentActions.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+    useUpdateAdjustment,
+    useDeleteAdjustment,
+    useConfirmAdjustment,
+    useCancelAdjustment,
+    useDeleteAdjustmentItem,
+} from '@/hooks/useAdjustments'
+import Notification from '@/components/ui/Notification'
+import toast from '@/components/ui/toast'
+import { getErrorMessage } from '@/utils/getErrorMessage'
+import type {
+    Adjustment,
+    AdjustmentItem,
+    AdjustmentUpdateInput,
+} from '@/services/AdjustmentService'
+
+export function useAdjustmentActions(
+    adjustmentId: number,
+    adjustment: Adjustment | undefined
+) {
+    const navigate = useNavigate()
+
+    const updateAdjustment = useUpdateAdjustment()
+    const deleteAdjustment = useDeleteAdjustment()
+    const confirmAdjustment = useConfirmAdjustment()
+    const cancelAdjustment = useCancelAdjustment()
+    const deleteItem = useDeleteAdjustmentItem()
+
+    const [editDialogOpen, setEditDialogOpen] = useState(false)
+    const [editData, setEditData] = useState<AdjustmentUpdateInput>({
+        notes: '',
+        adjustedBy: '',
+    })
+    const [itemFormOpen, setItemFormOpen] = useState(false)
+    const [selectedItem, setSelectedItem] = useState<AdjustmentItem | null>(
+        null
+    )
+    const [confirmDialogOpen, setConfirmDialogOpen] = useState(false)
+    const [cancelDialogOpen, setCancelDialogOpen] = useState(false)
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+    const [deleteItemDialog, setDeleteItemDialog] = useState<{
+        open: boolean
+        item: AdjustmentItem | null
+    }>({ open: false, item: null })
+
+    const handleEditAdjustment = () => {
+        if (adjustment) {
+            setEditData({
+                notes: adjustment.notes || '',
+                adjustedBy: adjustment.adjustedBy || '',
+            })
+            setEditDialogOpen(true)
+        }
+    }
+
+    const handleSaveEdit = async () => {
+        try {
+            await updateAdjustment.mutateAsync({
+                id: adjustmentId,
+                data: {
+                    notes: editData.notes || undefined,
+                    adjustedBy: editData.adjustedBy || undefined,
+                },
+            })
+            toast.push(
+                <Notification title="Ajuste actualizado" type="success">
+                    El ajuste se actualizó correctamente
+                </Notification>,
+                { placement: 'top-end' }
+            )
+            setEditDialogOpen(false)
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al actualizar el ajuste')}
+                </Notification>,
+                { placement: 'top-end' }
+            )
+        }
+    }
+
+    const handleConfirm = async () => {
+        try {
+            await confirmAdjustment.mutateAsync(adjustmentId)
+            toast.push(
+                <Notification title="Ajuste confirmado" type="success">
+                    El ajuste se confirmó y los movimientos de inventario fueron
+                    generados
+                </Notification>,
+                { placement: 'top-end' }
+            )
+            setConfirmDialogOpen(false)
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al confirmar el ajuste')}
+                </Notification>,
+                { placement: 'top-end' }
+            )
+        }
+    }
+
+    const handleCancel = async () => {
+        try {
+            await cancelAdjustment.mutateAsync(adjustmentId)
+            toast.push(
+                <Notification title="Ajuste cancelado" type="success">
+                    El ajuste fue cancelado
+                </Notification>,
+                { placement: 'top-end' }
+            )
+            setCancelDialogOpen(false)
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al cancelar el ajuste')}
+                </Notification>,
+                { placement: 'top-end' }
+            )
+        }
+    }
+
+    const handleDelete = async () => {
+        try {
+            await deleteAdjustment.mutateAsync(adjustmentId)
+            toast.push(
+                <Notification title="Ajuste eliminado" type="success">
+                    El ajuste fue eliminado
+                </Notification>,
+                { placement: 'top-end' }
+            )
+            navigate('/adjustments')
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al eliminar el ajuste')}
+                </Notification>,
+                { placement: 'top-end' }
+            )
+        }
+    }
+
+    const handleDeleteItemConfirm = async () => {
+        if (!deleteItemDialog.item) return
+        try {
+            await deleteItem.mutateAsync({
+                itemId: deleteItemDialog.item.id,
+                adjustmentId,
+            })
+            toast.push(
+                <Notification title="Item eliminado" type="success">
+                    El item fue eliminado
+                </Notification>,
+                { placement: 'top-end' }
+            )
+            setDeleteItemDialog({ open: false, item: null })
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al eliminar el item')}
+                </Notification>,
+                { placement: 'top-end' }
+            )
+        }
+    }
+
+    return {
+        updateAdjustment,
+        deleteAdjustment,
+        confirmAdjustment,
+        cancelAdjustment,
+        deleteItem,
+        editDialogOpen,
+        setEditDialogOpen,
+        editData,
+        setEditData,
+        itemFormOpen,
+        selectedItem,
+        confirmDialogOpen,
+        setConfirmDialogOpen,
+        cancelDialogOpen,
+        setCancelDialogOpen,
+        deleteDialogOpen,
+        setDeleteDialogOpen,
+        deleteItemDialog,
+        setDeleteItemDialog,
+        handleEditAdjustment,
+        handleSaveEdit,
+        handleConfirm,
+        handleCancel,
+        handleDelete,
+        handleDeleteItemConfirm,
+        handleAddItem: () => {
+            setSelectedItem(null)
+            setItemFormOpen(true)
+        },
+        handleEditItem: (item: AdjustmentItem) => {
+            setSelectedItem(item)
+            setItemFormOpen(true)
+        },
+        handleCloseItemForm: () => {
+            setItemFormOpen(false)
+            setSelectedItem(null)
+        },
+    }
+}

--- a/src/views/inventory/AdjustmentDetailView/utils.ts
+++ b/src/views/inventory/AdjustmentDetailView/utils.ts
@@ -1,0 +1,10 @@
+export const getDifferenceColor = (diff: number): string => {
+    if (diff > 0) return 'text-emerald-600 dark:text-emerald-400'
+    if (diff < 0) return 'text-red-600 dark:text-red-400'
+    return 'text-gray-500'
+}
+
+export const getDifferenceLabel = (diff: number): string => {
+    if (diff > 0) return `+${diff}`
+    return diff.toString()
+}

--- a/src/views/purchases/PurchaseOrderDetailView/EditOrderDialog.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/EditOrderDialog.tsx
@@ -1,0 +1,94 @@
+import Button from '@/components/ui/Button'
+import Dialog from '@/components/ui/Dialog'
+import Input from '@/components/ui/Input'
+import Select from '@/components/ui/Select'
+import type { PurchaseOrderUpdateInput } from '@/services/PurchaseOrderService'
+
+type EditData = PurchaseOrderUpdateInput & { supplierId: number }
+
+type SupplierOption = { value: string; label: string }
+
+type Props = {
+    open: boolean
+    editData: EditData
+    supplierOptions: SupplierOption[]
+    isPending: boolean
+    onClose: () => void
+    onChange: (data: EditData) => void
+    onSave: () => void
+}
+
+export const EditOrderDialog = ({
+    open,
+    editData,
+    supplierOptions,
+    isPending,
+    onClose,
+    onChange,
+    onSave,
+}: Props) => (
+    <Dialog
+        isOpen={open}
+        width={500}
+        onClose={onClose}
+        onRequestClose={onClose}
+    >
+        <h5 className="mb-4">Editar Orden de Compra</h5>
+        <div className="space-y-4">
+            <div>
+                <label className="block text-sm font-medium mb-2">
+                    Proveedor <span className="text-red-500">*</span>
+                </label>
+                <Select
+                    placeholder="Seleccionar proveedor"
+                    options={supplierOptions}
+                    value={supplierOptions.find(
+                        (o) => o.value === editData.supplierId.toString()
+                    )}
+                    onChange={(option) =>
+                        onChange({
+                            ...editData,
+                            supplierId: option ? parseInt(option.value) : 0,
+                        })
+                    }
+                />
+            </div>
+            <div>
+                <label className="block text-sm font-medium mb-2">
+                    Fecha Esperada
+                </label>
+                <Input
+                    type="date"
+                    value={editData.expectedDate || ''}
+                    onChange={(e) =>
+                        onChange({ ...editData, expectedDate: e.target.value })
+                    }
+                />
+            </div>
+            <div>
+                <label className="block text-sm font-medium mb-2">Notas</label>
+                <Input
+                    textArea
+                    placeholder="Observaciones"
+                    value={editData.notes || ''}
+                    onChange={(e) =>
+                        onChange({ ...editData, notes: e.target.value })
+                    }
+                />
+            </div>
+        </div>
+        <div className="flex justify-end gap-2 mt-6">
+            <Button variant="plain" onClick={onClose}>
+                Cancelar
+            </Button>
+            <Button
+                variant="solid"
+                loading={isPending}
+                disabled={editData.supplierId === 0}
+                onClick={onSave}
+            >
+                Guardar
+            </Button>
+        </div>
+    </Dialog>
+)

--- a/src/views/purchases/PurchaseOrderDetailView/PurchaseOrderHeader.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/PurchaseOrderHeader.tsx
@@ -1,0 +1,107 @@
+import Button from '@/components/ui/Button'
+import Badge from '@/components/ui/Badge'
+import {
+    HiOutlineArrowLeft,
+    HiOutlinePencil,
+    HiOutlineTrash,
+    HiOutlineX,
+} from 'react-icons/hi'
+import { HiOutlinePaperAirplane, HiOutlineArchiveBox } from 'react-icons/hi2'
+import {
+    PURCHASE_ORDER_STATUS_LABELS,
+    PURCHASE_ORDER_STATUS_CLASSES,
+} from '@/services/PurchaseOrderService'
+import type { PurchaseOrder } from '@/services/PurchaseOrderService'
+
+type Props = {
+    order: PurchaseOrder
+    isDraft: boolean
+    canReceive: boolean
+    canCancel: boolean
+    onBack: () => void
+    onEdit: () => void
+    onSend: () => void
+    onDelete: () => void
+    onReceive: () => void
+    onCancel: () => void
+}
+
+export const PurchaseOrderHeader = ({
+    order,
+    isDraft,
+    canReceive,
+    canCancel,
+    onBack,
+    onEdit,
+    onSend,
+    onDelete,
+    onReceive,
+    onCancel,
+}: Props) => (
+    <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+            <Button
+                variant="plain"
+                icon={<HiOutlineArrowLeft />}
+                onClick={onBack}
+            />
+            <h3>Orden {order.orderNumber}</h3>
+            <Badge
+                content={PURCHASE_ORDER_STATUS_LABELS[order.status]}
+                className={PURCHASE_ORDER_STATUS_CLASSES[order.status]}
+            />
+        </div>
+        <div className="flex gap-2">
+            {isDraft && (
+                <>
+                    <Button
+                        size="sm"
+                        variant="plain"
+                        icon={<HiOutlinePencil />}
+                        onClick={onEdit}
+                    >
+                        Editar
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="solid"
+                        color="blue-600"
+                        icon={<HiOutlinePaperAirplane />}
+                        onClick={onSend}
+                    >
+                        Enviar
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="plain"
+                        icon={<HiOutlineTrash />}
+                        onClick={onDelete}
+                    >
+                        Eliminar
+                    </Button>
+                </>
+            )}
+            {canReceive && (
+                <Button
+                    size="sm"
+                    variant="solid"
+                    color="emerald-600"
+                    icon={<HiOutlineArchiveBox />}
+                    onClick={onReceive}
+                >
+                    Recibir Mercancía
+                </Button>
+            )}
+            {canCancel && (
+                <Button
+                    size="sm"
+                    variant="plain"
+                    icon={<HiOutlineX />}
+                    onClick={onCancel}
+                >
+                    Cancelar
+                </Button>
+            )}
+        </div>
+    </div>
+)

--- a/src/views/purchases/PurchaseOrderDetailView/PurchaseOrderInfo.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/PurchaseOrderInfo.tsx
@@ -1,0 +1,64 @@
+import Card from '@/components/ui/Card'
+import { formatCurrency, formatDate, formatDatetime } from '@shared/lib/format'
+import type { PurchaseOrder } from '@/services/PurchaseOrderService'
+
+type Props = {
+    order: PurchaseOrder
+    supplierName: string
+}
+
+export const PurchaseOrderInfo = ({ order, supplierName }: Props) => (
+    <Card>
+        <h5 className="mb-4">Información de la Orden</h5>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div>
+                <p className="text-sm text-gray-500">Proveedor</p>
+                <p className="font-medium">{supplierName}</p>
+            </div>
+            <div>
+                <p className="text-sm text-gray-500">Número de Orden</p>
+                <p className="font-medium">{order.orderNumber}</p>
+            </div>
+            <div>
+                <p className="text-sm text-gray-500">Fecha Esperada</p>
+                <p className="font-medium">
+                    {order.expectedDate ? formatDate(order.expectedDate) : '-'}
+                </p>
+            </div>
+            <div>
+                <p className="text-sm text-gray-500">Fecha de Creación</p>
+                <p className="font-medium">
+                    {order.createdAt ? formatDatetime(order.createdAt) : '-'}
+                </p>
+            </div>
+            <div>
+                <p className="text-sm text-gray-500">Última Actualización</p>
+                <p className="font-medium">
+                    {order.updatedAt ? formatDatetime(order.updatedAt) : '-'}
+                </p>
+            </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4 pt-4 border-t dark:border-gray-600">
+            <div>
+                <p className="text-sm text-gray-500">Subtotal</p>
+                <p className="font-medium">{formatCurrency(order.subtotal)}</p>
+            </div>
+            <div>
+                <p className="text-sm text-gray-500">Impuestos</p>
+                <p className="font-medium">{formatCurrency(order.tax)}</p>
+            </div>
+            <div>
+                <p className="text-sm text-gray-500">Total</p>
+                <p className="text-lg font-semibold">
+                    {formatCurrency(order.total)}
+                </p>
+            </div>
+        </div>
+        {order.notes && (
+            <div className="mt-4 pt-4 border-t dark:border-gray-600">
+                <p className="text-sm text-gray-500">Notas</p>
+                <p className="font-medium">{order.notes}</p>
+            </div>
+        )}
+    </Card>
+)

--- a/src/views/purchases/PurchaseOrderDetailView/PurchaseOrderItems.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/PurchaseOrderItems.tsx
@@ -1,0 +1,136 @@
+import Card from '@/components/ui/Card'
+import Button from '@/components/ui/Button'
+import Table from '@/components/ui/Table'
+import { formatCurrency } from '@shared/lib/format'
+import { HiOutlinePlus, HiOutlinePencil, HiOutlineTrash } from 'react-icons/hi'
+import type {
+    PurchaseOrder,
+    PurchaseOrderItem,
+} from '@/services/PurchaseOrderService'
+
+const { Tr, Th, Td, THead, TBody, TFoot } = Table
+
+type Props = {
+    items: PurchaseOrderItem[]
+    itemsLoading: boolean
+    isDraft: boolean
+    order: PurchaseOrder
+    getProductName: (productId: number) => string
+    onAdd: () => void
+    onEdit: (item: PurchaseOrderItem) => void
+    onDeleteItem: (item: PurchaseOrderItem) => void
+}
+
+export const PurchaseOrderItems = ({
+    items,
+    itemsLoading,
+    isDraft,
+    order,
+    getProductName,
+    onAdd,
+    onEdit,
+    onDeleteItem,
+}: Props) => (
+    <Card>
+        <div className="flex items-center justify-between mb-4">
+            <h5>Items de la Orden ({items.length})</h5>
+            {isDraft && (
+                <Button
+                    size="sm"
+                    variant="solid"
+                    icon={<HiOutlinePlus />}
+                    onClick={onAdd}
+                >
+                    Agregar Item
+                </Button>
+            )}
+        </div>
+
+        {itemsLoading ? (
+            <div className="flex justify-center items-center h-32">
+                <div>Cargando items...</div>
+            </div>
+        ) : items.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">
+                No hay items en esta orden
+            </div>
+        ) : (
+            <Table>
+                <THead>
+                    <Tr>
+                        <Th>Producto</Th>
+                        <Th>Cant. Pedida</Th>
+                        <Th>Cant. Recibida</Th>
+                        <Th>Cant. Pendiente</Th>
+                        <Th>Costo Unitario</Th>
+                        <Th>Subtotal</Th>
+                        {isDraft && <Th>Acciones</Th>}
+                    </Tr>
+                </THead>
+                <TBody>
+                    {items.map((item) => {
+                        const pending =
+                            item.quantityOrdered - item.quantityReceived
+                        const subtotal = item.unitCost * item.quantityOrdered
+                        return (
+                            <Tr key={item.id}>
+                                <Td>{getProductName(item.productId)}</Td>
+                                <Td>{item.quantityOrdered}</Td>
+                                <Td>{item.quantityReceived}</Td>
+                                <Td>
+                                    {pending > 0 ? (
+                                        <span className="text-amber-600 dark:text-amber-400 font-medium">
+                                            {pending}
+                                        </span>
+                                    ) : (
+                                        <span className="text-emerald-600 dark:text-emerald-400">
+                                            0
+                                        </span>
+                                    )}
+                                </Td>
+                                <Td>{formatCurrency(item.unitCost)}</Td>
+                                <Td className="font-medium">
+                                    {formatCurrency(subtotal)}
+                                </Td>
+                                {isDraft && (
+                                    <Td>
+                                        <div className="flex gap-2">
+                                            <Button
+                                                size="sm"
+                                                variant="plain"
+                                                icon={<HiOutlinePencil />}
+                                                onClick={() => onEdit(item)}
+                                            />
+                                            <Button
+                                                size="sm"
+                                                variant="plain"
+                                                icon={<HiOutlineTrash />}
+                                                onClick={() =>
+                                                    onDeleteItem(item)
+                                                }
+                                            />
+                                        </div>
+                                    </Td>
+                                )}
+                            </Tr>
+                        )
+                    })}
+                </TBody>
+                <TFoot>
+                    <Tr>
+                        <Td
+                            colSpan={isDraft ? 6 : 5}
+                            className="text-right font-medium"
+                        >
+                            Total
+                        </Td>
+                        <Td className="font-semibold">
+                            {formatCurrency(order.total)}
+                        </Td>
+                        {isDraft && <Td />}
+                    </Tr>
+                </TFoot>
+            </Table>
+        )}
+    </Card>
+)

--- a/src/views/purchases/PurchaseOrderDetailView/PurchaseOrderReceipts.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/PurchaseOrderReceipts.tsx
@@ -1,0 +1,55 @@
+import Card from '@/components/ui/Card'
+import { formatDatetime } from '@shared/lib/format'
+import type {
+    PurchaseOrder,
+    PurchaseReceipt,
+} from '@/services/PurchaseOrderService'
+
+type Props = {
+    order: PurchaseOrder
+    receipts: PurchaseReceipt[]
+}
+
+export const PurchaseOrderReceipts = ({ order, receipts }: Props) => {
+    if (order.status === 'draft') return null
+
+    return (
+        <Card>
+            <h5 className="mb-4">Recepciones ({receipts.length})</h5>
+            {receipts.length === 0 ? (
+                <div className="text-center py-8 text-gray-500">
+                    No hay recepciones registradas
+                </div>
+            ) : (
+                <div className="space-y-3">
+                    {receipts.map((receipt) => (
+                        <div
+                            key={receipt.id}
+                            className="p-3 bg-gray-50 dark:bg-gray-700 rounded-lg"
+                        >
+                            <div className="flex items-center justify-between">
+                                <div>
+                                    <p className="font-medium">
+                                        Recepción #{receipt.id}
+                                    </p>
+                                    <p className="text-sm text-gray-500">
+                                        {receipt.receivedAt
+                                            ? formatDatetime(receipt.receivedAt)
+                                            : receipt.createdAt
+                                            ? formatDatetime(receipt.createdAt)
+                                            : '-'}
+                                    </p>
+                                </div>
+                            </div>
+                            {receipt.notes && (
+                                <p className="text-sm mt-2 text-gray-600 dark:text-gray-400">
+                                    {receipt.notes}
+                                </p>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </Card>
+    )
+}

--- a/src/views/purchases/PurchaseOrderDetailView/SendOrderDialog.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/SendOrderDialog.tsx
@@ -1,0 +1,74 @@
+import Button from '@/components/ui/Button'
+import Dialog from '@/components/ui/Dialog'
+import { formatCurrency } from '@shared/lib/format'
+import type {
+    PurchaseOrder,
+    PurchaseOrderItem,
+} from '@/services/PurchaseOrderService'
+
+type Props = {
+    open: boolean
+    items: PurchaseOrderItem[]
+    order: PurchaseOrder
+    getProductName: (productId: number) => string
+    isPending: boolean
+    onClose: () => void
+    onSend: () => void
+}
+
+export const SendOrderDialog = ({
+    open,
+    items,
+    order,
+    getProductName,
+    isPending,
+    onClose,
+    onSend,
+}: Props) => (
+    <Dialog isOpen={open} onClose={onClose} onRequestClose={onClose}>
+        <h5 className="mb-4">Enviar Orden de Compra</h5>
+        <p className="mb-4">
+            ¿Está seguro que desea enviar esta orden al proveedor? Una vez
+            enviada, los items no podrán ser modificados.
+        </p>
+        {items.length > 0 ? (
+            <div className="mb-4 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg">
+                <p className="text-sm font-medium mb-2">Items de la orden:</p>
+                <ul className="text-sm space-y-1">
+                    {items.map((item) => (
+                        <li key={item.id}>
+                            <span className="font-medium">
+                                {getProductName(item.productId)}
+                            </span>
+                            :{' '}
+                            <span className="text-blue-600 dark:text-blue-400">
+                                {item.quantityOrdered} uds. x{' '}
+                                {formatCurrency(item.unitCost)}
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+                <p className="mt-2 pt-2 border-t dark:border-gray-600 font-medium">
+                    Total: {formatCurrency(order.total)}
+                </p>
+            </div>
+        ) : (
+            <p className="mb-4 text-sm text-red-500">
+                No se puede enviar una orden sin items.
+            </p>
+        )}
+        <div className="flex justify-end gap-2">
+            <Button variant="plain" onClick={onClose}>
+                Cancelar
+            </Button>
+            <Button
+                variant="solid"
+                loading={isPending}
+                disabled={items.length === 0}
+                onClick={onSend}
+            >
+                Enviar
+            </Button>
+        </div>
+    </Dialog>
+)

--- a/src/views/purchases/PurchaseOrderDetailView/index.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/index.tsx
@@ -1,45 +1,23 @@
-import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import {
     usePurchaseOrder,
     usePurchaseOrderItems,
     usePurchaseOrderReceipts,
-    useUpdatePurchaseOrder,
-    useDeletePurchaseOrder,
-    useSendPurchaseOrder,
-    useCancelPurchaseOrder,
-    useDeletePurchaseOrderItem,
 } from '@/hooks/usePurchaseOrders'
 import { useProducts } from '@/hooks/useProducts'
 import { useSuppliers } from '@/hooks/useSuppliers'
-import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
-import Badge from '@/components/ui/Badge'
-import Table from '@/components/ui/Table'
 import Dialog from '@/components/ui/Dialog'
-import Input from '@/components/ui/Input'
-import Select from '@/components/ui/Select'
-import Notification from '@/components/ui/Notification'
-import toast from '@/components/ui/toast'
-import { getErrorMessage } from '@/utils/getErrorMessage'
-import {
-    PURCHASE_ORDER_STATUS_LABELS,
-    PURCHASE_ORDER_STATUS_CLASSES,
-    type PurchaseOrderItem,
-    type PurchaseOrderUpdateInput,
-} from '@/services/PurchaseOrderService'
+import { HiOutlineArrowLeft } from 'react-icons/hi'
+import { usePurchaseOrderActions } from './usePurchaseOrderActions'
+import { PurchaseOrderHeader } from './PurchaseOrderHeader'
+import { PurchaseOrderInfo } from './PurchaseOrderInfo'
+import { PurchaseOrderItems } from './PurchaseOrderItems'
+import { PurchaseOrderReceipts } from './PurchaseOrderReceipts'
+import { EditOrderDialog } from './EditOrderDialog'
+import { SendOrderDialog } from './SendOrderDialog'
 import PurchaseOrderItemForm from './PurchaseOrderItemForm'
 import ReceiveForm from './ReceiveForm'
-import {
-    HiOutlineArrowLeft,
-    HiOutlinePlus,
-    HiOutlinePencil,
-    HiOutlineTrash,
-    HiOutlineX,
-} from 'react-icons/hi'
-import { HiOutlinePaperAirplane, HiOutlineArchiveBox } from 'react-icons/hi2'
-
-const { Tr, Th, Td, THead, TBody, TFoot } = Table
 
 const PurchaseOrderDetailView = () => {
     const { id } = useParams<{ id: string }>()
@@ -57,11 +35,7 @@ const PurchaseOrderDetailView = () => {
     const { data: suppliersData } = useSuppliers({ limit: 100 })
     const suppliers = suppliersData?.items ?? []
 
-    const updateOrder = useUpdatePurchaseOrder()
-    const deleteOrder = useDeletePurchaseOrder()
-    const sendOrder = useSendPurchaseOrder()
-    const cancelOrder = useCancelPurchaseOrder()
-    const deleteItem = useDeletePurchaseOrderItem()
+    const actions = usePurchaseOrderActions(orderId, order)
 
     const isDraft = order?.status === 'draft'
     const isSent = order?.status === 'sent'
@@ -69,40 +43,9 @@ const PurchaseOrderDetailView = () => {
     const canReceive = isSent || isPartial
     const canCancel = isDraft || isSent || isPartial
 
-    // Edit order state
-    const [editDialogOpen, setEditDialogOpen] = useState(false)
-    const [editData, setEditData] = useState<
-        PurchaseOrderUpdateInput & { supplierId: number }
-    >({
-        supplierId: 0,
-        notes: '',
-        expectedDate: '',
-    })
-
-    // Item form state
-    const [itemFormOpen, setItemFormOpen] = useState(false)
-    const [selectedItem, setSelectedItem] = useState<PurchaseOrderItem | null>(
-        null
-    )
-
-    // Receive form state
-    const [receiveFormOpen, setReceiveFormOpen] = useState(false)
-
-    // Confirmation dialogs
-    const [sendDialogOpen, setSendDialogOpen] = useState(false)
-    const [cancelDialogOpen, setCancelDialogOpen] = useState(false)
-    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-    const [deleteItemDialog, setDeleteItemDialog] = useState<{
-        open: boolean
-        item: PurchaseOrderItem | null
-    }>({ open: false, item: null })
-
     const supplierOptions = suppliers
         .filter((s) => s.isActive)
-        .map((s) => ({
-            value: s.id.toString(),
-            label: s.name,
-        }))
+        .map((s) => ({ value: s.id.toString(), label: s.name }))
 
     const getProductName = (productId: number) => {
         const p = products.find((p) => p.id === productId)
@@ -112,155 +55,6 @@ const PurchaseOrderDetailView = () => {
     const getSupplierName = (supplierId: number) => {
         const s = suppliers.find((s) => s.id === supplierId)
         return s ? s.name : `#${supplierId}`
-    }
-
-    const formatCurrency = (value: number) => {
-        return new Intl.NumberFormat('es-EC', {
-            style: 'currency',
-            currency: 'USD',
-        }).format(value)
-    }
-
-    // Handlers
-    const handleEditOrder = () => {
-        if (order) {
-            setEditData({
-                supplierId: order.supplierId,
-                notes: order.notes || '',
-                expectedDate: order.expectedDate
-                    ? order.expectedDate.split('T')[0]
-                    : '',
-            })
-            setEditDialogOpen(true)
-        }
-    }
-
-    const handleSaveEdit = async () => {
-        try {
-            await updateOrder.mutateAsync({
-                id: orderId,
-                data: {
-                    supplierId: editData.supplierId,
-                    notes: editData.notes || undefined,
-                    expectedDate: editData.expectedDate
-                        ? `${editData.expectedDate}T00:00:00Z`
-                        : undefined,
-                },
-            })
-            toast.push(
-                <Notification title="Orden actualizada" type="success">
-                    La orden de compra se actualizó correctamente
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            setEditDialogOpen(false)
-        } catch (error: unknown) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al actualizar la orden')}
-                </Notification>,
-                { placement: 'top-end' }
-            )
-        }
-    }
-
-    const handleSend = async () => {
-        try {
-            await sendOrder.mutateAsync(orderId)
-            toast.push(
-                <Notification title="Orden enviada" type="success">
-                    La orden de compra fue enviada al proveedor
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            setSendDialogOpen(false)
-        } catch (error: unknown) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al enviar la orden')}
-                </Notification>,
-                { placement: 'top-end' }
-            )
-        }
-    }
-
-    const handleCancel = async () => {
-        try {
-            await cancelOrder.mutateAsync(orderId)
-            toast.push(
-                <Notification title="Orden cancelada" type="success">
-                    La orden de compra fue cancelada
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            setCancelDialogOpen(false)
-        } catch (error: unknown) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al cancelar la orden')}
-                </Notification>,
-                { placement: 'top-end' }
-            )
-        }
-    }
-
-    const handleDelete = async () => {
-        try {
-            await deleteOrder.mutateAsync(orderId)
-            toast.push(
-                <Notification title="Orden eliminada" type="success">
-                    La orden de compra fue eliminada
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            navigate('/purchase-orders')
-        } catch (error: unknown) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al eliminar la orden')}
-                </Notification>,
-                { placement: 'top-end' }
-            )
-        }
-    }
-
-    const handleDeleteItemConfirm = async () => {
-        if (!deleteItemDialog.item) return
-        try {
-            await deleteItem.mutateAsync({
-                itemId: deleteItemDialog.item.id,
-                orderId,
-            })
-            toast.push(
-                <Notification title="Item eliminado" type="success">
-                    El item fue eliminado
-                </Notification>,
-                { placement: 'top-end' }
-            )
-            setDeleteItemDialog({ open: false, item: null })
-        } catch (error: unknown) {
-            toast.push(
-                <Notification title="Error" type="danger">
-                    {getErrorMessage(error, 'Error al eliminar el item')}
-                </Notification>,
-                { placement: 'top-end' }
-            )
-        }
-    }
-
-    const handleAddItem = () => {
-        setSelectedItem(null)
-        setItemFormOpen(true)
-    }
-
-    const handleEditItem = (item: PurchaseOrderItem) => {
-        setSelectedItem(item)
-        setItemFormOpen(true)
-    }
-
-    const handleCloseItemForm = () => {
-        setItemFormOpen(false)
-        setSelectedItem(null)
     }
 
     if (orderLoading) {
@@ -288,473 +82,78 @@ const PurchaseOrderDetailView = () => {
 
     return (
         <div className="flex flex-col gap-4">
-            {/* Header */}
-            <div className="flex items-center justify-between">
-                <div className="flex items-center gap-4">
-                    <Button
-                        variant="plain"
-                        icon={<HiOutlineArrowLeft />}
-                        onClick={() => navigate('/purchase-orders')}
-                    />
-                    <h3>Orden {order.orderNumber}</h3>
-                    <Badge
-                        content={PURCHASE_ORDER_STATUS_LABELS[order.status]}
-                        className={PURCHASE_ORDER_STATUS_CLASSES[order.status]}
-                    />
-                </div>
-                <div className="flex gap-2">
-                    {isDraft && (
-                        <>
-                            <Button
-                                size="sm"
-                                variant="plain"
-                                icon={<HiOutlinePencil />}
-                                onClick={handleEditOrder}
-                            >
-                                Editar
-                            </Button>
-                            <Button
-                                size="sm"
-                                variant="solid"
-                                color="blue-600"
-                                icon={<HiOutlinePaperAirplane />}
-                                onClick={() => setSendDialogOpen(true)}
-                            >
-                                Enviar
-                            </Button>
-                            <Button
-                                size="sm"
-                                variant="plain"
-                                icon={<HiOutlineTrash />}
-                                onClick={() => setDeleteDialogOpen(true)}
-                            >
-                                Eliminar
-                            </Button>
-                        </>
-                    )}
-                    {canReceive && (
-                        <Button
-                            size="sm"
-                            variant="solid"
-                            color="emerald-600"
-                            icon={<HiOutlineArchiveBox />}
-                            onClick={() => setReceiveFormOpen(true)}
-                        >
-                            Recibir Mercancía
-                        </Button>
-                    )}
-                    {canCancel && (
-                        <Button
-                            size="sm"
-                            variant="plain"
-                            icon={<HiOutlineX />}
-                            onClick={() => setCancelDialogOpen(true)}
-                        >
-                            Cancelar
-                        </Button>
-                    )}
-                </div>
-            </div>
-
-            {/* Order Info */}
-            <Card>
-                <h5 className="mb-4">Información de la Orden</h5>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    <div>
-                        <p className="text-sm text-gray-500">Proveedor</p>
-                        <p className="font-medium">
-                            {getSupplierName(order.supplierId)}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-sm text-gray-500">Número de Orden</p>
-                        <p className="font-medium">{order.orderNumber}</p>
-                    </div>
-                    <div>
-                        <p className="text-sm text-gray-500">Fecha Esperada</p>
-                        <p className="font-medium">
-                            {order.expectedDate
-                                ? new Date(
-                                      order.expectedDate
-                                  ).toLocaleDateString('es-EC')
-                                : '-'}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-sm text-gray-500">
-                            Fecha de Creación
-                        </p>
-                        <p className="font-medium">
-                            {order.createdAt
-                                ? new Date(order.createdAt).toLocaleString(
-                                      'es-EC'
-                                  )
-                                : '-'}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-sm text-gray-500">
-                            Última Actualización
-                        </p>
-                        <p className="font-medium">
-                            {order.updatedAt
-                                ? new Date(order.updatedAt).toLocaleString(
-                                      'es-EC'
-                                  )
-                                : '-'}
-                        </p>
-                    </div>
-                </div>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4 pt-4 border-t dark:border-gray-600">
-                    <div>
-                        <p className="text-sm text-gray-500">Subtotal</p>
-                        <p className="font-medium">
-                            {formatCurrency(order.subtotal)}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-sm text-gray-500">Impuestos</p>
-                        <p className="font-medium">
-                            {formatCurrency(order.tax)}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-sm text-gray-500">Total</p>
-                        <p className="text-lg font-semibold">
-                            {formatCurrency(order.total)}
-                        </p>
-                    </div>
-                </div>
-                {order.notes && (
-                    <div className="mt-4 pt-4 border-t dark:border-gray-600">
-                        <p className="text-sm text-gray-500">Notas</p>
-                        <p className="font-medium">{order.notes}</p>
-                    </div>
-                )}
-            </Card>
-
-            {/* Items */}
-            <Card>
-                <div className="flex items-center justify-between mb-4">
-                    <h5>Items de la Orden ({items.length})</h5>
-                    {isDraft && (
-                        <Button
-                            size="sm"
-                            variant="solid"
-                            icon={<HiOutlinePlus />}
-                            onClick={handleAddItem}
-                        >
-                            Agregar Item
-                        </Button>
-                    )}
-                </div>
-
-                {itemsLoading ? (
-                    <div className="flex justify-center items-center h-32">
-                        <div>Cargando items...</div>
-                    </div>
-                ) : items.length === 0 ? (
-                    <div className="text-center py-8 text-gray-500">
-                        No hay items en esta orden
-                    </div>
-                ) : (
-                    <Table>
-                        <THead>
-                            <Tr>
-                                <Th>Producto</Th>
-                                <Th>Cant. Pedida</Th>
-                                <Th>Cant. Recibida</Th>
-                                <Th>Cant. Pendiente</Th>
-                                <Th>Costo Unitario</Th>
-                                <Th>Subtotal</Th>
-                                {isDraft && <Th>Acciones</Th>}
-                            </Tr>
-                        </THead>
-                        <TBody>
-                            {items.map((item) => {
-                                const pending =
-                                    item.quantityOrdered - item.quantityReceived
-                                const subtotal =
-                                    item.unitCost * item.quantityOrdered
-                                return (
-                                    <Tr key={item.id}>
-                                        <Td>
-                                            {getProductName(item.productId)}
-                                        </Td>
-                                        <Td>{item.quantityOrdered}</Td>
-                                        <Td>{item.quantityReceived}</Td>
-                                        <Td>
-                                            {pending > 0 ? (
-                                                <span className="text-amber-600 dark:text-amber-400 font-medium">
-                                                    {pending}
-                                                </span>
-                                            ) : (
-                                                <span className="text-emerald-600 dark:text-emerald-400">
-                                                    0
-                                                </span>
-                                            )}
-                                        </Td>
-                                        <Td>{formatCurrency(item.unitCost)}</Td>
-                                        <Td className="font-medium">
-                                            {formatCurrency(subtotal)}
-                                        </Td>
-                                        {isDraft && (
-                                            <Td>
-                                                <div className="flex gap-2">
-                                                    <Button
-                                                        size="sm"
-                                                        variant="plain"
-                                                        icon={
-                                                            <HiOutlinePencil />
-                                                        }
-                                                        onClick={() =>
-                                                            handleEditItem(item)
-                                                        }
-                                                    />
-                                                    <Button
-                                                        size="sm"
-                                                        variant="plain"
-                                                        icon={
-                                                            <HiOutlineTrash />
-                                                        }
-                                                        onClick={() =>
-                                                            setDeleteItemDialog(
-                                                                {
-                                                                    open: true,
-                                                                    item,
-                                                                }
-                                                            )
-                                                        }
-                                                    />
-                                                </div>
-                                            </Td>
-                                        )}
-                                    </Tr>
-                                )
-                            })}
-                        </TBody>
-                        <TFoot>
-                            <Tr>
-                                <Td
-                                    colSpan={isDraft ? 6 : 5}
-                                    className="text-right font-medium"
-                                >
-                                    Total
-                                </Td>
-                                <Td className="font-semibold">
-                                    {formatCurrency(order.total)}
-                                </Td>
-                                {isDraft && <Td />}
-                            </Tr>
-                        </TFoot>
-                    </Table>
-                )}
-            </Card>
-
-            {/* Receipts */}
-            {order.status !== 'draft' && (
-                <Card>
-                    <h5 className="mb-4">Recepciones ({receipts.length})</h5>
-                    {receipts.length === 0 ? (
-                        <div className="text-center py-8 text-gray-500">
-                            No hay recepciones registradas
-                        </div>
-                    ) : (
-                        <div className="space-y-3">
-                            {receipts.map((receipt) => (
-                                <div
-                                    key={receipt.id}
-                                    className="p-3 bg-gray-50 dark:bg-gray-700 rounded-lg"
-                                >
-                                    <div className="flex items-center justify-between">
-                                        <div>
-                                            <p className="font-medium">
-                                                Recepción #{receipt.id}
-                                            </p>
-                                            <p className="text-sm text-gray-500">
-                                                {receipt.receivedAt
-                                                    ? new Date(
-                                                          receipt.receivedAt
-                                                      ).toLocaleString('es-EC')
-                                                    : receipt.createdAt
-                                                    ? new Date(
-                                                          receipt.createdAt
-                                                      ).toLocaleString('es-EC')
-                                                    : '-'}
-                                            </p>
-                                        </div>
-                                    </div>
-                                    {receipt.notes && (
-                                        <p className="text-sm mt-2 text-gray-600 dark:text-gray-400">
-                                            {receipt.notes}
-                                        </p>
-                                    )}
-                                </div>
-                            ))}
-                        </div>
-                    )}
-                </Card>
-            )}
-
-            {/* Item Form Modal */}
-            <PurchaseOrderItemForm
-                orderId={orderId}
-                item={selectedItem}
-                open={itemFormOpen}
-                onClose={handleCloseItemForm}
+            <PurchaseOrderHeader
+                order={order}
+                isDraft={isDraft}
+                canReceive={canReceive}
+                canCancel={canCancel}
+                onBack={() => navigate('/purchase-orders')}
+                onEdit={actions.handleEditOrder}
+                onSend={() => actions.setSendDialogOpen(true)}
+                onDelete={() => actions.setDeleteDialogOpen(true)}
+                onReceive={() => actions.setReceiveFormOpen(true)}
+                onCancel={() => actions.setCancelDialogOpen(true)}
             />
 
-            {/* Receive Form Modal */}
+            <PurchaseOrderInfo
+                order={order}
+                supplierName={getSupplierName(order.supplierId)}
+            />
+
+            <PurchaseOrderItems
+                items={items}
+                itemsLoading={itemsLoading}
+                isDraft={isDraft}
+                order={order}
+                getProductName={getProductName}
+                onAdd={actions.handleAddItem}
+                onEdit={actions.handleEditItem}
+                onDeleteItem={(item) =>
+                    actions.setDeleteItemDialog({ open: true, item })
+                }
+            />
+
+            <PurchaseOrderReceipts order={order} receipts={receipts} />
+
+            <PurchaseOrderItemForm
+                orderId={orderId}
+                item={actions.selectedItem}
+                open={actions.itemFormOpen}
+                onClose={actions.handleCloseItemForm}
+            />
+
             <ReceiveForm
                 orderId={orderId}
                 items={items}
-                open={receiveFormOpen}
+                open={actions.receiveFormOpen}
                 getProductName={getProductName}
-                onClose={() => setReceiveFormOpen(false)}
+                onClose={() => actions.setReceiveFormOpen(false)}
             />
 
-            {/* Edit Order Dialog */}
-            <Dialog
-                isOpen={editDialogOpen}
-                width={500}
-                onClose={() => setEditDialogOpen(false)}
-                onRequestClose={() => setEditDialogOpen(false)}
-            >
-                <h5 className="mb-4">Editar Orden de Compra</h5>
-                <div className="space-y-4">
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Proveedor <span className="text-red-500">*</span>
-                        </label>
-                        <Select
-                            placeholder="Seleccionar proveedor"
-                            options={supplierOptions}
-                            value={supplierOptions.find(
-                                (o) =>
-                                    o.value === editData.supplierId.toString()
-                            )}
-                            onChange={(option) =>
-                                setEditData({
-                                    ...editData,
-                                    supplierId: option
-                                        ? parseInt(option.value)
-                                        : 0,
-                                })
-                            }
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Fecha Esperada
-                        </label>
-                        <Input
-                            type="date"
-                            value={editData.expectedDate || ''}
-                            onChange={(e) =>
-                                setEditData({
-                                    ...editData,
-                                    expectedDate: e.target.value,
-                                })
-                            }
-                        />
-                    </div>
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Notas
-                        </label>
-                        <Input
-                            textArea
-                            placeholder="Observaciones"
-                            value={editData.notes || ''}
-                            onChange={(e) =>
-                                setEditData({
-                                    ...editData,
-                                    notes: e.target.value,
-                                })
-                            }
-                        />
-                    </div>
-                </div>
-                <div className="flex justify-end gap-2 mt-6">
-                    <Button
-                        variant="plain"
-                        onClick={() => setEditDialogOpen(false)}
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        variant="solid"
-                        loading={updateOrder.isPending}
-                        disabled={editData.supplierId === 0}
-                        onClick={handleSaveEdit}
-                    >
-                        Guardar
-                    </Button>
-                </div>
-            </Dialog>
+            <EditOrderDialog
+                open={actions.editDialogOpen}
+                editData={actions.editData}
+                supplierOptions={supplierOptions}
+                isPending={actions.updateOrder.isPending}
+                onClose={() => actions.setEditDialogOpen(false)}
+                onChange={actions.setEditData}
+                onSave={actions.handleSaveEdit}
+            />
 
-            {/* Send Dialog */}
-            <Dialog
-                isOpen={sendDialogOpen}
-                onClose={() => setSendDialogOpen(false)}
-                onRequestClose={() => setSendDialogOpen(false)}
-            >
-                <h5 className="mb-4">Enviar Orden de Compra</h5>
-                <p className="mb-4">
-                    ¿Está seguro que desea enviar esta orden al proveedor? Una
-                    vez enviada, los items no podrán ser modificados.
-                </p>
-                {items.length > 0 ? (
-                    <div className="mb-4 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg">
-                        <p className="text-sm font-medium mb-2">
-                            Items de la orden:
-                        </p>
-                        <ul className="text-sm space-y-1">
-                            {items.map((item) => (
-                                <li key={item.id}>
-                                    <span className="font-medium">
-                                        {getProductName(item.productId)}
-                                    </span>
-                                    :{' '}
-                                    <span className="text-blue-600 dark:text-blue-400">
-                                        {item.quantityOrdered} uds. x{' '}
-                                        {formatCurrency(item.unitCost)}
-                                    </span>
-                                </li>
-                            ))}
-                        </ul>
-                        <p className="mt-2 pt-2 border-t dark:border-gray-600 font-medium">
-                            Total: {formatCurrency(order.total)}
-                        </p>
-                    </div>
-                ) : (
-                    <p className="mb-4 text-sm text-red-500">
-                        No se puede enviar una orden sin items.
-                    </p>
-                )}
-                <div className="flex justify-end gap-2">
-                    <Button
-                        variant="plain"
-                        onClick={() => setSendDialogOpen(false)}
-                    >
-                        Cancelar
-                    </Button>
-                    <Button
-                        variant="solid"
-                        loading={sendOrder.isPending}
-                        disabled={items.length === 0}
-                        onClick={handleSend}
-                    >
-                        Enviar
-                    </Button>
-                </div>
-            </Dialog>
+            <SendOrderDialog
+                open={actions.sendDialogOpen}
+                items={items}
+                order={order}
+                getProductName={getProductName}
+                isPending={actions.sendOrder.isPending}
+                onClose={() => actions.setSendDialogOpen(false)}
+                onSend={actions.handleSend}
+            />
 
-            {/* Cancel Dialog */}
             <Dialog
-                isOpen={cancelDialogOpen}
-                onClose={() => setCancelDialogOpen(false)}
-                onRequestClose={() => setCancelDialogOpen(false)}
+                isOpen={actions.cancelDialogOpen}
+                onClose={() => actions.setCancelDialogOpen(false)}
+                onRequestClose={() => actions.setCancelDialogOpen(false)}
             >
                 <h5 className="mb-4">Cancelar Orden de Compra</h5>
                 <p className="mb-6">
@@ -764,25 +163,24 @@ const PurchaseOrderDetailView = () => {
                 <div className="flex justify-end gap-2">
                     <Button
                         variant="plain"
-                        onClick={() => setCancelDialogOpen(false)}
+                        onClick={() => actions.setCancelDialogOpen(false)}
                     >
                         Volver
                     </Button>
                     <Button
                         variant="solid"
-                        loading={cancelOrder.isPending}
-                        onClick={handleCancel}
+                        loading={actions.cancelOrder.isPending}
+                        onClick={actions.handleCancel}
                     >
                         Cancelar Orden
                     </Button>
                 </div>
             </Dialog>
 
-            {/* Delete Order Dialog */}
             <Dialog
-                isOpen={deleteDialogOpen}
-                onClose={() => setDeleteDialogOpen(false)}
-                onRequestClose={() => setDeleteDialogOpen(false)}
+                isOpen={actions.deleteDialogOpen}
+                onClose={() => actions.setDeleteDialogOpen(false)}
+                onRequestClose={() => actions.setDeleteDialogOpen(false)}
             >
                 <h5 className="mb-4">Eliminar Orden de Compra</h5>
                 <p className="mb-6">
@@ -792,26 +190,27 @@ const PurchaseOrderDetailView = () => {
                 <div className="flex justify-end gap-2">
                     <Button
                         variant="plain"
-                        onClick={() => setDeleteDialogOpen(false)}
+                        onClick={() => actions.setDeleteDialogOpen(false)}
                     >
                         Cancelar
                     </Button>
                     <Button
                         variant="solid"
-                        loading={deleteOrder.isPending}
-                        onClick={handleDelete}
+                        loading={actions.deleteOrder.isPending}
+                        onClick={actions.handleDelete}
                     >
                         Eliminar
                     </Button>
                 </div>
             </Dialog>
 
-            {/* Delete Item Dialog */}
             <Dialog
-                isOpen={deleteItemDialog.open}
-                onClose={() => setDeleteItemDialog({ open: false, item: null })}
+                isOpen={actions.deleteItemDialog.open}
+                onClose={() =>
+                    actions.setDeleteItemDialog({ open: false, item: null })
+                }
                 onRequestClose={() =>
-                    setDeleteItemDialog({ open: false, item: null })
+                    actions.setDeleteItemDialog({ open: false, item: null })
                 }
             >
                 <h5 className="mb-4">Eliminar Item</h5>
@@ -823,15 +222,18 @@ const PurchaseOrderDetailView = () => {
                     <Button
                         variant="plain"
                         onClick={() =>
-                            setDeleteItemDialog({ open: false, item: null })
+                            actions.setDeleteItemDialog({
+                                open: false,
+                                item: null,
+                            })
                         }
                     >
                         Cancelar
                     </Button>
                     <Button
                         variant="solid"
-                        loading={deleteItem.isPending}
-                        onClick={handleDeleteItemConfirm}
+                        loading={actions.deleteItem.isPending}
+                        onClick={actions.handleDeleteItemConfirm}
                     >
                         Eliminar
                     </Button>

--- a/src/views/purchases/PurchaseOrderDetailView/usePurchaseOrderActions.tsx
+++ b/src/views/purchases/PurchaseOrderDetailView/usePurchaseOrderActions.tsx
@@ -1,0 +1,219 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+    useUpdatePurchaseOrder,
+    useDeletePurchaseOrder,
+    useSendPurchaseOrder,
+    useCancelPurchaseOrder,
+    useDeletePurchaseOrderItem,
+} from '@/hooks/usePurchaseOrders'
+import Notification from '@/components/ui/Notification'
+import toast from '@/components/ui/toast'
+import { getErrorMessage } from '@/utils/getErrorMessage'
+import type {
+    PurchaseOrder,
+    PurchaseOrderItem,
+    PurchaseOrderUpdateInput,
+} from '@/services/PurchaseOrderService'
+
+type EditData = PurchaseOrderUpdateInput & { supplierId: number }
+
+export function usePurchaseOrderActions(
+    orderId: number,
+    order: PurchaseOrder | undefined
+) {
+    const navigate = useNavigate()
+
+    const updateOrder = useUpdatePurchaseOrder()
+    const deleteOrder = useDeletePurchaseOrder()
+    const sendOrder = useSendPurchaseOrder()
+    const cancelOrder = useCancelPurchaseOrder()
+    const deleteItem = useDeletePurchaseOrderItem()
+
+    const [editDialogOpen, setEditDialogOpen] = useState(false)
+    const [editData, setEditData] = useState<EditData>({
+        supplierId: 0,
+        notes: '',
+        expectedDate: '',
+    })
+    const [itemFormOpen, setItemFormOpen] = useState(false)
+    const [selectedItem, setSelectedItem] = useState<PurchaseOrderItem | null>(
+        null
+    )
+    const [receiveFormOpen, setReceiveFormOpen] = useState(false)
+    const [sendDialogOpen, setSendDialogOpen] = useState(false)
+    const [cancelDialogOpen, setCancelDialogOpen] = useState(false)
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+    const [deleteItemDialog, setDeleteItemDialog] = useState<{
+        open: boolean
+        item: PurchaseOrderItem | null
+    }>({ open: false, item: null })
+
+    const handleEditOrder = () => {
+        if (order) {
+            setEditData({
+                supplierId: order.supplierId,
+                notes: order.notes || '',
+                expectedDate: order.expectedDate
+                    ? order.expectedDate.split('T')[0]
+                    : '',
+            })
+            setEditDialogOpen(true)
+        }
+    }
+
+    const handleSaveEdit = async () => {
+        try {
+            await updateOrder.mutateAsync({
+                id: orderId,
+                data: {
+                    supplierId: editData.supplierId,
+                    notes: editData.notes || undefined,
+                    expectedDate: editData.expectedDate
+                        ? `${editData.expectedDate}T00:00:00Z`
+                        : undefined,
+                },
+            })
+            toast.push(
+                <Notification title="Orden actualizada" type="success">
+                    La orden de compra se actualizó correctamente
+                </Notification>,
+                { placement: 'top-end' }
+            )
+            setEditDialogOpen(false)
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al actualizar la orden')}
+                </Notification>,
+                { placement: 'top-end' }
+            )
+        }
+    }
+
+    const handleSend = async () => {
+        try {
+            await sendOrder.mutateAsync(orderId)
+            toast.push(
+                <Notification title="Orden enviada" type="success">
+                    La orden de compra fue enviada al proveedor
+                </Notification>,
+                { placement: 'top-end' }
+            )
+            setSendDialogOpen(false)
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al enviar la orden')}
+                </Notification>,
+                { placement: 'top-end' }
+            )
+        }
+    }
+
+    const handleCancel = async () => {
+        try {
+            await cancelOrder.mutateAsync(orderId)
+            toast.push(
+                <Notification title="Orden cancelada" type="success">
+                    La orden de compra fue cancelada
+                </Notification>,
+                { placement: 'top-end' }
+            )
+            setCancelDialogOpen(false)
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al cancelar la orden')}
+                </Notification>,
+                { placement: 'top-end' }
+            )
+        }
+    }
+
+    const handleDelete = async () => {
+        try {
+            await deleteOrder.mutateAsync(orderId)
+            toast.push(
+                <Notification title="Orden eliminada" type="success">
+                    La orden de compra fue eliminada
+                </Notification>,
+                { placement: 'top-end' }
+            )
+            navigate('/purchase-orders')
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al eliminar la orden')}
+                </Notification>,
+                { placement: 'top-end' }
+            )
+        }
+    }
+
+    const handleDeleteItemConfirm = async () => {
+        if (!deleteItemDialog.item) return
+        try {
+            await deleteItem.mutateAsync({
+                itemId: deleteItemDialog.item.id,
+                orderId,
+            })
+            toast.push(
+                <Notification title="Item eliminado" type="success">
+                    El item fue eliminado
+                </Notification>,
+                { placement: 'top-end' }
+            )
+            setDeleteItemDialog({ open: false, item: null })
+        } catch (error: unknown) {
+            toast.push(
+                <Notification title="Error" type="danger">
+                    {getErrorMessage(error, 'Error al eliminar el item')}
+                </Notification>,
+                { placement: 'top-end' }
+            )
+        }
+    }
+
+    return {
+        updateOrder,
+        deleteOrder,
+        sendOrder,
+        cancelOrder,
+        deleteItem,
+        editDialogOpen,
+        setEditDialogOpen,
+        editData,
+        setEditData,
+        itemFormOpen,
+        selectedItem,
+        receiveFormOpen,
+        setReceiveFormOpen,
+        sendDialogOpen,
+        setSendDialogOpen,
+        cancelDialogOpen,
+        setCancelDialogOpen,
+        deleteDialogOpen,
+        setDeleteDialogOpen,
+        deleteItemDialog,
+        setDeleteItemDialog,
+        handleEditOrder,
+        handleSaveEdit,
+        handleSend,
+        handleCancel,
+        handleDelete,
+        handleDeleteItemConfirm,
+        handleAddItem: () => {
+            setSelectedItem(null)
+            setItemFormOpen(true)
+        },
+        handleEditItem: (item: PurchaseOrderItem) => {
+            setSelectedItem(item)
+            setItemFormOpen(true)
+        },
+        handleCloseItemForm: () => {
+            setItemFormOpen(false)
+            setSelectedItem(null)
+        },
+    }
+}


### PR DESCRIPTION
## Descripción

  - PurchaseOrderDetailView (844 LOC) → 8 files, max 242 LOC each
  - AdjustmentDetailView (706 LOC) → 8 files, max 231 LOC each
  - Extracted mutations + dialog state into usePurchaseOrderActions / useAdjustmentActions hooks (SRP)
  - Created section components: Header, Info, Items, Receipts, EditDialog, SendDialog / ConfirmDialog
  - Replaced inline formatCurrency and toLocaleString calls with formatDate / formatDatetime / formatCurrency from @shared/lib/format

## Tipo de cambio

- [ ] 🐛 Bug fix
- [x] ✨ Nueva funcionalidad
- [ ] 🔨 Refactorización
- [ ] 📝 Documentación
- [ ] 🎨 Estilos/UI

## Checklist

- [ ] El código compila sin errores (`npm run build`)
- [ ] Los cambios siguen las convenciones del proyecto
- [ ] Se actualizó la documentación si es necesario
- [ ] Se probaron los cambios localmente

## Screenshots (opcional)

<!-- Si aplica, agrega capturas de pantalla de los cambios UI -->
